### PR TITLE
Use ConcurrentStack instead of List for thread safety

### DIFF
--- a/src/MultiExtractor/FileEntry.cs
+++ b/src/MultiExtractor/FileEntry.cs
@@ -46,7 +46,10 @@ namespace Microsoft.CST.OpenSource.MultiExtractor
             if (passthroughStream && inputStream.CanSeek)
             {
                 Content = inputStream;
-                Content.Position = 0;
+                if (Content.Position != 0)
+                {
+                    Content.Position = 0;
+                }
             }
             else
             {
@@ -57,10 +60,13 @@ namespace Microsoft.CST.OpenSource.MultiExtractor
                 if (inputStream.CanSeek)
                 {
                     initialPosition = inputStream.Position;
-                    inputStream.Position = 0;
+                    if (inputStream.Position != 0)
+                    {
+                        inputStream.Position = 0;
+                    }
                 }
                 inputStream.CopyTo(Content);
-                if (inputStream.CanSeek)
+                if (inputStream.CanSeek && inputStream.Position != 0)
                 {
                     inputStream.Position = initialPosition ?? 0;
                 }

--- a/src/MultiExtractor/MiniMagic.cs
+++ b/src/MultiExtractor/MiniMagic.cs
@@ -221,7 +221,7 @@ namespace Microsoft.CST.OpenSource.MultiExtractor
             //https://www.microsoft.com/en-us/download/details.aspx?id=23850 - 'Hard Disk Footer Format'
             // Unlike other formats the magic string is stored in the footer, which is either the last 511 or 512 bytes
             // The magic string is Magic string "conectix" (63 6F 6E 65 63 74 69 78)
-            if (fileEntry.Content.Length > 510)
+            if (fileEntry.Content.Length > 512)
             {
                 Span<byte> vhdFooterCookie = stackalloc byte[] { 0x63, 0x6F, 0x6E, 0x65, 0x63, 0x74, 0x69, 0x78 };
 


### PR DESCRIPTION
Discovered an issue with this when creating new benchmarks for Application Inspector https://github.com/microsoft/ApplicationInspector/pull/215 and porting the fix to the official multi-extractor here.