### PR TITLE
Update pipeline to re-enable multiple platform targets

### DIFF
--- a/Pipelines/core-pipeline.yml
+++ b/Pipelines/core-pipeline.yml
@@ -22,7 +22,6 @@ stages:
 - stage: Build
   jobs:
   - job: build_nix
-    condition: eq(1,2)
     displayName: Build Linux & Mac
     pool:
       vmImage: 'ubuntu-latest'
@@ -108,7 +107,6 @@ stages:
         workingDirectory: $(SolutionDirectory)
     - task: DotNetCoreCLI@2
       displayName: Dotnet Build .NET Core App
-      enabled: false
       inputs:
         command: 'build'
         arguments: '-c $(BuildConfiguration) -o $(Build.BinariesDirectory)\netcoreapp\OSSGadget_$(ReleaseVersion) /p:DebugType=None'
@@ -152,7 +150,6 @@ stages:
         replaceExistingArchive: true
     - task: ArchiveFiles@2
       displayName: Archive Artifact - .NET Core App
-      enabled: false
       inputs:
         rootFolderOrFile: '$(Build.BinariesDirectory)\netcoreapp'
         includeRootFolder: true
@@ -179,9 +176,10 @@ stages:
   - job: sign_hash_release
     displayName: Code Sign, Generate Hashes, Publish Public Releases
     dependsOn:
-    # - build_nix Temporarily disabled
+    - build_nix
     - build_win
-    condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual'))
+    # TODO: remove eq(1,2) from condition after verifying artifacts
+    condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual'), eq(1,2))
     pool:
       vmImage: 'windows-latest'
     steps:
@@ -200,7 +198,6 @@ stages:
           Write-Host "##vso[task.setvariable variable=ReleaseVersion;]$version"
     - task: DownloadBuildArtifacts@0
       displayName: Retrieve Linux & Mac Archives
-      enabled: false
       inputs:
         buildType: 'current'
         downloadType: 'specific'
@@ -236,7 +233,6 @@ stages:
         version: '2.1.804'
     - task: EsrpCodeSigning@1
       displayName: Code Sign Linux
-      enabled: false
       inputs:
         ConnectedServiceName: 'OSSGadget_CodeSign'
         FolderPath: '$(Build.BinariesDirectory)/linux/OSSGadget_$(ReleaseVersion)'
@@ -270,7 +266,6 @@ stages:
         MaxRetryAttempts: '5'
     - task: EsrpCodeSigning@1
       displayName: Code Sign MacOS
-      enabled: false
       inputs:
         ConnectedServiceName: 'OSSGadget_CodeSign'
         FolderPath: '$(Build.BinariesDirectory)/macos/OSSGadget_$(ReleaseVersion)'
@@ -337,7 +332,6 @@ stages:
         MaxRetryAttempts: '5'
     - task: EsrpCodeSigning@1
       displayName: Code Sign .NET Core App
-      enabled: false
       inputs:
         ConnectedServiceName: 'OSSGadget_CodeSign'
         FolderPath: '$(Build.BinariesDirectory)/netcoreapp/OSSGadget_$(ReleaseVersion)'
@@ -401,7 +395,6 @@ stages:
       displayName: 'Delete Code Sign Summaries'
     - task: ArchiveFiles@2
       displayName: Archive Artifact - Linux
-      enabled: false
       inputs:
         rootFolderOrFile: '$(Build.BinariesDirectory)/linux/OSSGadget_$(ReleaseVersion)'
         includeRootFolder: true
@@ -410,7 +403,6 @@ stages:
         replaceExistingArchive: true
     - task: ArchiveFiles@2
       displayName: Archive Artifact - MacOS
-      enabled: false
       inputs:
         rootFolderOrFile: '$(Build.BinariesDirectory)/macos/OSSGadget_$(ReleaseVersion)'
         includeRootFolder: true
@@ -427,7 +419,6 @@ stages:
         replaceExistingArchive: true
     - task: ArchiveFiles@2
       displayName: Archive Artifact - .NET Core App
-      enabled: false
       inputs:
         rootFolderOrFile: '$(Build.BinariesDirectory)/netcoreapp/OSSGadget_$(ReleaseVersion)'
         includeRootFolder: true

--- a/Pipelines/core-pipeline.yml
+++ b/Pipelines/core-pipeline.yml
@@ -98,34 +98,10 @@ stages:
           $version = (nbgv get-version -v AssemblyInformationalVersion).split('+')[0]
           Write-Host "##vso[task.setvariable variable=ReleaseVersion;]$version"
     - task: DotNetCoreCLI@2
