### PR TITLE
Add cryptographic implementation detection

### DIFF
--- a/src/OSSGadget.sln
+++ b/src/OSSGadget.sln
@@ -24,6 +24,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "oss-detect-backdoor", "oss-
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "tests", "tests\tests.csproj", "{501992E3-6026-40C3-9E36-139C8130FF41}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "oss-detect-cryptography", "oss-detect-cryptography\oss-detect-cryptography.csproj", "{CD18B51D-21B0-4E1F-B0A2-F41E80D3BBDD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -62,6 +64,10 @@ Global
 		{501992E3-6026-40C3-9E36-139C8130FF41}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{501992E3-6026-40C3-9E36-139C8130FF41}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{501992E3-6026-40C3-9E36-139C8130FF41}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CD18B51D-21B0-4E1F-B0A2-F41E80D3BBDD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CD18B51D-21B0-4E1F-B0A2-F41E80D3BBDD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CD18B51D-21B0-4E1F-B0A2-F41E80D3BBDD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CD18B51D-21B0-4E1F-B0A2-F41E80D3BBDD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Shared/MultiExtractor/ArArchiveFile.cs
+++ b/src/Shared/MultiExtractor/ArArchiveFile.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Text;
 
@@ -34,9 +34,10 @@ namespace Microsoft.CST.OpenSource.Shared
                 var entryHeader = innerContent.Slice(0, 60);
                 var filename = Encoding.ASCII.GetString(innerContent.Slice(0, 16)).Trim();  // filename is 16 bytes
                 var fileSizeBytes = entryHeader.Slice(48, 10); // File size is decimal-encoded, 10 bytes long
-                var fileSize = int.Parse(Encoding.ASCII.GetString(fileSizeBytes.ToArray()).Trim());
+                var fileSize = int.Parse(Encoding.ASCII.GetString(fileSizeBytes.ToArray()).Trim(), CultureInfo.InvariantCulture);
                 var entryContent = innerContent.Slice(60, fileSize);
-                results.Add(new FileEntry(filename, fileEntry.FullPath, new MemoryStream(entryContent.ToArray())));
+                using var entryStream = new MemoryStream(entryContent.ToArray());
+                results.Add(new FileEntry(filename, fileEntry.FullPath, entryStream));
                 innerContent = innerContent[(60 + fileSize)..];
             }
             return results;

--- a/src/Shared/MultiExtractor/ArArchiveFile.cs
+++ b/src/Shared/MultiExtractor/ArArchiveFile.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Microsoft.CST.OpenSource.Shared
+{
+    /**
+     * Very simple implementation of an Ar format parser, needed for Debian .deb archives.
+     * Reference: https://en.wikipedia.org/wiki/Ar_(Unix)
+     */
+    public static class ArArchiveFile
+    {
+        // Simple method which returns a the file entries. We can't make this a continuation because
+        // we're using spans.
+        public static IEnumerable<FileEntry> GetFileEntries(FileEntry fileEntry)
+        {
+            if (fileEntry == null)
+            {
+                return Array.Empty<FileEntry>();
+            }
+
+            // First, cut out the global file header (8 bytes)
+            var innerContent = new Span<byte>(fileEntry.Content.ToArray(), 8, (int)fileEntry.Content.Length - 8);
+            var results = new List<FileEntry>();
+
+            while (true)
+            {
+                if (innerContent.Length < 60)  // The header is 60 bytes
+                {
+                    break;
+                }
+                var entryHeader = innerContent.Slice(0, 60);
+                var filename = Encoding.ASCII.GetString(innerContent.Slice(0, 16)).Trim();  // filename is 16 bytes
+                var fileSizeBytes = entryHeader.Slice(48, 10); // File size is decimal-encoded, 10 bytes long
+                var fileSize = int.Parse(Encoding.ASCII.GetString(fileSizeBytes.ToArray()).Trim());
+                var entryContent = innerContent.Slice(60, fileSize);
+                results.Add(new FileEntry(filename, fileEntry.FullPath, new MemoryStream(entryContent.ToArray())));
+                innerContent = innerContent[(60 + fileSize)..];
+            }
+            return results;
+        }
+    }
+}

