### PR TITLE
Fix raw file extraction

### DIFF
--- a/src/RecursiveExtractor/RecursiveExtractor.Tests/ExtractorTests.cs
+++ b/src/RecursiveExtractor/RecursiveExtractor.Tests/ExtractorTests.cs
@@ -48,6 +48,8 @@ namespace Microsoft.CST.OpenSource.Tests
         [DataRow("Shared.wim", true)]
         [DataRow("Empty.vmdk", false, 0)]
         [DataRow("Empty.vmdk", true, 0)]
+        [DataRow("TextFile.md", false, 1)]
+        [DataRow("TextFile.md", true, 1)]
         public void ExtractArchive(string fileName, bool parallel, int expectedNumFiles = 26)
         {
             var extractor = new Extractor();
@@ -91,6 +93,8 @@ namespace Microsoft.CST.OpenSource.Tests
         [DataRow("Shared.wim", true)]
         [DataRow("Empty.vmdk", false, 0)]
         [DataRow("Empty.vmdk", true, 0)]
+        [DataRow("TextFile.md", false, 1)]
+        [DataRow("TextFile.md", true, 1)]
         public void ExtractArchiveFromStream(string fileName, bool parallel, int expectedNumFiles = 26)
         {
             var extractor = new Extractor();
@@ -130,6 +134,7 @@ namespace Microsoft.CST.OpenSource.Tests
         [DataRow("Shared.vhdx", ArchiveFileType.VHDX)]
         [DataRow("Shared.wim", ArchiveFileType.WIM)]
         [DataRow("Empty.vmdk", ArchiveFileType.VMDK)]
+        [DataRow("TextFile.md", ArchiveFileType.UNKNOWN)]
         public void TestMiniMagic(string fileName, ArchiveFileType expectedArchiveFileType)
         {
             var path = Path.Combine(Directory.GetCurrentDirectory(), "TestData", fileName);

--- a/src/RecursiveExtractor/RecursiveExtractor.Tests/RecursiveExtractor.Tests.csproj
+++ b/src/RecursiveExtractor/RecursiveExtractor.Tests/RecursiveExtractor.Tests.csproj
@@ -54,6 +54,9 @@
     <None Update="TestData\Nested.zip">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="TestData\TextFile.md">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="TestData\Shared.7z">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -114,9 +117,6 @@
     <None Update="TestData\zbxl.zip">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="TestData\" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Update="Nerdbank.GitVersioning" Version="3.1.91" />

--- a/src/RecursiveExtractor/RecursiveExtractor.Tests/TestData/TextFile.md
+++ b/src/RecursiveExtractor/RecursiveExtractor.Tests/TestData/TextFile.md
@@ -1,0 +1,57 @@
+﻿## RecursiveExtractor
+
+RecursiveExtractor is a general-purpose file extractor.
+
+### Format Support
+
+RecursiveExtractor supports extracting the following types of archives:
+
+* GNU AR
+* BZip2
+* [deb](https://en.wikipedia.org/wiki/Deb_(file_format))
+* ISO
+* tar
+* VHD
+* VHDX
+* VMDK
+* WIM
+* XZip
+* zip
+
+## Using RecursiveExtractor
+
+To use RecursiveExtractor, just instantiate an `Extractor` object and call the `ExtractFile`
+method with either a filename or a byte array. This method will return an IEnumerable
+of FileEntry objects, each one of which will contain the name of the file and its 
+contents, plus some additional metadata. 
+
+```
+using Microsoft.CST.RecursiveExtractor;
+
+...
+
+// Initialize the RecursiveExtractor extractor
+var extractor = new Extractor();
+
+// Extract from an existing file
+foreach (var fileEntry in extractor.ExtractFile("test.zip"))
+{
+    Console.WriteLine(fileEntry.FullPath);
+}
+
+// Extract from a byte array
+byte[] bytes = ...;
+// The "nonexistent.zip" name doesn't really matter, but is used as part of the
+// FileEntry.FullPath string.
+foreach (var fileEntry in extractor.ExtractFile("nonexistent.zip", bytes))
+{
+    Console.WriteLine(fileEntry.FullPath);
+}
+```
+
+## Issues
+
+If you find any issues with RecursiveExtractor, please [open an issue](https://github.com/Microsoft/OSSGadget/issues/new)
+in the [Microsoft/OSSGadget](https://github.com/Microsoft/OSSGadget) repository.
+
+

--- a/src/RecursiveExtractor/RecursiveExtractor/Extractor.cs
+++ b/src/RecursiveExtractor/RecursiveExtractor/Extractor.cs
@@ -639,7 +639,10 @@ namespace Microsoft.CST.OpenSource.RecursiveExtractor
             {
                 Logger.Debug(ex, "Error extracting {0}: {1}", fileEntry.FullPath, ex.Message);
                 useRaw = true;
-                result = new[] { fileEntry };   // Default is to not try to extract.
+
+                result = new[] {
+                    new FileEntry(fileEntry.Name,fileEntry.Content,fileEntry.Parent)
+                };
             }
 
             // After we are done with an archive subtract its bytes. Contents have been counted now separately

--- a/src/RecursiveExtractor/RecursiveExtractor/FileEntry.cs
+++ b/src/RecursiveExtractor/RecursiveExtractor/FileEntry.cs
@@ -89,11 +89,11 @@ namespace Microsoft.CST.OpenSource.RecursiveExtractor
             }
         }
 
-        public Stream Content { get; set; }
-        public string FullPath { get; set; }
-        public string Name { get; set; }
-        public FileEntry? Parent { get; set; }
-        public string? ParentPath { get; set; }
+        public Stream Content { get; }
+        public string FullPath { get; }
+        public string Name { get; }
+        public FileEntry? Parent { get; }
+        public string? ParentPath { get; }
         private readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
 
         ~FileEntry()


### PR DESCRIPTION
Copies the raw file into a new FileEntry not reusing original stream which we can't rely on.
Add single file extraction test