### PR TITLE
Fixes #155 (missing HttpClient init), GitHub find source regex #153, #156, .NET Core 5 merge.

### DIFF
--- a/src/Shared/PackageManagers/GitHubProjectManager.cs
+++ b/src/Shared/PackageManagers/GitHubProjectManager.cs
@@ -178,9 +178,9 @@ namespace Microsoft.CST.OpenSource.Shared
                     @"(?:(?<username>[\w-]+)@)*" +
                     @"(github\.com)" +
                     @"[:/]*" +
-                    @"(?<port>[\d]+){0,1}" +
-                    @"\/(?<user>[\w-]+)" +
-                    @"\/(?<repo>[\w-]+)\/?",
+                    @"(?<port>[\d]+)?" +
+                    @"/(?<user>[\w-\.]+)" +
+                    @"/(?<repo>[\w-\.]+)/?",
                         RegexOptions.Compiled);
 
         /// <summary>
@@ -191,10 +191,10 @@ namespace Microsoft.CST.OpenSource.Shared
             @"(?:(?<user>.+)@)*" +
             @"(?<resource>[a-z0-9_.-]*)" +
             @"[:/]*" +
-            @"(?<port>[\d]+){0,1}" +
-            @"(?<pathname>\/((?<namespace>[\w\-]+)\/)" +
-            @"(?<subpath>[\w\-]+\/)*" +
-            @"((?<name>[\w\-\.]+?)(\.git|\/)?)?)$",
+            @"(?<port>[\d]+)?" +
+            @"(?<pathname>\/((?<namespace>[\w\-\.]+)/)" +
+            @"(?<subpath>[\w\-]+/)*" +
+            @"((?<name>[\w\-\.]+?)(\.git|/)?)?)$",
                 RegexOptions.Singleline | RegexOptions.Compiled);
     }
 }

--- a/src/oss-characteristics/CharacteristicTool.cs
+++ b/src/oss-characteristics/CharacteristicTool.cs
@@ -84,6 +84,7 @@ namespace Microsoft.CST.OpenSource
                 SourcePath = directory,
                 IgnoreDefaultRules = options.DisableDefaultRules == true,
                 CustomRulesPath = options.CustomRuleDirectory,
+                
             };
 
             try

--- a/src/oss-tests/DetectCryptographyTests.cs
+++ b/src/oss-tests/DetectCryptographyTests.cs
@@ -11,6 +11,12 @@ namespace Microsoft.CST.OpenSource.Tests
     [TestClass]
     public class DetectCryptographyTests
     {
+        [ClassInitialize()]
+        public static void ClassInit(TestContext context)
+        {
+            CommonInitialization.Initialize();
+        }
+
         [DataTestMethod]
         [DataRow("pkg:npm/blake2", "Cryptography.Implementation.Hash.Blake", "Cryptography.Implementation.Hash.Blake2", "Cryptography.Implementation.Hash.JH", "Cryptography.Implementation.Hash.SHA-512")]
         [DataRow("pkg:npm/blake3", "Cryptography.Implementation.Hash.Blake3", "Cryptography.Implementation.Hash.SHA-512")]

--- a/src/oss-tests/DownloadTests.cs
+++ b/src/oss-tests/DownloadTests.cs
@@ -13,6 +13,12 @@ namespace Microsoft.CST.OpenSource.Tests
     [TestClass]
     public class DownloadTests
     {
+        [ClassInitialize()]
+        public static void ClassInit(TestContext context)
+        {
+            CommonInitialization.Initialize();
+        }
+
         [DataTestMethod]
         [DataRow("pkg:cargo/rand@0.7.3", "CARGO.toml", 1)]
         [DataRow("pkg:cargo/rand", "CARGO.toml", 1)]

--- a/src/oss-tests/DownloadTests.cs
+++ b/src/oss-tests/DownloadTests.cs
@@ -113,6 +113,7 @@ namespace Microsoft.CST.OpenSource.Tests
 
         [DataTestMethod]
         [DataRow("pkg:nuget/RandomType@2.0.0", "RandomType.nuspec", 1)]
+        [DataRow("pkg:nuget/d3.TypeScript.DefinitelyTyped", "d3.TypeScript.DefinitelyTyped.nuspec", 1)]
         public async Task NuGet_Download_Version_Succeeds(string purl, string targetFilename, int expectedCount)
         {
             await TestDownload(purl, targetFilename, expectedCount);

--- a/src/oss-tests/FindSourceTests.cs
+++ b/src/oss-tests/FindSourceTests.cs
@@ -13,6 +13,12 @@ namespace Microsoft.CST.OpenSource.Tests
     [TestClass]
     public class FindSourceTests
     {
+        [ClassInitialize()]
+        public static void ClassInit(TestContext context)
+        {
+            CommonInitialization.Initialize();
+        }
+
         [DataTestMethod]
         [DataRow("pkg:npm/md5", "https://github.com/pvorb/node-md5")]
         public async Task Check_Sarif(string purl, string targetResult)

--- a/src/oss-tests/VersionTests.cs
+++ b/src/oss-tests/VersionTests.cs
@@ -11,6 +11,12 @@ namespace Microsoft.CST.OpenSource.Tests
     [TestClass]
     public class VersionTests
     {
+        [ClassInitialize()]
+        public static void ClassInit(TestContext context)
+        {
+            CommonInitialization.Initialize();
+        }
+
         [DataTestMethod]
         [DataRow("0.1,0.2,0.3", "0.1,0.2,0.3")]
         [DataRow("0.1,0.3,0.2", "0.1,0.2,0.3")]


### PR DESCRIPTION
This PR adds initialization to each of the test classes so that the HttpClient will be initialized before use.

It also improves the regular expression used to extract GitHub URLs, which was referenced in #153.