--- a/src/Shared/MultiExtractor/Extractor.cs
+++ b/src/Shared/MultiExtractor/Extractor.cs
@@ -453,7 +453,6 @@ namespace Microsoft.CST.OpenSource.Shared
         {
             foreach (var entry in ArArchiveFile.GetFileEntries(fileEntry))
             {
-                using var memoryStream = new MemoryStream();
                 CheckResourceGovernor((long)entry.Content.Length);
                 foreach (var extractedFile in ExtractFile(entry))
                 {

--- a/src/Shared/MultiExtractor/Extractor.cs
+++ b/src/Shared/MultiExtractor/Extractor.cs
@@ -230,6 +230,9 @@ namespace Microsoft.CST.OpenSource.Shared
                     case ArchiveFileType.P7ZIP:
                         result = Extract7ZipFile(fileEntry);
                         break;
+                    case ArchiveFileType.DEB:
+                        result = ExtractArFile(fileEntry);
+                        break;
                     default:
                         rawFileUsed = true;
                         result = new[] { fileEntry };
@@ -435,6 +438,24 @@ namespace Microsoft.CST.OpenSource.Shared
                 CheckResourceGovernor(entry.Size);
                 var newFileEntry = new FileEntry(entry.Key, fileEntry.FullPath, entry.OpenEntryStream());
                 foreach (var extractedFile in ExtractFile(newFileEntry))
+                {
+                    yield return extractedFile;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Extracts an .ar (deb) file contained in fileEntry.
+        /// </summary>
+        /// <param name="fileEntry">FileEntry to extract</param>
+        /// <returns>Extracted files</returns>
+        private IEnumerable<FileEntry> ExtractArFile(FileEntry fileEntry)
+        {
+            foreach (var entry in ArArchiveFile.GetFileEntries(fileEntry))
+            {
+                using var memoryStream = new MemoryStream();
+                CheckResourceGovernor((long)entry.Content.Length);
+                foreach (var extractedFile in ExtractFile(entry))
                 {
                     yield return extractedFile;
                 }

--- a/src/Shared/MultiExtractor/MiniMagic.cs
+++ b/src/Shared/MultiExtractor/MiniMagic.cs
@@ -18,6 +18,7 @@ namespace Microsoft.CST.OpenSource.Shared
         BZIP2,
         RAR,
         P7ZIP,
+        DEB,
         UNKNOWN,
     }
 
@@ -50,7 +51,9 @@ namespace Microsoft.CST.OpenSource.Shared
 
             {"rar", ArchiveFileType.RAR },
 
-            {"7z", ArchiveFileType.P7ZIP }
+            {"7z", ArchiveFileType.P7ZIP },
+
+            {"deb", ArchiveFileType.DEB }
         };
 
         public static ArchiveFileType DetectFileType(string filename)
@@ -106,6 +109,11 @@ namespace Microsoft.CST.OpenSource.Shared
                 if (buffer[0] == 0x37 && buffer[1] == 0x7A && buffer[2] == 0xBC && buffer[3] == 0xAF && buffer[4] == 0x27 && buffer[5] == 0x1C)
                 {
                     return ArchiveFileType.P7ZIP;
+                }
+                // .deb - https://manpages.debian.org/unstable/dpkg-dev/deb.5.en.html
+                if (buffer[0] == 0x21 && buffer[1] == 0x3c && buffer[2] == 0x61 && buffer[3] == 0x72 && buffer[4] == 0x63 && buffer[5] == 0x68 && buffer[6] == 0x3e)
+                {
+                    return ArchiveFileType.DEB;
                 }
             }
 

--- a/src/Shared/PackageManagers/UbuntuProjectManager.cs
+++ b/src/Shared/PackageManagers/UbuntuProjectManager.cs
@@ -255,6 +255,11 @@ namespace Microsoft.CST.OpenSource.Shared
         public override async Task<string> GetMetadata(PackageURL purl)
         {
             Logger.Trace("GetMetadata {0}", purl?.ToString());
+            
+            if (purl == default || purl.Name == default)
+            {
+                return string.Empty;
+            }
 
             var metadataContent = new StringBuilder();
 

--- a/src/Shared/PackageManagers/UbuntuProjectManager.cs
+++ b/src/Shared/PackageManagers/UbuntuProjectManager.cs
@@ -1,0 +1,374 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+using AngleSharp.Html.Parser;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.CST.OpenSource.Shared
+{
+    class UbuntuProjectManager : BaseProjectManager
+    {
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
+        public static string ENV_UBUNTU_ENDPOINT = "https://packages.ubuntu.com";
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
+        public static string ENV_UBUNTU_ARCHIVE_MIRROR = "https://mirror.math.princeton.edu/pub";
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
+        public static string ENV_UBUNTU_POOL_NAMES = "main,universe,multiverse,restricted";
+
+        /// <summary>
+        /// Download one VS Marketplace package and extract it to the target directory.
+        /// </summary>
+        /// <param name="purl">Package URL of the package to download.</param>
+        /// <returns>the path or file written.</returns>
+        public override async Task<IEnumerable<string>> DownloadVersion(PackageURL purl, bool doExtract = true)
+        {
+            Logger.Trace("DownloadVersion {0}", purl?.ToString());
+            
+            var packageVersion = purl?.Version;
+            var downloadedPaths = new List<string>();
+            var downloadedUrls = new HashSet<string>();
+
+            if (purl == default || purl.Name == default)
+            {
+                return downloadedPaths;
+            }
+
+            var availablePools = await GetPoolsForProject(purl);
+            foreach (var pool in availablePools)
+            {
+                var archiveBaseUrl = await GetArchiveBaseUrlForProject(purl, pool);
+                if (archiveBaseUrl == default)
+                {
+                    Logger.Debug("Unable to find archive base URL.");
+                    continue;
+                }
+
+                try
+                {
+                    var html = await GetHttpStringCache(archiveBaseUrl, neverThrow: true);
+                    if (html == default)
+                    {
+                        continue;
+                    }
+
+                    var document = await new HtmlParser().ParseDocumentAsync(html);
+                    foreach (var anchor in document.QuerySelectorAll("a"))
+                    {
+                        var anchorHref = anchor.GetAttribute("href");
+                        if (anchorHref.Contains(packageVersion) && anchorHref.EndsWith(".deb"))
+                        {
+                            var fullDownloadUrl = archiveBaseUrl + "/" + anchorHref;
+                            if (!downloadedUrls.Add(fullDownloadUrl))
+                            {
+                                // Never re-download the same file twice.
+                                continue;
+                            }
+
+                            var downloadResult = await WebClient.GetAsync(fullDownloadUrl);
+                            if (!downloadResult.IsSuccessStatusCode)
+                            {
+                                Logger.Debug("Error {0} downloading file {1}", downloadResult.StatusCode, fullDownloadUrl);
+                                continue;
+                            }
+
+                            // TODO: Add distro version id
+                            var targetName = $"ubuntu-{purl.Name}@{packageVersion}-{Path.GetFileNameWithoutExtension(anchorHref)}";
+
+                            if (doExtract)
+                            {
+                                downloadedPaths.Add(await ExtractArchive(targetName, await downloadResult.Content.ReadAsByteArrayAsync()));
+                            }
+                            else
+                            {
+                                targetName += Path.GetExtension(anchorHref) ?? "";
+                                await File.WriteAllBytesAsync(targetName, await downloadResult.Content.ReadAsByteArrayAsync());
+                                downloadedPaths.Add(targetName);
+                            }
+                        }
+
+                        // Source Code URLs don't have the full version on the source files.
+                        // We need to find them in the .dsc
+                        else if (anchorHref.Contains(packageVersion) && anchorHref.EndsWith(".dsc"))
+                        {
+                            var dscContent = await GetHttpStringCache(archiveBaseUrl + "/" + anchorHref);
+                            if (dscContent == default)
+                            {
+                                continue;
+                            }
+
+                            var seenFiles = new HashSet<string>();
+                            foreach (Match match in Regex.Matches(dscContent, "^ [a-z0-9]+ \\d+ (.*)$", RegexOptions.Multiline | RegexOptions.IgnoreCase))
+                            {
+                                seenFiles.Add(match.Groups[1].Value.Trim());
+                            }
+
+                            // Now we need to go through the anchor tags again looking for the source code files
+                            foreach (var secondAnchor in document.QuerySelectorAll("a"))
+                            {
+                                var secondHref = secondAnchor.GetAttribute("href");
+                                var fullDownloadUrl = archiveBaseUrl + "/" + secondHref;
+                                if (seenFiles.Any(f => secondHref.Contains(f) && !secondHref.EndsWith(".deb") && !secondHref.EndsWith(".dsc")))
+                                {
+                                    var downloadResult = await WebClient.GetAsync(fullDownloadUrl);
+                                    if (!downloadResult.IsSuccessStatusCode)
+                                    {
+                                        Logger.Debug("Error {0} downloading file {1}", downloadResult.StatusCode, fullDownloadUrl);
+                                        continue;
+                                    }
+
+                                    // TODO: Add distro version id
+                                    var targetName = $"ubuntu-{purl.Name}@{packageVersion}-{Path.GetFileNameWithoutExtension(anchorHref)}";
+
+                                    if (doExtract)
+                                    {
+                                        downloadedPaths.Add(await ExtractArchive(targetName, await downloadResult.Content.ReadAsByteArrayAsync()));
+                                    }
+                                    else
+                                    {
+                                        targetName += Path.GetExtension(anchorHref) ?? "";
+                                        await File.WriteAllBytesAsync(targetName, await downloadResult.Content.ReadAsByteArrayAsync());
+                                        downloadedPaths.Add(targetName);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logger.Warn("Error downloading binary for {0}: {1}", purl.ToString(), ex.Message);
+                }
+            }
+
+            return downloadedPaths;
+        }
+
+
+        private List<string> GetBaseURLs(PackageURL purl)
+        {
+            var results = new List<string>();
+            var dirName = purl.Name.StartsWith("lib") ? "lib" + purl.Name.Substring(3, 1) : purl.Name.Substring(0, 1);
+
+            var distroName = "ubuntu";  // default
+            purl.Qualifiers?.TryGetValue("distro", out distroName);
+            
+            if (purl.Qualifiers != default && purl.Qualifiers.TryGetValue("pool", out string selectedPool))
+            {
+                results.Add($"{ENV_UBUNTU_ARCHIVE_MIRROR}/{distroName}/pool/{selectedPool}/{dirName}/{purl.Name}/");
+            }
+            else
+            {
+                foreach (var pool in ENV_UBUNTU_POOL_NAMES.Split(","))
+                {
+                    results.Add($"{ENV_UBUNTU_ARCHIVE_MIRROR}/{distroName}/pool/{pool}/{dirName}/{purl.Name}/");
+                    Logger.Debug($"{ENV_UBUNTU_ARCHIVE_MIRROR}/{distroName}/pool/{pool}/{dirName}/{purl.Name}/");
+
+                }
+            }
+            return results;
+        }
+
+        public override async Task<IEnumerable<string>> EnumerateVersions(PackageURL purl)
+        {
+            Logger.Trace("EnumerateVersions {0}", purl?.ToString());
+
+            var versionList = new List<string>(); 
+            if (purl == default || purl.Name == default)
+            {
+                return versionList;
+            }
+            var availablePools = await GetPoolsForProject(purl);
+            foreach (var pool in availablePools)
+            {
+                var archiveBaseUrl = await GetArchiveBaseUrlForProject(purl, pool);
+                if (archiveBaseUrl == default)
+                {
+                    Logger.Debug("Unable to find archive base URL.");
+                    continue;
+                }
+
+                Logger.Debug("Located archive base URL: {0}", archiveBaseUrl);
+
+                // Now load the archive page, which will show all of the versions in each
+                // of the .dsc files there.
+                try
+                {
+                    var html = await GetHttpStringCache(archiveBaseUrl, neverThrow: true);
+                    if (html == default)
+                    {
+                        continue;
+                    }
+                    var document = await new HtmlParser().ParseDocumentAsync(html);
+                    foreach (var anchor in document.QuerySelectorAll("a"))
+                    {
+                        var anchorHref = anchor.GetAttribute("href");
+                        if (anchorHref.EndsWith(".dsc"))
+                        {
+                            Logger.Debug("Found a .dsc file: {0}", anchorHref);
+                            var dscContent = await GetHttpStringCache(archiveBaseUrl + "/" + anchorHref);
+                            foreach (var line in dscContent.Split(new char[] { '\n', '\r' }))
+                            {
+                                if (line.StartsWith("Version:"))
+                                {
+                                    var versionOnly = line.Replace("Version:", "").Trim();
+                                    Match match = Regex.Match(versionOnly, "^\\d+:(.*)$");
+                                    if (match.Success)
+                                    {
+                                        versionOnly = match.Groups[1].Value;
+                                    }
+
+                                    Logger.Debug("Identified a version: {0}", versionOnly);
+                                    versionList.Add(versionOnly);
+                                    break;  // Only care about the first version
+                                }
+                            }
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logger.Warn(ex, "Error enumerating Ubuntu package versions: {0}", ex.Message);
+                    return Array.Empty<string>();
+                }
+            }
+            return SortVersions(versionList.Distinct());
+        }
+
+        public override async Task<string> GetMetadata(PackageURL purl)
+        {
+            Logger.Trace("GetMetadata {0}", purl?.ToString());
+
+            var metadataContent = new StringBuilder();
+
+            foreach (var distroUrlPrefix in GetBaseURLs(purl))
+            {
+                try
+                {
+                    var html = await GetHttpStringCache(distroUrlPrefix, neverThrow: true);
+                    if (html != default)
+                    {
+                        var document = await new HtmlParser().ParseDocumentAsync(html);
+                        foreach (var anchor in document.QuerySelectorAll("a"))
+                        {
+                            var anchorHref = anchor.GetAttribute("href");
+                            if (anchorHref.EndsWith(".dsc"))
+                            {
+                                Logger.Debug("Found a .dsc file: {0}", anchorHref);
+                                var dscContent = await GetHttpStringCache(distroUrlPrefix + anchorHref, neverThrow: true);
+                                if (dscContent == default)
+                                {
+                                    continue;
+                                }
+                                metadataContent.AppendLine(dscContent);
+                            }
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logger.Warn("Error obtaining .dsc file for {0}: {1}", purl.ToString(), ex.Message);
+                }
+
+                // Fallback to packages.ubuntu.com if we haven't seen any .dsc files
+                if (metadataContent.Length == 0)
+                {
+                    try
+                    {
+                        var searchResults = await GetHttpStringCache($"{ENV_UBUNTU_ENDPOINT}/search?keywords={purl.Name}&searchon=names&exact=1&suite=all&section=all");
+                        var parser = new HtmlParser();
+                        var document = await parser.ParseDocumentAsync(searchResults);
+                        var anchorItems = document.QuerySelectorAll("a.resultlink");
+                        var metadataUrlList = anchorItems.Select(s => s.GetAttribute("href") ?? "");
+
+                        foreach (var metadataUrl in metadataUrlList)
+                        {
+                            metadataContent.AppendLine(await GetHttpStringCache($"{ENV_UBUNTU_ENDPOINT}/{metadataUrl}"));
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Warn(ex, "Error fetching Ubuntu metadata: {0}", ex.Message);
+                    }
+                }
+            }
+
+            return metadataContent.ToString();
+        }
+
+        /// <summary>
+        /// Identifies the base URL for package source files.
+        /// </summary>
+        /// <param name="purl"></param>
+        /// <param name="pool"></param>
+        /// <returns></returns>
+        private async Task<string> GetArchiveBaseUrlForProject(PackageURL purl, string pool)
+        {
+            try
+            {
+                var html = await GetHttpStringCache($"{ENV_UBUNTU_ENDPOINT}/{pool}/{purl.Name}");
+                var document = await new HtmlParser().ParseDocumentAsync(html);
+                foreach (var anchor in document.QuerySelectorAll("a"))
+                {
+                    var href = anchor.GetAttribute("href");
+                    if (href != default && href.EndsWith(".dsc"))
+                    {
+                        var match = Regex.Match(href, "(.+)/[^/]+\\.dsc");
+                        if (match.Success)
+                        {
+                            return match.Groups[1].Value.Trim();
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Warn(ex, "Error fetching Ubuntu archive base URL for {0}: {1}", purl.ToString(), ex.Message);
+            }
+            return default;
+        }
+
+        /// <summary>
+        /// Identifies the available pools for a given Ubuntu project. For example,
+        /// 'xenial'.
+        /// </summary>
+        /// <param name="purl">Package URL to look up (only name is used).</param>
+        /// <returns>List of pool names</returns>
+        private async Task<IEnumerable<string>> GetPoolsForProject(PackageURL purl)
+        {
+            var pools = new HashSet<string>();
+            try
+            {
+                var searchResults = await GetHttpStringCache($"{ENV_UBUNTU_ENDPOINT}/search?keywords={purl.Name}&searchon=names&exact=1&suite=all&section=all");
+                var document = await new HtmlParser().ParseDocumentAsync(searchResults);
+                foreach (var anchor in document.QuerySelectorAll("a.resultlink"))
+                {
+                    var href = anchor.GetAttribute("href");
+                    if (href != default)
+                    {
+                        var match = Regex.Match(href, "^/([^/]+)/.+");
+                        if (match.Success)
+                        {
+                            var pool = match.Groups[1].Value.Trim();
+                            Logger.Debug("Identified pool: {0}", pool);
+                            pools.Add(pool);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Warn(ex, "Error fetching Ubuntu pools for {0}: {1}", purl.ToString(), ex.Message);
+            }
+            return pools;
+        }
+    }
+}

--- a/src/Shared/PackageManagers/UbuntuProjectManager.cs
+++ b/src/Shared/PackageManagers/UbuntuProjectManager.cs
@@ -72,6 +72,7 @@ namespace Microsoft.CST.OpenSource.Shared
                                 // Never re-download the same file twice.
                                 continue;
                             }
+                            Logger.Debug("Downloading binary: {0}", fullDownloadUrl);
 
                             var downloadResult = await WebClient.GetAsync(fullDownloadUrl);
                             if (!downloadResult.IsSuccessStatusCode)
@@ -81,7 +82,7 @@ namespace Microsoft.CST.OpenSource.Shared
                             }
 
                             // TODO: Add distro version id
-                            var targetName = $"ubuntu-{purl.Name}@{packageVersion}-{Path.GetFileNameWithoutExtension(anchorHref)}";
+                            var targetName = $"ubuntu-{purl.Name}@{packageVersion}-{anchorHref}";
 
                             if (doExtract)
                             {
@@ -115,9 +116,16 @@ namespace Microsoft.CST.OpenSource.Shared
                             foreach (var secondAnchor in document.QuerySelectorAll("a"))
                             {
                                 var secondHref = secondAnchor.GetAttribute("href");
-                                var fullDownloadUrl = archiveBaseUrl + "/" + secondHref;
-                                if (seenFiles.Any(f => secondHref.Contains(f) && !secondHref.EndsWith(".deb") && !secondHref.EndsWith(".dsc")))
+                                if (seenFiles.Any(f => f.Equals(secondHref) && !secondHref.EndsWith(".deb") && !secondHref.EndsWith(".dsc")))
                                 {
+                                    var fullDownloadUrl = archiveBaseUrl + "/" + secondHref;
+                                    if (!downloadedUrls.Add(fullDownloadUrl))
+                                    {
+                                        // Never re-download the same file twice.
+                                        continue;
+                                    }
+                                    Logger.Debug("Downloading source code: {0}", fullDownloadUrl);
+                                    
                                     var downloadResult = await WebClient.GetAsync(fullDownloadUrl);
                                     if (!downloadResult.IsSuccessStatusCode)
                                     {
@@ -126,7 +134,7 @@ namespace Microsoft.CST.OpenSource.Shared
                                     }
 
                                     // TODO: Add distro version id
-                                    var targetName = $"ubuntu-{purl.Name}@{packageVersion}-{Path.GetFileNameWithoutExtension(anchorHref)}";
+                                    var targetName = $"ubuntu-{purl.Name}@{packageVersion}-{secondHref}";
 
                                     if (doExtract)
                                     {

--- a/src/Shared/PackageUrl/PackageUrl.cs
+++ b/src/Shared/PackageUrl/PackageUrl.cs
@@ -26,6 +26,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -168,6 +169,12 @@ namespace Microsoft.CST.OpenSource.Shared
                 purl.Append("#").Append(Subpath);
             }
             return purl.ToString();
+        }
+
+        public string ToStringFilename()
+        {
+            var invalidChars = new string(Path.GetInvalidFileNameChars()) + new string(Path.GetInvalidPathChars());
+            return Regex.Replace(this.ToString(), "[" + Regex.Escape(invalidChars) + "]", "-");
         }
 
         private void Parse(string purl)

--- a/src/Shared/nlog.config
+++ b/src/Shared/nlog.config
@@ -18,7 +18,7 @@
     </target>
     <target xsi:type="File"
             name="fileLog"
-            layout="${date}|${level:uppercase=true}|${message} ${exception}|${logger}|${all-event-properties}"
+            layout="${date}|${level:uppercase=true}|${message} ${exception}|${all-event-properties}"
             encoding="utf-8"
             lineEnding="default"
             fileName="oss-gadget.log">

--- a/src/oss-detect-cryptography/DetectCryptographyTool.cs
+++ b/src/oss-detect-cryptography/DetectCryptographyTool.cs
@@ -1,0 +1,629 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using ELFSharp.ELF;
+using ELFSharp;
+using ELFSharp.MachO;
+using PeNet;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CST.OpenSource.Shared;
+using Microsoft.DevSkim;
+using ICSharpCode.Decompiler;
+using ICSharpCode.Decompiler.CSharp;
+using System.Text.RegularExpressions;
+using System.Reflection;
+using SharpDisasm;
+
+namespace Microsoft.CST.OpenSource
+{
+    public class DetectCryptographyTool
+    {
+        /// <summary>
+        /// Name of this tool.
+        /// </summary>
+        private const string TOOL_NAME = "oss-detect-cryptography";
+
+        /// <summary>
+        /// Holds the version string, from the assembly.
+        /// </summary>
+        private static readonly string VERSION = typeof(DetectCryptographyTool).Assembly.GetName().Version.ToString();
+
+        /// <summary>
+        /// Logger for this class
+        /// </summary>
+        private static NLog.ILogger Logger { get; set; }
+
+        /// <summary>
+        /// Command line options
+        /// </summary>
+        public Dictionary<string, object> Options = new Dictionary<string, object>()
+        {
+            { "target", new List<string>() },
+            { "disable-default-rules", false },
+            { "custom-rule-directory", null },
+            { "verbose", false }
+        };
+
+        private static readonly IEnumerable<string> IGNORE_FILES = new List<string>()
+        {
+            ".signature.p7s"
+        };
+
+        /// <summary>
+        /// Main entrypoint for the download program.
+        /// </summary>
+        /// <param name="args">parameters passed in from the user</param>
+        static async Task Main(string[] args)
+        {
+            var detectCryptographyTool = new DetectCryptographyTool();
+            Logger.Info($"Microsoft OSS Gadget - {TOOL_NAME} {VERSION}");
+
+            detectCryptographyTool.ParseOptions(args);
+
+            if (((IList<string>)detectCryptographyTool.Options["target"]).Count > 0)
+            {
+                foreach (var target in (IList<string>)detectCryptographyTool.Options["target"])
+                {
+                    var sb = new StringBuilder();
+                    try
+                    {
+                        List<IssueRecord> results = null;
+                        if (target.StartsWith("pkg:"))
+                        {
+                            var purl = new PackageURL(target);
+                            results = await detectCryptographyTool.AnalyzePackage(purl);
+                        }
+                        else if (Directory.Exists(target))
+                        {
+                            results = await detectCryptographyTool.AnalyzeDirectory(target);
+                        }
+                        else if (File.Exists(target))
+                        {
+                            string targetDirectoryName = null;
+                            while (targetDirectoryName == null || Directory.Exists(targetDirectoryName))
+                            {
+                                targetDirectoryName = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+                            }
+                            var projectManager = new BaseProjectManager()
+                            {
+                                TopLevelExtractionDirectory = targetDirectoryName
+                            };
+                            
+                            #pragma warning disable SCS0018 // Path traversal: injection possible in {1} argument passed to '{0}'
+                            var path = await projectManager.ExtractArchive("temp", File.ReadAllBytes(target));
+                            #pragma warning restore SCS0018 // Path traversal: injection possible in {1} argument passed to '{0}'
+                            
+                            results = await detectCryptographyTool.AnalyzeDirectory(path);
+                            
+                            // Clean up after ourselves
+                            try
+                            {
+                                if (targetDirectoryName != null)
+                                {
+                                    Directory.Delete(targetDirectoryName, true);
+                                }
+                            }
+                            catch (Exception ex)
+                            {
+                                Logger.Warn("Unable to delete {0}: {1}", targetDirectoryName, ex.Message);
+                            }
+                        }
+                        
+                        if (results.Count() == 0)
+                        {
+                            sb.AppendLine($"[ ] {target} - This software package does NOT appear to implement cryptography.");
+                        }
+                        else
+                        {
+                            var shortTags = results.SelectMany(r => r.Issue.Rule.Tags)
+                                                   .Distinct()
+                                                   .Where (t => t.StartsWith("Cryptography.Implementation."))
+                                                   .Select(t => t.Replace("Cryptography.Implementation.", ""));
+                            var otherTags = results.SelectMany(r => r.Issue.Rule.Tags)
+                                                   .Distinct()
+                                                   .Where(t => !t.StartsWith("Cryptography.Implementation."));
+
+                            if (shortTags.Count() > 0)
+                            {
+                                sb.AppendLine($"[X] {target} - This software package appears to implement {string.Join(", ", shortTags)}.");
+                            }
+
+                            if (otherTags.Contains("Cryptography.GenericImplementation.HighDensityOperators"))
+                            {
+                                sb.AppendLine($"[X] {target} - This software package has a high-density of cryptographic operators.");
+                            }
+                            else
+                            {
+                                sb.AppendLine($"[ ] {target} - This software package does NOT have a high-density of cryptographic operators.");
+                            }
+
+                            if (otherTags.Contains("Cryptography.GenericImplementation.CryptographicWords"))
+                            {
+                                sb.AppendLine($"[X] {target} - This software package contains words that suggest cryptography.");
+                            }
+                            else
+                            {
+                                sb.AppendLine($"[ ] {target} - This software package does NOT contains words that suggest cryptography.");
+                            }
+                            
+                            if ((bool)detectCryptographyTool.Options["verbose"])
+                            {
+                                var items = results.GroupBy(k => k.Issue.Rule.Name).OrderByDescending(k => k.Count());
+                                foreach (var item in items)
+                                {
+                                    sb.AppendLine();
+                                    sb.AppendLine($"There were {item.Count()} finding(s) of type [{item.Key}].");
+                                    
+                                    foreach (var result in results)
+                                    {
+                                        if (result.Issue.Rule.Name == item.Key)
+                                        {
+                                            sb.AppendLine($" {result.Filename}:");
+                                            if (result.Issue.Rule.Id == "_CRYPTO_DENSITY")
+                                            {
+                                                // No excert for cryptogrpahic density
+                                                // TODO: We stuffed the density in the unused 'Description' field. This is code smell.
+                                                sb.AppendLine($"  | The maximum cryptographic density is {result.Issue.Rule.Description}.");
+                                            }
+                                            else
+                                            {
+                                                // Show the excerpt
+                                                foreach (var line in result.TextSample.Split(new char[] { '\n', '\r' }))
+                                                {
+                                                    if (!string.IsNullOrWhiteSpace(line))
+                                                    {
+                                                        sb.AppendLine($"  | {line.Trim()}");
+                                                    }
+                                                }
+                                            }
+                                            sb.AppendLine();
+                                        }
+                                    }
+                                }
+                            }
+
+                            if (Logger.IsDebugEnabled)
+                            {
+                                foreach (var result in results)
+                                {
+                                    Logger.Debug($"Result: {result.Filename} {result.Issue.Rule.Name} {result.TextSample}");
+                                }
+                            }
+                        }
+                        Console.WriteLine(sb.ToString());
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Warn(ex, "Error processing {0}: {1}", target, ex.Message);
+                        Logger.Warn(ex.StackTrace);
+                    }
+                }
+            }
+            else
+            {
+                Logger.Warn("No target provided; nothing to analyze.");
+                DetectCryptographyTool.ShowUsage();
+                Environment.Exit(1);
+            }
+        }
+
+        public DetectCryptographyTool()
+        {
+            CommonInitialization.Initialize();
+            Logger = CommonInitialization.Logger;
+        }
+
+
+        /// <summary>
+        /// Analyze a package by downloading it first.
+        /// </summary>
+        /// <param name="purl">The package-url of the package to analyze.</param>
+        /// <returns>List of tags identified</returns>
+        public async Task<List<IssueRecord>> AnalyzePackage(PackageURL purl)
+        {
+            Logger.Trace("AnalyzePackage({0})", purl.ToString());
+
+            var analysisResults = new List<IssueRecord>();
+
+            string targetDirectoryName = null;
+            while (targetDirectoryName == null || Directory.Exists(targetDirectoryName))
+            {
+                targetDirectoryName = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            }
+
+            Logger.Trace("Creating directory [{0}]", targetDirectoryName);
+            Directory.CreateDirectory(targetDirectoryName);
+
+            var downloadTool = new DownloadTool();
+            var directoryNames = await downloadTool.Download(purl, targetDirectoryName);
+            directoryNames = directoryNames.Distinct().ToList<string>();
+
+            if (directoryNames.Count > 0)
+            {
+                foreach (var directoryName in directoryNames)
+                {
+                    Logger.Trace("Analyzing directory {0}", directoryName);
+                    var singleResult = await AnalyzeDirectory(directoryName);
+                    if (singleResult != default)
+                    {
+                        analysisResults.AddRange(singleResult);
+                    }
+
+                    Logger.Trace("Removing directory {0}", directoryName);
+                    try
+                    {
+                        Directory.Delete(directoryName, true);
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Warn("Error removing {0}: {1}", directoryName, ex.Message);
+                    }
+                }
+            }
+            else
+            {
+                Logger.Warn("Error downloading {0}.", purl.ToString());
+            }
+            
+
+            return analysisResults.ToList();
+        }
+        private string NormalizeFileContent(string filename, byte[] buffer)
+        {
+            Logger.Trace("NormalizeFileContent({0}, {1}", filename, buffer?.Length);
+
+            if (buffer == null || buffer.Length == 0)
+            {
+                return string.Empty;
+            }
+
+            // Check if we have a binary file - meaning more than 10% control characters
+            // TODO: Is this the right metric?
+            var bufferString = Encoding.ASCII.GetString(buffer);
+            var countControlChars = bufferString.Count(ch => char.IsControl(ch) && ch != '\r' && ch != '\n');
+            var isBinaryFile = (((double)countControlChars / (double)bufferString.Length) > 0.10);
+
+            if (isBinaryFile)
+            {
+                // First, is it a PE file?
+                if (PeFile.IsPeFile(buffer))
+                {
+                    try
+                    {
+                        var decompiler = new CSharpDecompiler(filename, new DecompilerSettings());
+                        return decompiler.DecompileWholeModuleAsString();
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Warn("Unable to decompile {0}: {1}", filename, ex.Message);
+                    }
+                }
+
+                try
+                {
+                    // Do a full disassembly, but only show unique lines.
+                    Disassembler.Translator.IncludeAddress = false;
+                    Disassembler.Translator.IncludeBinary = false;
+                    var architecture = buffer.Length > 5 && buffer[5] == 0x02 ? ArchitectureMode.x86_64 : ArchitectureMode.x86_32;
+                    Disassembler d = new Disassembler(buffer, architecture);
+                    var resultStrings = new HashSet<string>();
+                    foreach (var instruction in d.Disassemble())
+                    {
+                        resultStrings.Add(instruction.ToString());
+                        
+                    }
+                    return string.Join('\n', resultStrings);
+                }
+                catch(Exception ex)
+                {
+                    Logger.Warn("Unable to decompile {0}: {1}", filename, ex.Message);
+                }
+
+                return string.Join('\n', UniqueStringsFromBinary(buffer));
+            }
+
+            // Fallback, just return the string iteself
+            return bufferString;
+        }
+
+        /// <summary>
+        /// Analyzes a directory of files.
+        /// </summary>
+        /// <param name="directory">directory to analyze.</param>
+        /// <returns>List of tags identified</returns>
+        public async Task<List<IssueRecord>> AnalyzeDirectory(string directory)
+        {
+            Logger.Trace("AnalyzeDirectory({0})", directory);
+
+            var analysisResults = new List<IssueRecord>();
+
+            RuleSet rules = new RuleSet();
+            if (!(bool)Options["disable-default-rules"])
+            {
+                var assembly = Assembly.GetExecutingAssembly();
+                foreach (var resourceName in assembly.GetManifestResourceNames())
+                {
+                    if (resourceName.EndsWith(".json"))
+                    {
+                        try
+                        {
+                            var stream = assembly.GetManifestResourceStream(resourceName);
+                            using var resourceStream = new StreamReader(stream);
+                            rules.AddString(resourceStream.ReadToEnd(), resourceName);
+                        }
+                        catch(Exception ex)
+                        {
+                            Logger.Warn(ex, "Error loading {0}: {1}", resourceName, ex.Message);
+                        }
+                    }
+                }
+            }
+
+            if ((string)Options["custom-rule-directory"] != null)
+            {
+                rules.AddDirectory((string)Options["custom-rule-directory"]);
+            }
+
+            if (rules.Count() == 0)
+            {
+                Logger.Error("No rules were specified, unable to continue.");
+                return analysisResults; // empty
+            }
+
+            var processor = new RuleProcessor(rules)
+            {
+                EnableSuppressions = false,
+                SeverityLevel = (Severity)31
+            };
+
+            foreach (var filename in Directory.GetFiles(directory, "*", SearchOption.AllDirectories))
+            {
+                Logger.Trace($"Processing {filename}");
+
+                // TODO: Make this more resilient
+                if (IGNORE_FILES.Contains(Path.GetFileName(filename)))
+                {
+                    Logger.Trace($"Ignoring {filename}");
+                    continue;
+                }
+
+                var buffer = NormalizeFileContent(filename, File.ReadAllBytes(filename));
+                Logger.Debug("Normalization complete.");
+
+                double MIN_CRYPTO_OP_DENSITY = 0.10;
+                try
+                {
+                    // TODO don't do this if we disassembled native code
+                    var cryptoOperationLikelihood = CalculateCryptoOpDensity(buffer);
+                    Logger.Debug("Cryptographic operation density for {0} was {1}", filename, cryptoOperationLikelihood);
+
+                    if (cryptoOperationLikelihood >= MIN_CRYPTO_OP_DENSITY)
+                    {
+                        analysisResults.Add(new IssueRecord(
+                            Filename: filename,
+                            Filesize: buffer.Length,
+                            TextSample: "n/a",
+                            Issue: new Issue(
+                                Boundary: new Boundary(),
+                                StartLocation: new Location(),
+                                EndLocation: new Location(),
+                                Rule: new Rule("Crypto Symbols")
+                                {
+                                    Id = "_CRYPTO_DENSITY",
+                                    Name = "Cryptographic symbols",
+                                    Description = cryptoOperationLikelihood.ToString(),
+                                    Tags = new string[]
+                                    {
+                                        "Cryptography.GenericImplementation.HighDensityOperators"
+                                    }
+                                }
+                            )
+                        ));
+                    }
+                    Logger.Debug($"Analyzing {filename}, length={buffer.Length}");
+                    
+                    Issue[] fileResults = null;
+                    var task = Task.Run(() => processor.Analyze(buffer, Language.FromFileName(filename)));
+                    if (task.Wait(TimeSpan.FromSeconds(2)))
+                    {
+                        fileResults = task.Result;
+                    }
+                    else
+                    {
+                        Logger.Debug("DevSkim operation timed out.");
+                        return analysisResults;
+                    }
+
+                    Logger.Debug("Operation Complete: {0}", fileResults?.Length);
+
+                    foreach (var issue in fileResults)
+                    {
+                        var fileContentArray = buffer.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
+                        var excerpt = new List<string>();
+                        var startLoc = Math.Max(issue.StartLocation.Line - 1, 0);
+                        var endLoc = Math.Min(issue.EndLocation.Line + 1, fileContentArray.Length - 1);
+                        for (int i=startLoc; i<=endLoc; i++)
+                        {
+                            excerpt.Add(fileContentArray[i].Trim());
+                        }
+
+                        analysisResults.Add(new IssueRecord(
+                            Filename: filename,
+                            Filesize: buffer.Length,
+                            TextSample: issue.StartLocation.Line + " => " + string.Join(Environment.NewLine, excerpt),
+                            Issue: issue)
+                        );
+                    }
+                }
+                catch(Exception ex)
+                {
+                    Logger.Warn(ex, "Error analyzing {0}: {1}", filename, ex.Message);
+                    Logger.Warn(ex.StackTrace);
+                }
+            }
+
+            return analysisResults;
+        }
+
+        /// <summary>
+        /// Calculates the density of cryptographic operators within the buffer.
+        /// </summary>
+        /// <param name="buffer">Buffer to analyze</param>
+        /// <param name="windowSize">Size of the window to use</param>
+        /// <returns>Ratio (0-1) of the most dense windowSize characters of the buffer.</returns>
+        private double CalculateCryptoOpDensity(string buffer, int windowSize = 50)
+        {
+            Logger.Trace("CalculateCryptoOpDensity()");
+
+            if (string.IsNullOrWhiteSpace(buffer))
+            {
+                return 0;
+            }
+            int MIN_BUFFER_LENGTH = 5;
+
+            // Consolidate whitespace
+            buffer = Regex.Replace(buffer, "[\t ]", "");
+
+            // Condense all multi-character strings into a single character
+            buffer = Regex.Replace(buffer, "[a-zA-Z\\$_][a-zA-Z0-9_]*", "X");
+
+            // If we have a very short string, ignore it.
+            if (buffer.Distinct<char>().Count() < MIN_BUFFER_LENGTH)
+            {
+                return 0;
+            }
+
+            // Normalize the sliding window size
+            windowSize = windowSize >= buffer.Length ? buffer.Length : windowSize;
+            windowSize = windowSize <= 0 ? 50 : windowSize;
+
+            // This is a horrible regular expression, but the intent is to capture symbol characters that
+            // probably mean something within cryptographic code, but not within other code.
+            var cryptoChars = new Regex("(?<=[a-z0-9_])\\^=?(?=[a-z_])|(?<=[a-z0-9_])(>{2,3}|<{2,3})=?(?=[a-z0-9])|(?<=[a-z0-9_])([&^~|])=?(?=[a-z0-9])", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+            // We report on the highest ratio of symbol to total characters
+            double maxRatio = 0;
+
+            // Iterate through all windows: TODO We can skip-count a few here
+            for (int i = 0; i < buffer.Length - windowSize; i += 1)
+            {
+                var windowBuffer = buffer.Substring(i, windowSize);
+                windowBuffer = cryptoChars.Replace(windowBuffer, string.Empty);
+                double ratio = ((double)windowSize - (double)windowBuffer.Length) / (double)windowSize;
+                if (ratio > maxRatio)
+                {
+                    maxRatio = ratio;
+                    Logger.Trace("Updated from: {0}", buffer.Substring(i, windowSize));
+                    Logger.Trace("          to: {0}", windowBuffer);
+                }
+            }
+            return maxRatio;
+        }
+
+        /// <summary>
+        /// Extract unique strings (alphabetic) from a string
+        /// TODO: This is ASCII-only.
+        /// </summary>
+        /// <param name="buffer">string to scan</param>
+        /// <returns>unique strings</returns>
+        private IEnumerable<string> UniqueStringsFromBinary(byte[] buffer)
+        {
+            var bufferString = Encoding.ASCII.GetString(buffer);
+            var words = Regex.Matches(bufferString, @"([a-zA-Z]\.[a-zA-Z ]{4,})");
+            return words.Select(m => m.Value).Distinct<string>();
+        }
+
+        /// <summary>
+        /// Parses options for this program.
+        /// </summary>
+        /// <param name="args">arguments (passed in from the user)</param>
+        private void ParseOptions(string[] args)
+        {
+            if (args == null)
+            {
+                ShowUsage();
+                Environment.Exit(1);
+            }
+
+            for (int i = 0; i < args.Length; i++)
+            {
+                switch (args[i])
+                {
+                    case "-h":
+                    case "--help":
+                        ShowUsage();
+                        Environment.Exit(1);
+                        break;
+
+                    case "-v":
+                    case "--version":
+                        Console.Error.WriteLine($"{TOOL_NAME} {VERSION}");
+                        Environment.Exit(1);
+                        break;
+
+                    case "--verbose":
+                        Options["verbose"] = true;
+                        break;
+
+                    case "--custom-rule-directory":
+                        Options["custom-rule-directory"] = args[++i];
+                        break;
+
+                    case "--disable-default-rules":
+                        Options["disable-default-rules"] = true;
+                        break;
+
+                    default:
+                        ((IList<string>)Options["target"]).Add(args[i]);
+                        break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Displays usage information for the program.
+        /// </summary>
+        private static void ShowUsage()
+        {
+            Console.Error.WriteLine($@"
+{TOOL_NAME} {VERSION}
+
+Usage: {TOOL_NAME} [options] package-url...
+
+positional arguments:
+    package-url                 PackgeURL specifier to download (required, repeats OK)
+
+{BaseProjectManager.GetCommonSupportedHelpText()}
+
+optional arguments:
+  --verbose                     increase output verbosity
+  --custom-rule-directory DIR   load rules from directory DIR
+  --disable-default-rules       do not load default, built-in rules.
+  --help                        show this help message and exit
+  --version                     show version of this tool
+");
+        }
+    }
+
+    public class IssueRecord
+    {
+        public string Filename { get; }
+        public int Filesize { get; }
+        public string TextSample { get; }
+        public Issue Issue { get; }
+
+        public IssueRecord(string Filename, int Filesize, string TextSample, Issue Issue)
+        {
+            this.Filename = Filename;
+            this.Filesize = Filesize;
+            this.TextSample = TextSample;
+            this.Issue = Issue;
+        }
+    }
+}
+

--- a/src/oss-detect-cryptography/Resources/CryptographyRules/implementation-asymmetric.json
+++ b/src/oss-detect-cryptography/Resources/CryptographyRules/implementation-asymmetric.json
@@ -1,0 +1,16 @@
+[
+  {
+    "name": "OAEP",
+    "id": "DS802020",
+    "description": "An implementation bcrypt-pbkdf.",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.BCryptPBKDF"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "",
+    "patterns": [
+    ]
+  }
+]

--- a/src/oss-detect-cryptography/Resources/CryptographyRules/implementation-block-cipher.json
+++ b/src/oss-detect-cryptography/Resources/CryptographyRules/implementation-block-cipher.json
@@ -1,0 +1,25 @@
+[
+  {
+    "name": "Implementation of SM4",
+    "id": "DS802050",
+    "description": "An implementation SM4",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.SM4"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "",
+    "patterns": [
+      {
+        "pattern": "d6.{0,10}90.{0,10}e9.{0,10}fe.{0,10}cc.{0,10}e1.{0,10}3d",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "all"
+        ],
+        "_comment": "Magic Constant for SM4"
+      }
+    ]
+  }
+]

--- a/src/oss-detect-cryptography/Resources/CryptographyRules/implementation-crypto-generic.json
+++ b/src/oss-detect-cryptography/Resources/CryptographyRules/implementation-crypto-generic.json
@@ -1,0 +1,23 @@
+[
+  {
+    "name": "Cryptographic Words",
+    "id": "DS802030",
+    "description": "Cryptographic Words",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.GenericImplementation.CryptographicWords"
+    ],
+    "severity": "moderate",
+    "_comment": "",
+    "rule_info": "",
+    "patterns": [
+      {
+        "pattern": "(roundkey|keyround|mixcolumns|s-?box|key\\s*schedule|(linear congruential)|(substitution box)|publickeymodulus|publickeyexponent)",
+        "type": "regex",
+        "scopes": [ "all" ],
+        "modifiers": [ "i" ],
+        "_comment": "Words that are often used with crypto implementations"
+      }
+    ]
+  }
+]

--- a/src/oss-detect-cryptography/Resources/CryptographyRules/implementation-hash.json
+++ b/src/oss-detect-cryptography/Resources/CryptographyRules/implementation-hash.json
@@ -1,61 +1,397 @@
 [
   {
-    "name": "Implementation of Blowfish",
+    "name": "Implementation of Blake",
     "id": "DS802000",
-    "description": "An implementation Blowfish",
+    "description": "An implementation Blake",
     "recommendation": "",
     "tags": [
-      "Cryptography.Implementation.Blowfish"
+      "Cryptography.Implementation.Hash.Blake"
     ],
     "severity": "important",
     "_comment": "",
-    "rule_info": "",
+    "rule_info": "https://en.wikipedia.org/wiki/BLAKE_(hash_function)",
     "patterns": [
       {
-        "pattern": "d1310ba6|487cac60|243f6a88|608135816",
+        "pattern": "243F6A88|243F6A8885A308D3|C1059ED8|CBBB9D5DC1059ED8|6A09E667F3BCC908",
         "type": "regex",
         "modifiers": [ "i" ],
         "scopes": [
           "code"
         ],
-        "_comment": "Blowfish Constants"
+        "_comment": ""
       }
     ]
   },
   {
-    "name": "Implementation of bcrypt-pbkdf",
+    "name": "Implementation of Blake2",
     "id": "DS802001",
-    "description": "An implementation bcrypt-pbkdf.",
+    "description": "An implementation Blake2",
     "recommendation": "",
     "tags": [
-      "Cryptography.Implementation.BCryptPBKDF"
+      "Cryptography.Implementation.Hash.Blake2"
     ],
     "severity": "important",
     "_comment": "",
-    "rule_info": "",
+    "rule_info": "https://en.wikipedia.org/wiki/BLAKE_(hash_function)#BLAKE2",
     "patterns": [
       {
-        "pattern": "99,\\s*66,\\s*108,\\s*111|OxychromaticBlowfishSwatDynamite",
+        "pattern": "6A09E667F3BCC908",
         "type": "regex",
         "modifiers": [ "i" ],
         "scopes": [
           "code"
         ],
-        "_comment": "Magic Constant for BCrypt-PBKDF"
+        "_comment": "IV is also used with SHA2-512."
+      }
+    ]
+  },
+  {
+    "name": "Implementation of Blake3",
+    "id": "DS802002",
+    "description": "An implementation Blake3",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.Hash.Blake3"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "https://en.wikipedia.org/wiki/BLAKE_(hash_function)#BLAKE3",
+    "patterns": [
+      {
+        "pattern": "12,\\s?13,\\s?9,\\s?11,\\s?15,\\s?10,\\s?14,\\s?8,\\s?7",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "Blake3 message schedule"
+      }
+    ]
+  },
+  {
+    "name": "Implementation of GOST",
+    "id": "DS802003",
+    "description": "An implementation GOST",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.Hash.GOST"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "https://en.wikipedia.org/wiki/GOST_(hash_function)",
+    "patterns": [
+      {
+        "pattern": "4,\\s?10,\\s?9,\\s?2,\\s?13,\\s?8,\\s?0,\\s?14,\\s?6,\\s?11,\\s?1,\\s?12,\\s?7,\\s?15,\\s?3",
+        "type": "regex",
+        "modifiers": [],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "sbox for GOST"
+      }
+    ]
+  },
+  {
+    "name": "Implementation of Grøstl",
+    "id": "DS802004",
+    "description": "An implementation Grøstl",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.Hash.Grøstl"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "http://www.groestl.info/implementations.html",
+    "patterns": [
+      {
+        "pattern": "0x63,\\s?0x7c,\\s?0x77,\\s?0x7b,\\s?0xf2,\\s?0x6b,\\s?0x6f,\\s?0xc5",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "Grøstl s-box"
+      }
+    ]
+  },
+  {
+    "name": "Implementation of HAS-160",
+    "id": "DS802005",
+    "description": "An implementation HAS-160",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.Hash.HAS-160"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "https://www.randombit.net/has160.html",
+    "patterns": [
+      {
+        "pattern": "5A827999|6ED9EBA1|8F1BBCDC",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "HAS-160 Initialization Vector"
+      }
+    ]
+  },
+  {
+    "name": "Implementation of HAVAL",
+    "id": "DS802006",
+    "description": "An implementation HAVAL",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.Hash.HAVAL"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "https://web.archive.org/web/20150111210116/http://labs.calyptix.com/haval.php",
+    "patterns": [
+      {
+        "pattern": "243F6A88|85A308D3|13198A2E|03707344",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "HAVAL Initialization Vector"
+      }
+    ]
+  },
+  {
+    "name": "Implementation of Kupyna",
+    "id": "DS802007",
+    "description": "An implementation Kupyna",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.Hash.Kupyna"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "https://github.com/Roman-Oliynykov/Kupyna-reference",
+    "patterns": [
+      {
+        "pattern": "0xa8,\\s?0x43,\\s?0x5f,\\s?0x06,\\s?0x6b,\\s?0x75,\\s?0x6c,\\s?0x59",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "Kupyna s-box"
+      }
+    ]
+  },
+  {
+    "name": "Implementation of JH",
+    "id": "DS802008",
+    "description": "An implementation JH",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.Hash.JH"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "https://www3.ntu.edu.sg/home/wuhj/research/jh/index.html",
+    "patterns": [
+      {
+        "pattern": "0x2d,\\s?0xfe,\\s?0xdd,\\s?0x62,\\s?0xf9,\\s?0x9a,\\s?0x98,\\s?0xac",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "Non-optimized 32-bit bit-slice reference implementation"
+      },
+      {
+        "pattern": "6[0x\\s,]{0,4}a[0x\\s,]{0,4}9[0x\\s,]{0,4}e[0x\\s,]{0,4}6[0x\\s,]{0,4}6[0x\\s,]{0,4}7[0x\\s,]{0,4}f[0x\\s,]{0,4}3",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "Optimized implementations"
+      }
+    ]
+  },
+  {
+    "name": "Implementation of MD2",
+    "id": "DS802009",
+    "description": "An implementation MD2",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.Hash.MD2"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "https://en.wikipedia.org/wiki/MD2_(hash_function)",
+    "patterns": [
+      {
+        "pattern": "0x29,\\s?0x2e,\\s?0x42,\\s?0xc9,\\s?0xa2,\\s?0xd8,\\s?0x7c,\\s?0x01",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "MD2 s-box (hex)"
+      },
+      {
+        "pattern": "41,\\s?46,\\s?67,\\s?201,\\s?162,\\s?216,\\s?124,\\s?1",
+        "type": "regex",
+        "modifiers": [],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "MD2 s-box (decimal), from https://github.com/B-Con/crypto-algorithms/blob/master/md2.c"
+      }
+    ]
+  },
+  {
+    "name": "Implementation of MD4 or SHA-1",
+    "id": "DS802010",
+    "description": "An implementation MD4 or SHA-1",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.Hash.MD4",
+      "Cryptography.Implementation.Hash.SHA-1"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "https://en.wikipedia.org/wiki/MD4_(hash_function)",
+    "patterns": [
+      {
+        "pattern": "6ed9eba1|5a827999",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "MD4 and SHA-1 constants"
+      }
+    ]
+  },
+  {
+    "name": "Implementation of MD5",
+    "id": "DS802011",
+    "description": "An implementation MD5",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.Hash.MD5"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "https://en.wikipedia.org/wiki/MD4_(hash_function)",
+    "patterns": [
+      {
+        "pattern": "d76aa478|e8c7b756|242070db|c1bdceee ",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "MD5 constants (hex)"
+      },
+      {
+        "pattern": "680876936|389564586|606105819|1044525330",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "MD5 constants (decimal)"
+      }
+    ]
+  },
+  {
+    "name": "Implementation of MD6",
+    "id": "DS802012",
+    "description": "An implementation MD6",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.Hash.MD6"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "https://en.wikipedia.org/wiki/MD5_(hash_function)",
+    "patterns": [
+      {
+        "pattern": "7311c281|2425cfa0",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "MD6 constants"
+      }
+    ]
+  },
+  {
+    "name": "Implementation of RIPEMD",
+    "id": "DS802013",
+    "description": "An implementation RIPEMD",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.Hash.RIPEMD"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "https://en.wikipedia.org/wiki/RIPEMD",
+    "patterns": [
+      {
+        "pattern": "7a6d76e9|5c4dd124",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "RIPEMD constants"
+      }
+    ]
+  },
+  {
+    "name": "Implementation of SHA-1",
+    "id": "DS802014",
+    "description": "An implementation SHA-1.",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.Hash.SHA-1"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "https://en.wikipedia.org/wiki/SHA-1",
+    "patterns": [
+      {
+        "pattern": "8F1BBCDC|5A827999|C3D2E1F0|3285377520",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "SHA-1 constants (hex)"
+      },
+      {
+        "pattern": "1732584193|271733879|1732584194|271733878",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "SHA-1 constants (decimal)"
       }
     ]
   },
   {
     "name": "Implementation of SHA-2",
-    "id": "DS802002",
+    "id": "DS802015",
     "description": "An implementation SHA-2.",
     "recommendation": "",
     "tags": [
-      "Cryptography.Implementation.SHA2"
+      "Cryptography.Implementation.Hash.SHA-2"
     ],
     "severity": "important",
     "_comment": "",
-    "rule_info": "",
+    "rule_info": "https://en.wikipedia.org/wiki/SHA-2",
     "patterns": [
       {
         "pattern": "c1059ed8|367cd507|914150663",
@@ -96,270 +432,170 @@
     ]
   },
   {
-    "name": "Implementation of SHA-1",
-    "id": "DS802003",
-    "description": "An implementation SHA-1.",
+    "name": "Implementation of SHA-3",
+    "id": "DS802016",
+    "description": "An implementation SHA-3.",
     "recommendation": "",
     "tags": [
-      "Cryptography.Implementation.SHA1"
+      "Cryptography.Implementation.Hash.SHA-3",
+      "Cryptography.Implementation.Hash.Keccak"
     ],
     "severity": "important",
     "_comment": "",
-    "rule_info": "",
+    "rule_info": "https://en.wikipedia.org/wiki/SHA-3",
     "patterns": [
       {
-        "pattern": "8F1BBCDC|5A827999|C3D2E1F0|3285377520",
+        "pattern": "8000000000008089|800000008000000A",
         "type": "regex",
         "modifiers": [ "i" ],
         "scopes": [
           "code"
         ],
-        "_comment": "Magic Constant for SHA-1"
+        "_comment": "SHA-3 constants"
       }
     ]
   },
   {
-    "name": "Implementation of MD5",
-    "id": "DS802004",
-    "description": "An implementation MD5",
+    "name": "Implementation of Skein",
+    "id": "DS802017",
+    "description": "An implementation Skein.",
     "recommendation": "",
     "tags": [
-      "Cryptography.Implementation.MD5"
+      "Cryptography.Implementation.Hash.Skein"
     ],
     "severity": "important",
     "_comment": "",
-    "rule_info": "",
+    "rule_info": "http://www.skein-hash.info/",
     "patterns": [
       {
-        "pattern": "d76aa478|4787c62a|680876936|1069501632|1236535329",
+        "pattern": "C6098A8C9AE5EA0B|FC9DA860D048B449|CCD0616248677224|CCD044A12FDB3E13|A3F6C6BF3A75EF5F|4903ADFF749C51CE",
         "type": "regex",
         "modifiers": [ "i" ],
         "scopes": [
           "code"
         ],
-        "_comment": "Magic Constant for MD5"
+        "_comment": "Skein initialization vectors"
       }
     ]
   },
   {
-    "name": "Implementation of RIPEMD",
-    "id": "DS802005",
-    "description": "An implementation RIPEMD",
+    "name": "Implementation of Snefru",
+    "id": "DS802018",
+    "description": "An implementation Snefru.",
     "recommendation": "",
     "tags": [
-      "Cryptography.Implementation.RIPEMD"
+      "Cryptography.Implementation.Hash.Snefru"
     ],
     "severity": "important",
     "_comment": "",
-    "rule_info": "",
+    "rule_info": "https://en.wikipedia.org/wiki/Snefru",
     "patterns": [
       {
-        "pattern": "A953FD4E|2840853838",
+        "pattern": "64f9001b|feddcdf6|7c8ff1e2|11d71514",
         "type": "regex",
         "modifiers": [ "i" ],
         "scopes": [
           "code"
         ],
-        "_comment": "Magic Constant for RIPEMD"
+        "_comment": "Snefru initialization vectors"
       }
     ]
   },
   {
-    "name": "Implementation of HMAC",
-    "id": "DS802006",
-    "description": "An implementation HMAC",
+    "name": "Implementation of Spectral Hash",
+    "id": "DS802019",
+    "description": "An implementation Spectral Hash.",
     "recommendation": "",
     "tags": [
-      "Cryptography.Implementation.HMAC"
+      "Cryptography.Implementation.Hash.SpectralHash"
     ],
     "severity": "important",
     "_comment": "",
-    "rule_info": "",
+    "rule_info": "http://koclab.org/shash/index.html",
     "patterns": [
       {
-        "pattern": "\\^.*(5c5c5c5c|36363636|909522486)",
+        "pattern": "7,\\s?0,\\s?8,\\s?2,\\s?12,\\s?4,\\s?13,\\s?11,\\s?10,\\s?3,\\s?14,\\s?15,\\s?6,\\s?1,\\s?5,\\s?9",
         "type": "regex",
         "modifiers": [ "i" ],
         "scopes": [
           "code"
         ],
-        "_comment": "Magic Constant for HMAC"
+        "_comment": "Spectral Hash initialization vectors"
       }
     ]
   },
   {
-    "name": "Implementation of BCrypt",
-    "id": "DS802007",
-    "description": "An implementation BCrypt",
+    "name": "Implementation of Streebog",
+    "id": "DS802020",
+    "description": "An implementation Streebog.",
     "recommendation": "",
     "tags": [
-      "Cryptography.Implementation.BCrypt"
+      "Cryptography.Implementation.Hash.Streebog"
     ],
     "severity": "important",
-    "_comment": "",
-    "rule_info": "",
+    "_comment": "GOST R 34.11-2012",
+    "rule_info": "https://tools.ietf.org/html/rfc6986",
     "patterns": [
       {
-        "pattern": "OrpheanBeholderScryDoubt",
-        "type": "regex",
-        "modifiers": [ "i" ],
-        "scopes": [
-          "all"
-        ],
-        "_comment": "Magic Constant for BCrypt"
-      },
-      {
-        "pattern": "4f.{1,10}72.{1,10}70.{1,10}68",
+        "pattern": "46b60f011a83988e|3435363738393031|dd806559f2a64507|0745a6f2596580dd",
         "type": "regex",
         "modifiers": [ "i" ],
         "scopes": [
           "code"
         ],
-        "_comment": "Magic Constant for BCrypt"
+        "_comment": "Streebog constants"
       }
     ]
   },
   {
-    "name": "Implementation of Blake2b",
-    "id": "DS802007",
-    "description": "An implementation Blake2b",
+    "name": "Implementation of Tiger",
+    "id": "DS802021",
+    "description": "An implementation Tiger.",
     "recommendation": "",
     "tags": [
-      "Cryptography.Implementation.Blake2b"
+      "Cryptography.Implementation.Hash.Tiger"
     ],
     "severity": "important",
     "_comment": "",
-    "rule_info": "",
+    "rule_info": "https://www.cs.technion.ac.il/~biham/Reports/Tiger/",
     "patterns": [
       {
-        "pattern": "ae8584c|10e527fade6",
+        "pattern": "F096A5B4C3B2E187",
         "type": "regex",
         "modifiers": [ "i" ],
         "scopes": [
-          "all"
+          "code"
         ],
-        "_comment": "Magic Constant for Blake2b"
-      }
-    ]
-  },
-  {
-    "name": "Implementation of MD2",
-    "id": "DS802007",
-    "description": "An implementation MD2",
-    "recommendation": "",
-    "tags": [
-      "Cryptography.Implementation.MD2"
-    ],
-    "severity": "important",
-    "_comment": "",
-    "rule_info": "",
-    "patterns": [
-      {
-        "pattern": "29.{0,10}2e.{0,10}43.{0,10}c9.{0,10}a2.{0,10}d8",
-        "type": "regex",
-        "modifiers": [ "i" ],
-        "scopes": [
-          "all"
-        ],
-        "_comment": "Magic Constant for MD2"
-      }
-    ]
-  },
-  {
-    "name": "Implementation of MD4",
-    "id": "DS802008",
-    "description": "An implementation MD4",
-    "recommendation": "",
-    "tags": [
-      "Cryptography.Implementation.MD4"
-    ],
-    "severity": "important",
-    "_comment": "",
-    "rule_info": "",
-    "patterns": [
-      {
-        "pattern": "67452301|6ED9EBA1|1732584193",
-        "type": "regex",
-        "modifiers": [ "i" ],
-        "scopes": [
-          "all"
-        ],
-        "_comment": "Magic Constant for MD4"
+        "_comment": "Tiger constants"
       }
     ]
   },
   {
     "name": "Implementation of Whirlpool",
-    "id": "DS802009",
+    "id": "DS802022",
     "description": "An implementation Whirlpool",
     "recommendation": "",
     "tags": [
-      "Cryptography.Implementation.Whirlpool"
+      "Cryptography.Implementation.Hash.Whirlpool"
     ],
     "severity": "important",
     "_comment": "",
-    "rule_info": "",
+    "rule_info": "https://en.wikipedia.org/wiki/Whirlpool_(hash_function)",
     "patterns": [
       {
-        "pattern": "18.{0,10}18.{0,10}60.{0,10}18.{0,10}c0.{0,10}78.{0,10}30",
+        "pattern": "1823c6e887b8014f|36a6d2f5796f9152",
         "type": "regex",
         "modifiers": [ "i" ],
         "scopes": [
-          "all"
+          "code"
         ],
         "_comment": "Magic Constant for Whirlpool"
       }
     ]
   },
   {
-    "name": "Implementation of SM3",
-    "id": "DS802010",
-    "description": "An implementation SM3",
-    "recommendation": "",
-    "tags": [
-      "Cryptography.Implementation.SM3"
-    ],
-    "severity": "important",
-    "_comment": "",
-    "rule_info": "",
-    "patterns": [
-      {
-        "pattern": "79CC4519|7311465E|11465E73|2043430169",
-        "type": "regex",
-        "modifiers": [ "i" ],
-        "scopes": [
-          "all"
-        ],
-        "_comment": "Magic Constant for SM3"
-      }
-    ]
-  },
-  {
-    "name": "Implementation of SM4",
-    "id": "DS802011",
-    "description": "An implementation SM4",
-    "recommendation": "",
-    "tags": [
-      "Cryptography.Implementation.SM4"
-    ],
-    "severity": "important",
-    "_comment": "",
-    "rule_info": "",
-    "patterns": [
-      {
-        "pattern": "d6.{0,10}90.{0,10}e9.{0,10}fe.{0,10}cc.{0,10}e1.{0,10}3d",
-        "type": "regex",
-        "modifiers": [ "i" ],
-        "scopes": [
-          "all"
-        ],
-        "_comment": "Magic Constant for SM4"
-      }
-    ]
-  },
-  {
     "name": "Implementation of Siphash",
-    "id": "DS802011",
+    "id": "DS802023",
     "description": "An implementation Siphash",
     "recommendation": "",
     "tags": [
@@ -367,16 +603,95 @@
     ],
     "severity": "important",
     "_comment": "",
-    "rule_info": "",
+    "rule_info": "https://en.wikipedia.org/wiki/SipHash",
     "patterns": [
       {
-        "pattern": "736f6d6570736575|6c7967656e657261|8317987319222330741",
+        "pattern": "736f6d6570736575|646f72616e646f6d|6c7967656e657261|7465646279746573",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "Magic Constant for Siphash"
+      }
+    ]
+  },
+  {
+    "name": "Implementation of SM3",
+    "id": "DS802024",
+    "description": "An implementation SM3",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.SM3"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "https://en.wikipedia.org/wiki/SM3_(hash_function)",
+    "patterns": [
+      {
+        "pattern": "79CC4519|7A879D8A|7311465E|7380166F|4914B2B9",
         "type": "regex",
         "modifiers": [ "i" ],
         "scopes": [
           "all"
         ],
-        "_comment": "Magic Constant for Siphash"
+        "_comment": "SM3 constants"
+      }
+    ]
+  },
+  {
+    "name": "Implementation of bcrypt-pbkdf",
+    "id": "DS802025",
+    "description": "An implementation bcrypt-pbkdf.",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.BCryptPBKDF"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "",
+    "patterns": [
+      {
+        "pattern": "(99,\\s?66,\\s?108,\\s?111,\\s?119,\\s?102,\\s?105,\\s?115)|OxychromaticBlowfishSwatDynamite",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "Magic Constant for BCrypt-PBKDF"
+      }
+    ]
+  },
+
+
+    "name": "Implementation of BCrypt",
+    "id": "DS802026",
+    "description": "An implementation BCrypt",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.BCrypt"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "https://en.wikipedia.org/wiki/Bcrypt",
+    "patterns": [
+      {
+        "pattern": "OrpheanBeholderScryDoubt",
+        "type": "string",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "all"
+        ],
+        "_comment": "Magic Constant for BCrypt"
+      },
+      {
+        "pattern": "0x4f,\\s?0x72,\\s?0x70,\\s?0x68",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "Magic Constant for BCrypt"
       }
     ]
   }

--- a/src/oss-detect-cryptography/Resources/CryptographyRules/implementation-hash.json
+++ b/src/oss-detect-cryptography/Resources/CryptographyRules/implementation-hash.json
@@ -1,0 +1,383 @@
+[
+  {
+    "name": "Implementation of Blowfish",
+    "id": "DS802000",
+    "description": "An implementation Blowfish",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.Blowfish"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "",
+    "patterns": [
+      {
+        "pattern": "d1310ba6|487cac60|243f6a88|608135816",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "Blowfish Constants"
+      }
+    ]
+  },
+  {
+    "name": "Implementation of bcrypt-pbkdf",
+    "id": "DS802001",
+    "description": "An implementation bcrypt-pbkdf.",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.BCryptPBKDF"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "",
+    "patterns": [
+      {
+        "pattern": "99,\\s*66,\\s*108,\\s*111|OxychromaticBlowfishSwatDynamite",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "Magic Constant for BCrypt-PBKDF"
+      }
+    ]
+  },
+  {
+    "name": "Implementation of SHA-2",
+    "id": "DS802002",
+    "description": "An implementation SHA-2.",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.SHA2"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "",
+    "patterns": [
+      {
+        "pattern": "c1059ed8|367cd507|914150663",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "Magic Constant for SHA-224"
+      },
+      {
+        "pattern": "53380d13|5cb0a9dc|1555081692",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "Magic Constant for SHA-256"
+      },
+      {
+        "pattern": "9159015a|f70e5939|4144912697",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "Magic Constant for SHA-384"
+      },
+      {
+        "pattern": "428A2F98|D728AE22|CBBB9D5D|FC2BF72C|8C3D37C8|6A09E667|1779033703",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "Magic Constant for SHA-512"
+      }
+    ]
+  },
+  {
+    "name": "Implementation of SHA-1",
+    "id": "DS802003",
+    "description": "An implementation SHA-1.",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.SHA1"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "",
+    "patterns": [
+      {
+        "pattern": "8F1BBCDC|5A827999|C3D2E1F0|3285377520",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "Magic Constant for SHA-1"
+      }
+    ]
+  },
+  {
+    "name": "Implementation of MD5",
+    "id": "DS802004",
+    "description": "An implementation MD5",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.MD5"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "",
+    "patterns": [
+      {
+        "pattern": "d76aa478|4787c62a|680876936|1069501632|1236535329",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "Magic Constant for MD5"
+      }
+    ]
+  },
+  {
+    "name": "Implementation of RIPEMD",
+    "id": "DS802005",
+    "description": "An implementation RIPEMD",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.RIPEMD"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "",
+    "patterns": [
+      {
+        "pattern": "A953FD4E|2840853838",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "Magic Constant for RIPEMD"
+      }
+    ]
+  },
+  {
+    "name": "Implementation of HMAC",
+    "id": "DS802006",
+    "description": "An implementation HMAC",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.HMAC"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "",
+    "patterns": [
+      {
+        "pattern": "\\^.*(5c5c5c5c|36363636|909522486)",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "Magic Constant for HMAC"
+      }
+    ]
+  },
+  {
+    "name": "Implementation of BCrypt",
+    "id": "DS802007",
+    "description": "An implementation BCrypt",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.BCrypt"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "",
+    "patterns": [
+      {
+        "pattern": "OrpheanBeholderScryDoubt",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "all"
+        ],
+        "_comment": "Magic Constant for BCrypt"
+      },
+      {
+        "pattern": "4f.{1,10}72.{1,10}70.{1,10}68",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "Magic Constant for BCrypt"
+      }
+    ]
+  },
+  {
+    "name": "Implementation of Blake2b",
+    "id": "DS802007",
+    "description": "An implementation Blake2b",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.Blake2b"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "",
+    "patterns": [
+      {
+        "pattern": "ae8584c|10e527fade6",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "all"
+        ],
+        "_comment": "Magic Constant for Blake2b"
+      }
+    ]
+  },
+  {
+    "name": "Implementation of MD2",
+    "id": "DS802007",
+    "description": "An implementation MD2",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.MD2"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "",
+    "patterns": [
+      {
+        "pattern": "29.{0,10}2e.{0,10}43.{0,10}c9.{0,10}a2.{0,10}d8",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "all"
+        ],
+        "_comment": "Magic Constant for MD2"
+      }
+    ]
+  },
+  {
+    "name": "Implementation of MD4",
+    "id": "DS802008",
+    "description": "An implementation MD4",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.MD4"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "",
+    "patterns": [
+      {
+        "pattern": "67452301|6ED9EBA1|1732584193",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "all"
+        ],
+        "_comment": "Magic Constant for MD4"
+      }
+    ]
+  },
+  {
+    "name": "Implementation of Whirlpool",
+    "id": "DS802009",
+    "description": "An implementation Whirlpool",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.Whirlpool"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "",
+    "patterns": [
+      {
+        "pattern": "18.{0,10}18.{0,10}60.{0,10}18.{0,10}c0.{0,10}78.{0,10}30",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "all"
+        ],
+        "_comment": "Magic Constant for Whirlpool"
+      }
+    ]
+  },
+  {
+    "name": "Implementation of SM3",
+    "id": "DS802010",
+    "description": "An implementation SM3",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.SM3"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "",
+    "patterns": [
+      {
+        "pattern": "79CC4519|7311465E|11465E73|2043430169",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "all"
+        ],
+        "_comment": "Magic Constant for SM3"
+      }
+    ]
+  },
+  {
+    "name": "Implementation of SM4",
+    "id": "DS802011",
+    "description": "An implementation SM4",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.SM4"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "",
+    "patterns": [
+      {
+        "pattern": "d6.{0,10}90.{0,10}e9.{0,10}fe.{0,10}cc.{0,10}e1.{0,10}3d",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "all"
+        ],
+        "_comment": "Magic Constant for SM4"
+      }
+    ]
+  },
+  {
+    "name": "Implementation of Siphash",
+    "id": "DS802011",
+    "description": "An implementation Siphash",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.Siphash"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "",
+    "patterns": [
+      {
+        "pattern": "736f6d6570736575|6c7967656e657261|8317987319222330741",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "all"
+        ],
+        "_comment": "Magic Constant for Siphash"
+      }
+    ]
+  }
+]

--- a/src/oss-detect-cryptography/Resources/CryptographyRules/implementation-prng.json
+++ b/src/oss-detect-cryptography/Resources/CryptographyRules/implementation-prng.json
@@ -1,0 +1,89 @@
+[
+  {
+    "name": "Use of random.org",
+    "id": "DS802020",
+    "description": "Use of random.org",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.PRNG.RandomOrg"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "",
+    "patterns": [
+      {
+        "pattern": "api.random.org",
+        "type": "string",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "Random.org API"
+      }
+    ]
+  },
+  {
+    "name": "LCG-looking construct",
+    "id": "DS802021",
+    "description": "LCG-looking construct",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.PRNG.LCG"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "",
+    "patterns": [
+      {
+        "pattern": "=.{0,10}\\S+\\s{0,10}\\*\\s{0,10}\\S+\\s{0,10}\\+\\s{0,10}\\S+\\s{0,10}\\)\\s{0,10}\\%\\s{0,10}\\S{1,10}",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "x = (a * b + c) % d"
+      },
+      {
+        "pattern": "=.{0,10}\\S+\\s{0,10}\\*\\s{0,10}\\S+\\s{0,10}\\)\\s{0,10}\\%\\s{0,10}\\S{1,10}",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "x = (a * b) % d"
+      },
+      {
+        "pattern": "1013904223|18851643",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "https://github.com/francoislaberge/arbitrary/blob/master/src/Generator.js"
+      }
+    ]
+  },
+  {
+    "name": "LCG-looking construct",
+    "id": "DS802022",
+    "description": "LCG-looking construct",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.PRNG.LCG"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "",
+    "patterns": [
+      {
+        "pattern": "1013904223|18851643",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "https://github.com/francoislaberge/arbitrary/blob/master/src/Generator.js"
+      }
+    ]
+  }
+]

--- a/src/oss-detect-cryptography/Resources/CryptographyRules/implementation-signature.json
+++ b/src/oss-detect-cryptography/Resources/CryptographyRules/implementation-signature.json
@@ -1,0 +1,25 @@
+[
+  {
+    "name": "Implementation of Ed25519",
+    "id": "DS802300",
+    "description": "Implementation of Ed25519",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.Ed25519"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "",
+    "patterns": [
+      {
+        "pattern": "78a3.{0,10}1359.{0,10}4dca",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "Ed25519 D variable"
+      }
+    ]
+  }
+]

--- a/src/oss-detect-cryptography/Resources/CryptographyRules/implementation-symmetric.json
+++ b/src/oss-detect-cryptography/Resources/CryptographyRules/implementation-symmetric.json
@@ -74,7 +74,7 @@
     "description": "ChaCha",
     "recommendation": "",
     "tags": [
-      "Cryptography.Implementation.DES"
+      "Cryptography.Implementation.ChaCha"
     ],
     "severity": "important",
     "_comment": "",
@@ -87,7 +87,7 @@
         "scopes": [
           "code"
         ],
-        "_comment": "ChaCha "
+        "_comment": "ChaCha"
       }
     ]
   }

--- a/src/oss-detect-cryptography/Resources/CryptographyRules/implementation-symmetric.json
+++ b/src/oss-detect-cryptography/Resources/CryptographyRules/implementation-symmetric.json
@@ -1,0 +1,94 @@
+[
+  {
+    "name": "Implementation of AES",
+    "id": "DS802040",
+    "description": "An implementation AES.",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.AES"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "",
+    "patterns": [
+      {
+        "pattern": "c66363a5|0x51f4a750|3f23312a",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "Magic constant for AES"
+      }
+    ]
+  },
+  {
+    "name": "Skip32",
+    "id": "DS802041",
+    "description": "Skip32",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.PRNG.Skip32"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "",
+    "patterns": [
+      {
+        "pattern": "a3.{0,10}d7.{0,10}09.{0,10}83.{0,10}f8.{0,10}48.{0,10}f6",
+        "type": "regex",
+        "modifiers": [ "i" ],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "https://wiki.postgresql.org/wiki/Skip32_(crypt_32_bits)"
+      }
+    ]
+  },
+  {
+    "name": "DES",
+    "id": "DS802042",
+    "description": "DES",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.DES"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "",
+    "patterns": [
+      {
+        "pattern": "14,.{0,3}4,.{0,3}13,.{0,3}1,.{0,3}2,.{0,3}15",
+        "type": "regex",
+        "modifiers": [],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "DES S1 structure"
+      }
+    ]
+  },
+  {
+    "name": "ChaCha",
+    "id": "DS802043",
+    "description": "ChaCha",
+    "recommendation": "",
+    "tags": [
+      "Cryptography.Implementation.DES"
+    ],
+    "severity": "important",
+    "_comment": "",
+    "rule_info": "",
+    "patterns": [
+      {
+        "pattern": "61707865|6b206574",
+        "type": "regex",
+        "modifiers": [],
+        "scopes": [
+          "code"
+        ],
+        "_comment": "ChaCha "
+      }
+    ]
+  }
+]

--- a/src/oss-detect-cryptography/oss-detect-cryptography.csproj
+++ b/src/oss-detect-cryptography/oss-detect-cryptography.csproj
@@ -1,0 +1,58 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RootNamespace>Microsoft.CST.OpenSource</RootNamespace>
+    <Company>Microsoft Corporation</Company>
+    <Description>OSS Gadget - Cryptography Detector</Description>
+    <Authors>Michael Scovetta</Authors>
+    <RepositoryType>GitHub</RepositoryType>
+    <RepositoryUrl>https://github.com/Microsoft/OSSGadget</RepositoryUrl>
+    <StartupObject>Microsoft.CST.OpenSource.DetectCryptographyTool</StartupObject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="Resources\CryptographyRules\implementation-asymmetric.json" />
+    <None Remove="Resources\CryptographyRules\implementation-crypto-generic.json" />
+    <None Remove="Resources\CryptographyRules\implementation-hash.json" />
+    <None Remove="Resources\CryptographyRules\implementation-prng.json" />
+    <None Remove="Resources\CryptographyRules\implementation-signature.json" />
+    <None Remove="Resources\CryptographyRules\implementation-symmetric.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\CryptographyRules\implementation-signature.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Resources\CryptographyRules\implementation-symmetric.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Resources\CryptographyRules\implementation-asymmetric.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Resources\CryptographyRules\implementation-crypto-generic.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Resources\CryptographyRules\implementation-prng.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Resources\CryptographyRules\implementation-hash.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ELFSharp" Version="2.7.0" />
+    <PackageReference Include="ICSharpCode.Decompiler" Version="5.0.2.5153" />
+    <PackageReference Include="Microsoft.CST.DevSkim" Version="0.4.118" />
+    <PackageReference Include="PeNet" Version="2.0.0" />
+    <PackageReference Include="SharpDisasm" Version="1.1.11" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\oss-download\oss-download.csproj" />
+    <ProjectReference Include="..\Shared\Shared.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/oss-detect-cryptography/oss-detect-cryptography.csproj
+++ b/src/oss-detect-cryptography/oss-detect-cryptography.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <None Remove="Resources\CryptographyRules\implementation-asymmetric.json" />
+    <None Remove="Resources\CryptographyRules\implementation-block-cipher.json" />
     <None Remove="Resources\CryptographyRules\implementation-crypto-generic.json" />
     <None Remove="Resources\CryptographyRules\implementation-hash.json" />
     <None Remove="Resources\CryptographyRules\implementation-prng.json" />
@@ -22,6 +23,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="Resources\CryptographyRules\implementation-block-cipher.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </EmbeddedResource>
     <EmbeddedResource Include="Resources\CryptographyRules\implementation-signature.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>

--- a/src/oss-download/oss-download.csproj
+++ b/src/oss-download/oss-download.csproj
@@ -10,7 +10,6 @@
     <RepositoryType>GitHub</RepositoryType>
     <RepositoryUrl>https://github.com/Microsoft/OSSGadget</RepositoryUrl>
     <StartupObject>Microsoft.CST.OpenSource.DownloadTool</StartupObject>
-    <RuntimeIdentifiers>win10-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/tests/tests.csproj
+++ b/src/tests/tests.csproj
@@ -20,7 +20,6 @@
     <ProjectReference Include="..\oss-download\oss-download.csproj" />
     <ProjectReference Include="..\oss-find-source\oss-find-source.csproj" />
     <ProjectReference Include="..\oss-health\oss-health.csproj" />
-    <ProjectReference Include="..\oss-risk-calculator\oss-risk-calculator.csproj" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
This pull requests includes a basic tool for detecting cryptographic implementations, meaning, code that does the math behind the crypto, not code that just *uses* crypto. (For that, use oss-characteristic.)

It does this with a combination of pattern matching (magic strings), searching package metadata, and decompiling .NET and native binaries, in an attempt to find those same magic strings.

The tool also implements a PackageManager for Ubuntu, and adds support for .deb files to MultiExtractor.