-      displayName: Dotnet Publish Windows 10 x64
-      inputs:
-        command: 'publish'
-        arguments: '-c $(BuildConfiguration) -o $(Build.BinariesDirectory)\windows\OSSGadget_$(ReleaseVersion) -r win10-x64 /p:DebugType=None'
-        publishWebProjects: false
-        zipAfterPublish: false
-        workingDirectory: $(SolutionDirectory)
-    - task: DotNetCoreCLI@2
-      displayName: Dotnet Publish Windows 10 x64
-      inputs:
-        command: 'publish'
-        arguments: '-c $(BuildConfiguration) -o $(Build.BinariesDirectory)\win10-x64\OSSGadget_$(ReleaseVersion) -r win10-x64 /p:DebugType=None'
-        publishWebProjects: false
-        zipAfterPublish: false
-        workingDirectory: $(SolutionDirectory)
-    - task: DotNetCoreCLI@2
-      displayName: Dotnet Publish Windows Generic x64
+      displayName: Dotnet Publish Windows x64
       inputs:
         command: 'publish'
         arguments: '-c $(BuildConfiguration) -o $(Build.BinariesDirectory)\win-x64\OSSGadget_$(ReleaseVersion) -r win-x64 /p:DebugType=None'
-        publishWebProjects: false
-        zipAfterPublish: false
-        workingDirectory: $(SolutionDirectory)
-    - task: DotNetCoreCLI@2
-      displayName: Dotnet Publish Windows Generic x86
-      inputs:
-        command: 'publish'
-        arguments: '-c $(BuildConfiguration) -o $(Build.BinariesDirectory)\win-x86\OSSGadget_$(ReleaseVersion) -r win-x86 /p:DebugType=None'
         publishWebProjects: false
         zipAfterPublish: false
         workingDirectory: $(SolutionDirectory)
@@ -165,28 +141,12 @@ stages:
         SignatureFreshness: 'UpToDate'
         TreatStaleSignatureAs: 'Warning'
     - task: ArchiveFiles@2
-      displayName: Archive Artifact - Windows 10 x64
-      inputs:
-        rootFolderOrFile: '$(Build.BinariesDirectory)\win10-x64'
-        includeRootFolder: true
-        archiveType: 'zip'
-        archiveFile: '$(Build.StagingDirectory)\OSSGadget_win10-x64_$(ReleaseVersion).zip'
-        replaceExistingArchive: true
-    - task: ArchiveFiles@2
-      displayName: Archive Artifact - Windows Generic x64
+      displayName: Archive Artifact - Windows x64
       inputs:
         rootFolderOrFile: '$(Build.BinariesDirectory)\win-x64'
         includeRootFolder: true
         archiveType: 'zip'
         archiveFile: '$(Build.StagingDirectory)\OSSGadget_win-x64_$(ReleaseVersion).zip'
-        replaceExistingArchive: true
-    - task: ArchiveFiles@2
-      displayName: Archive Artifact - Windows Generic x86
-      inputs:
-        rootFolderOrFile: '$(Build.BinariesDirectory)\win-x86'
-        includeRootFolder: true
-        archiveType: 'zip'
-        archiveFile: '$(Build.StagingDirectory)\OSSGadget_win-x86_$(ReleaseVersion).zip'
         replaceExistingArchive: true
     - task: ArchiveFiles@2
       displayName: Archive Artifact - .NET Core App
@@ -218,8 +178,7 @@ stages:
     dependsOn:
     - build_nix
     - build_win
-    # TODO: remove eq(1,2) from condition after verifying artifacts
-    condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual'), eq(1,2))
+    condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual'))
     pool:
       vmImage: 'windows-latest'
     steps:
@@ -341,7 +300,7 @@ stages:
       displayName: Code Sign Windows
       inputs:
         ConnectedServiceName: 'OSSGadget_CodeSign'
-        FolderPath: '$(Build.BinariesDirectory)\windows\OSSGadget_$(ReleaseVersion)'
+        FolderPath: '$(Build.BinariesDirectory)\win-x64\OSSGadget_$(ReleaseVersion)'
         Pattern: 'oss-characteristic.exe, oss-characteristic.dll, oss-defog.exe, oss-defog.dll, oss-detect-backdoor.exe, oss-detect-backdoor.dll, oss-download.exe, oss-download.dll, oss-find-source.exe, oss-find-source.dll, oss-health.exe, oss-health.dll'
         signConfigType: 'inlineSignParams'
         inlineOperation: |
@@ -452,10 +411,10 @@ stages:
     - task: ArchiveFiles@2
       displayName: Archive Artifact - Windows
       inputs:
-        rootFolderOrFile: '$(Build.BinariesDirectory)/windows/OSSGadget_$(ReleaseVersion)'
+        rootFolderOrFile: '$(Build.BinariesDirectory)/win-x64/OSSGadget_$(ReleaseVersion)'
         includeRootFolder: true
         archiveType: 'zip'
-        archiveFile: '$(Build.StagingDirectory)/OSSGadget_windows_$(ReleaseVersion).zip'
+        archiveFile: '$(Build.StagingDirectory)/OSSGadget_win-x64_$(ReleaseVersion).zip'
         replaceExistingArchive: true
     - task: ArchiveFiles@2
       displayName: Archive Artifact - .NET Core App

--- a/Pipelines/core-pipeline.yml
+++ b/Pipelines/core-pipeline.yml
@@ -106,6 +106,30 @@ stages:
         zipAfterPublish: false
         workingDirectory: $(SolutionDirectory)
     - task: DotNetCoreCLI@2
+      displayName: Dotnet Publish Windows 10 x64
+      inputs:
+        command: 'publish'
+        arguments: '-c $(BuildConfiguration) -o $(Build.BinariesDirectory)\win10-x64\OSSGadget_$(ReleaseVersion) -r win10-x64 /p:DebugType=None'
+        publishWebProjects: false
+        zipAfterPublish: false
+        workingDirectory: $(SolutionDirectory)
+    - task: DotNetCoreCLI@2
+      displayName: Dotnet Publish Windows Generic x64
+      inputs:
+        command: 'publish'
+        arguments: '-c $(BuildConfiguration) -o $(Build.BinariesDirectory)\win-x64\OSSGadget_$(ReleaseVersion) -r win-x64 /p:DebugType=None'
+        publishWebProjects: false
+        zipAfterPublish: false
+        workingDirectory: $(SolutionDirectory)
+    - task: DotNetCoreCLI@2
+      displayName: Dotnet Publish Windows Generic x86
+      inputs:
+        command: 'publish'
+        arguments: '-c $(BuildConfiguration) -o $(Build.BinariesDirectory)\win-x86\OSSGadget_$(ReleaseVersion) -r win-x86 /p:DebugType=None'
+        publishWebProjects: false
+        zipAfterPublish: false
+        workingDirectory: $(SolutionDirectory)
+    - task: DotNetCoreCLI@2
       displayName: Dotnet Build .NET Core App
       inputs:
         command: 'build'
@@ -141,12 +165,28 @@ stages:
         SignatureFreshness: 'UpToDate'
         TreatStaleSignatureAs: 'Warning'
     - task: ArchiveFiles@2
-      displayName: Archive Artifact - Windows
+      displayName: Archive Artifact - Windows 10 x64
       inputs:
-        rootFolderOrFile: '$(Build.BinariesDirectory)\windows'
+        rootFolderOrFile: '$(Build.BinariesDirectory)\win10-x64'
         includeRootFolder: true
         archiveType: 'zip'
-        archiveFile: '$(Build.StagingDirectory)\OSSGadget_windows_$(ReleaseVersion).zip'
+        archiveFile: '$(Build.StagingDirectory)\OSSGadget_win10-x64_$(ReleaseVersion).zip'
+        replaceExistingArchive: true
+    - task: ArchiveFiles@2
+      displayName: Archive Artifact - Windows Generic x64
+      inputs:
+        rootFolderOrFile: '$(Build.BinariesDirectory)\win-x64'
+        includeRootFolder: true
+        archiveType: 'zip'
+        archiveFile: '$(Build.StagingDirectory)\OSSGadget_win-x64_$(ReleaseVersion).zip'
+        replaceExistingArchive: true
+    - task: ArchiveFiles@2
+      displayName: Archive Artifact - Windows Generic x86
+      inputs:
+        rootFolderOrFile: '$(Build.BinariesDirectory)\win-x86'
+        includeRootFolder: true
+        archiveType: 'zip'
+        archiveFile: '$(Build.StagingDirectory)\OSSGadget_win-x86_$(ReleaseVersion).zip'
         replaceExistingArchive: true
     - task: ArchiveFiles@2
       displayName: Archive Artifact - .NET Core App


### PR DESCRIPTION
Change windows to generic x64 target, re-enable linux, mac, netcoreapp

Fixes #19 
