### PR TITLE
Add OSS Metadata Tool

### DIFF
--- a/src/OSSGadget.sln
+++ b/src/OSSGadget.sln
@@ -28,6 +28,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "oss-risk-calculator", "oss-
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "oss-tests", "oss-tests\oss-tests.csproj", "{812DF4A5-057B-4227-A3E8-4DFF67DBE07A}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "oss-metadata", "oss-metadata\oss-metadata.csproj", "{7E9A489A-B502-4622-A34C-EF507E18DFEB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -73,6 +75,10 @@ Global
 		{812DF4A5-057B-4227-A3E8-4DFF67DBE07A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{812DF4A5-057B-4227-A3E8-4DFF67DBE07A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{812DF4A5-057B-4227-A3E8-4DFF67DBE07A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7E9A489A-B502-4622-A34C-EF507E18DFEB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7E9A489A-B502-4622-A34C-EF507E18DFEB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7E9A489A-B502-4622-A34C-EF507E18DFEB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7E9A489A-B502-4622-A34C-EF507E18DFEB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Shared/Model/PackageMetadata.cs
+++ b/src/Shared/Model/PackageMetadata.cs
@@ -1,0 +1,117 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace Microsoft.CST.OpenSource.Model
+{
+    public class License
+    {
+        [JsonProperty(PropertyName = "spix_id")]
+        public string? SPIX_ID { get; set; }
+
+        [JsonProperty(PropertyName = "type")]
+        public string? Type { get; set; }
+
+        [JsonProperty(PropertyName = "url")]
+        public string? Url { get; set; }
+    }
+
+    public class PackageMetadata
+    {
+        public PackageMetadata()
+        {
+            AllVersions = new List<Version>();
+            Maintainers = new List<User>();
+            Authors = new List<User>();
+            Repository = new List<Repository>();
+            Keywords = new List<string>();
+            Licenses = new List<License>();
+        }
+
+        [JsonProperty(PropertyName = "all_versions")]
+        public List<Version> AllVersions { get; set; }
+
+        [JsonProperty(PropertyName = "authors")]
+        public List<User> Authors { get; set; }
+
+        [JsonProperty(PropertyName = "description")]
+        public string? Description { get; set; }
+
+        [JsonProperty(PropertyName = "keywords")]
+        public List<string> Keywords { get; set; }
+
+        [JsonProperty(PropertyName = "language")]
+        public string? Language { get; set; }
+
+        [JsonProperty(PropertyName = "latest_package_version")]
+        public string? LatestPackageVersion { get; set; }
+
+        [JsonProperty(PropertyName = "licenses")]
+        public List<License> Licenses { get; set; }
+
+        [JsonProperty(PropertyName = "maintainers")]
+        public List<User> Maintainers { get; set; }
+
+        [JsonProperty(PropertyName = "name")]
+        public string? Name { get; set; }
+
+        [JsonProperty(PropertyName = "package_uri")]
+        public string? Package_Uri { get; set; }
+
+        [JsonProperty(PropertyName = "package_manager_uri")]
+        public string? PackageManagerUri { get; set; }
+
+        [JsonProperty(PropertyName = "package_version")]
+        public string? PackageVersion { get; set; }
+
+        [JsonProperty(PropertyName = "platform")]
+        public string? Platform { get; set; }
+
+        [JsonProperty(PropertyName = "repository")]
+        public List<Repository> Repository { get; set; }
+
+        [JsonProperty(PropertyName = "version_download_uri")]
+        public string? VersionDownloadUri { get; set; }
+
+        [JsonProperty(PropertyName = "version_uri")]
+        public string? VersionUri { get; set; }
+
+        // construct the json format for the metadata
+        public override string ToString()
+        {
+            return JsonConvert.SerializeObject(this);
+        }
+    }
+
+    public class Repository
+    {
+        [JsonProperty(PropertyName = "rank")]
+        public double Rank { get; set; }
+
+        [JsonProperty(PropertyName = "type")]
+        public string? Type { get; set; }
+
+        [JsonProperty(PropertyName = "url")]
+        public string? Uri { get; set; }
+    }
+
+    public class User
+    {
+        [JsonProperty(PropertyName = "email")]
+        public string? Email { get; set; }
+
+        [JsonProperty(PropertyName = "name")]
+        public string? Name { get; set; }
+
+        [JsonProperty(PropertyName = "url")]
+        public string? Url { get; set; }
+    }
+
+    public class Version
+    {
+        [JsonProperty(PropertyName = "index")]
+        public int Index { get; set; }
+
+        [JsonProperty(PropertyName = "version")]
+        public string? VersionString { get; set; }
+    }
+}

--- a/src/Shared/Model/PackageMetadata.cs
+++ b/src/Shared/Model/PackageMetadata.cs
@@ -1,117 +1,143 @@
 ﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.CST.OpenSource.Model
 {
+    public class Downloads
+    {
+        [JsonProperty(PropertyName = "daily", NullValueHandling = NullValueHandling.Ignore)]
+        public int? Daily { get; set; }
+
+        [JsonProperty(PropertyName = "monthly", NullValueHandling = NullValueHandling.Ignore)]
+        public int? Monthly { get; set; }
+
+        [JsonProperty(PropertyName = "overall", NullValueHandling = NullValueHandling.Ignore)]
+        public int? Overall { get; set; }
+
+        [JsonProperty(PropertyName = "weekly", NullValueHandling = NullValueHandling.Ignore)]
+        public int? Weekly { get; set; }
+
+        [JsonProperty(PropertyName = "yearly", NullValueHandling = NullValueHandling.Ignore)]
+        public int? Yearly { get; set; }
+    }
+
     public class License
     {
-        [JsonProperty(PropertyName = "spix_id")]
+        [JsonProperty(PropertyName = "type", NullValueHandling = NullValueHandling.Ignore)]
+        public string? Name { get; set; }
+
+        [JsonProperty(PropertyName = "spix_id", NullValueHandling = NullValueHandling.Ignore)]
         public string? SPIX_ID { get; set; }
 
-        [JsonProperty(PropertyName = "type")]
-        public string? Type { get; set; }
-
-        [JsonProperty(PropertyName = "url")]
+        [JsonProperty(PropertyName = "url", NullValueHandling = NullValueHandling.Ignore)]
         public string? Url { get; set; }
+    }
+
+    /// <summary>
+    ///     this class enables placeholders for data stored in other places. This can be local file, blob,
+    ///     gist, or any other place where data can be stored
+    /// </summary>
+    public class LinkedData
+    {
+        // name of the tool (in case of analysis tools), name of the repo (in case of repository) etc the tool
+        // storing this information will know what to do with it
+        [JsonProperty(PropertyName = "name", NullValueHandling = NullValueHandling.Ignore)]
+        public string? Name { get; set; }
+
+        // type of pointer - blob/gist/file/...
+        [JsonProperty(PropertyName = "pointer_type", NullValueHandling = NullValueHandling.Ignore)]
+        public string? PointerType { get; set; }
+
+        [JsonProperty(PropertyName = "pointer_link", NullValueHandling = NullValueHandling.Ignore)]
+        public string? Rank { get; set; }
     }
 
     public class PackageMetadata
     {
-        public PackageMetadata()
-        {
-            AllVersions = new List<Version>();
-            Maintainers = new List<User>();
-            Authors = new List<User>();
-            Repository = new List<Repository>();
-            Keywords = new List<string>();
-            Licenses = new List<License>();
-        }
-
-        [JsonProperty(PropertyName = "all_versions")]
-        public List<Version> AllVersions { get; set; }
-
-        [JsonProperty(PropertyName = "authors")]
-        public List<User> Authors { get; set; }
-
-        [JsonProperty(PropertyName = "description")]
-        public string? Description { get; set; }
-
-        [JsonProperty(PropertyName = "keywords")]
-        public List<string> Keywords { get; set; }
-
-        [JsonProperty(PropertyName = "language")]
-        public string? Language { get; set; }
-
-        [JsonProperty(PropertyName = "latest_package_version")]
-        public string? LatestPackageVersion { get; set; }
-
-        [JsonProperty(PropertyName = "licenses")]
-        public List<License> Licenses { get; set; }
-
-        [JsonProperty(PropertyName = "maintainers")]
-        public List<User> Maintainers { get; set; }
-
-        [JsonProperty(PropertyName = "name")]
+        [JsonProperty(PropertyName = "name", NullValueHandling = NullValueHandling.Ignore)]
         public string? Name { get; set; }
 
-        [JsonProperty(PropertyName = "package_uri")]
+        [JsonProperty(PropertyName = "description", NullValueHandling = NullValueHandling.Ignore)]
+        public string? Description { get; set; }
+
+        [JsonProperty(PropertyName = "all_versions", NullValueHandling = NullValueHandling.Ignore)]
+        public List<Version>? AllVersions { get; set; }
+
+        [JsonProperty(PropertyName = "authors", NullValueHandling = NullValueHandling.Ignore)]
+        public List<User>? Authors { get; set; }
+
+        [JsonProperty(PropertyName = "keywords", NullValueHandling = NullValueHandling.Ignore)]
+        public List<string>? Keywords { get; set; }
+
+        [JsonProperty(PropertyName = "language", NullValueHandling = NullValueHandling.Ignore)]
+        public string? Language { get; set; }
+
+        [JsonProperty(PropertyName = "latest_package_version", NullValueHandling = NullValueHandling.Ignore)]
+        public string? LatestPackageVersion { get; set; }
+
+        [JsonProperty(PropertyName = "licenses", NullValueHandling = NullValueHandling.Ignore)]
+        public List<License>? Licenses { get; set; }
+
+        [JsonProperty(PropertyName = "maintainers", NullValueHandling = NullValueHandling.Ignore)]
+        public List<User>? Maintainers { get; set; }
+
+        [JsonProperty(PropertyName = "package_uri", NullValueHandling = NullValueHandling.Ignore)]
         public string? Package_Uri { get; set; }
 
-        [JsonProperty(PropertyName = "package_manager_uri")]
+        [JsonProperty(PropertyName = "package_manager_uri", NullValueHandling = NullValueHandling.Ignore)]
         public string? PackageManagerUri { get; set; }
 
-        [JsonProperty(PropertyName = "package_version")]
+        [JsonProperty(PropertyName = "package_version", NullValueHandling = NullValueHandling.Ignore)]
         public string? PackageVersion { get; set; }
 
-        [JsonProperty(PropertyName = "platform")]
+        [JsonProperty(PropertyName = "platform", NullValueHandling = NullValueHandling.Ignore)]
         public string? Platform { get; set; }
 
-        [JsonProperty(PropertyName = "repository")]
-        public List<Repository> Repository { get; set; }
+        [JsonProperty(PropertyName = "repository", NullValueHandling = NullValueHandling.Ignore)]
+        public List<Repository>? Repository { get; set; }
 
-        [JsonProperty(PropertyName = "version_download_uri")]
+        [JsonProperty(PropertyName = "version_download_uri", NullValueHandling = NullValueHandling.Ignore)]
         public string? VersionDownloadUri { get; set; }
 
-        [JsonProperty(PropertyName = "version_uri")]
+        [JsonProperty(PropertyName = "version_uri", NullValueHandling = NullValueHandling.Ignore)]
         public string? VersionUri { get; set; }
+
+        // remote property bag
+        [JsonProperty(PropertyName = "extended_data", NullValueHandling = NullValueHandling.Ignore)]
+        public List<LinkedData>? ExtendedData { get; set; }
 
         // construct the json format for the metadata
         public override string ToString()
         {
-            return JsonConvert.SerializeObject(this);
+            return JsonConvert.SerializeObject(this, Formatting.Indented);
         }
-    }
-
-    public class Repository
-    {
-        [JsonProperty(PropertyName = "rank")]
-        public double Rank { get; set; }
-
-        [JsonProperty(PropertyName = "type")]
-        public string? Type { get; set; }
-
-        [JsonProperty(PropertyName = "url")]
-        public string? Uri { get; set; }
     }
 
     public class User
     {
-        [JsonProperty(PropertyName = "email")]
+        [JsonProperty(PropertyName = "active_flag", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? Active { get; set; }
+
+        [JsonProperty(PropertyName = "email", NullValueHandling = NullValueHandling.Ignore)]
         public string? Email { get; set; }
 
-        [JsonProperty(PropertyName = "name")]
+        [JsonProperty(PropertyName = "Id", NullValueHandling = NullValueHandling.Ignore)]
+        public int? Id { get; set; }
+
+        [JsonProperty(PropertyName = "name", NullValueHandling = NullValueHandling.Ignore)]
         public string? Name { get; set; }
 
-        [JsonProperty(PropertyName = "url")]
+        [JsonProperty(PropertyName = "url", NullValueHandling = NullValueHandling.Ignore)]
         public string? Url { get; set; }
     }
 
     public class Version
-    {
-        [JsonProperty(PropertyName = "index")]
-        public int Index { get; set; }
+    {   // ascending value of indexes to sort out the versions
+        [JsonProperty(PropertyName = "index", NullValueHandling = NullValueHandling.Ignore)]
+        public int? Index { get; set; }
 
-        [JsonProperty(PropertyName = "version")]
+        [JsonProperty(PropertyName = "version", NullValueHandling = NullValueHandling.Ignore)]
         public string? VersionString { get; set; }
     }
 }

--- a/src/Shared/Model/PackageMetadata.cs
+++ b/src/Shared/Model/PackageMetadata.cs
@@ -7,19 +7,19 @@ namespace Microsoft.CST.OpenSource.Model
     public class Downloads
     {
         [JsonProperty(PropertyName = "daily", NullValueHandling = NullValueHandling.Ignore)]
-        public int? Daily { get; set; }
+        public long? Daily { get; set; }
 
         [JsonProperty(PropertyName = "monthly", NullValueHandling = NullValueHandling.Ignore)]
-        public int? Monthly { get; set; }
+        public long? Monthly { get; set; }
 
         [JsonProperty(PropertyName = "overall", NullValueHandling = NullValueHandling.Ignore)]
-        public int? Overall { get; set; }
+        public long? Overall { get; set; }
 
         [JsonProperty(PropertyName = "weekly", NullValueHandling = NullValueHandling.Ignore)]
-        public int? Weekly { get; set; }
+        public long? Weekly { get; set; }
 
         [JsonProperty(PropertyName = "yearly", NullValueHandling = NullValueHandling.Ignore)]
-        public int? Yearly { get; set; }
+        public long? Yearly { get; set; }
     }
 
     public class License
@@ -41,7 +41,7 @@ namespace Microsoft.CST.OpenSource.Model
     public class LinkedData
     {
         // name of the tool (in case of analysis tools), name of the repo (in case of repository) etc the tool
-        // storing this information will know what to do with it
+        // storing and reading this information will know what to do with it
         [JsonProperty(PropertyName = "name", NullValueHandling = NullValueHandling.Ignore)]
         public string? Name { get; set; }
 
@@ -50,7 +50,7 @@ namespace Microsoft.CST.OpenSource.Model
         public string? PointerType { get; set; }
 
         [JsonProperty(PropertyName = "pointer_link", NullValueHandling = NullValueHandling.Ignore)]
-        public string? Rank { get; set; }
+        public string? Pointer_Link { get; set; }
     }
 
     public class PackageMetadata
@@ -73,6 +73,9 @@ namespace Microsoft.CST.OpenSource.Model
         [JsonProperty(PropertyName = "language", NullValueHandling = NullValueHandling.Ignore)]
         public string? Language { get; set; }
 
+        [JsonProperty(PropertyName = "downloads", NullValueHandling = NullValueHandling.Ignore)]
+        public Downloads? Downloads { get; set; }
+
         [JsonProperty(PropertyName = "latest_package_version", NullValueHandling = NullValueHandling.Ignore)]
         public string? LatestPackageVersion { get; set; }
 
@@ -91,11 +94,26 @@ namespace Microsoft.CST.OpenSource.Model
         [JsonProperty(PropertyName = "package_version", NullValueHandling = NullValueHandling.Ignore)]
         public string? PackageVersion { get; set; }
 
+        [JsonProperty(PropertyName = "signature", NullValueHandling = NullValueHandling.Ignore)]
+        public List<Digest>? Signature { get; set; }
+
         [JsonProperty(PropertyName = "platform", NullValueHandling = NullValueHandling.Ignore)]
         public string? Platform { get; set; }
 
+        [JsonProperty(PropertyName = "size", NullValueHandling = NullValueHandling.Ignore)]
+        public long? Size { get; set; }
+
+        [JsonProperty(PropertyName = "upload_time", NullValueHandling = NullValueHandling.Ignore)]
+        public string? UploadTime { get; set; }
+
+        [JsonProperty(PropertyName = "commit_id", NullValueHandling = NullValueHandling.Ignore)]
+        public string? CommitId { get; set; }
+
         [JsonProperty(PropertyName = "repository", NullValueHandling = NullValueHandling.Ignore)]
         public List<Repository>? Repository { get; set; }
+
+        [JsonProperty(PropertyName = "repository_commit_id", NullValueHandling = NullValueHandling.Ignore)]
+        public string? RepositoryCommitID { get; set; }
 
         [JsonProperty(PropertyName = "version_download_uri", NullValueHandling = NullValueHandling.Ignore)]
         public string? VersionDownloadUri { get; set; }
@@ -103,9 +121,18 @@ namespace Microsoft.CST.OpenSource.Model
         [JsonProperty(PropertyName = "version_uri", NullValueHandling = NullValueHandling.Ignore)]
         public string? VersionUri { get; set; }
 
+        [JsonProperty(PropertyName = "active_flag", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? Active { get; set; }
+
         // remote property bag
         [JsonProperty(PropertyName = "extended_data", NullValueHandling = NullValueHandling.Ignore)]
         public List<LinkedData>? ExtendedData { get; set; }
+
+        [JsonProperty(PropertyName = "dependencies", NullValueHandling = NullValueHandling.Ignore)]
+        public List<Dependency>? Dependencies { get; set; }
+
+        [JsonProperty(PropertyName = "install_scripts", NullValueHandling = NullValueHandling.Ignore)]
+        public List<Command>? Scripts { get; set; }
 
         // construct the json format for the metadata
         public override string ToString()
@@ -139,5 +166,29 @@ namespace Microsoft.CST.OpenSource.Model
 
         [JsonProperty(PropertyName = "version", NullValueHandling = NullValueHandling.Ignore)]
         public string? VersionString { get; set; }
+    }
+
+    public class Digest
+    {
+        [JsonProperty(PropertyName = "signature_algorithm", NullValueHandling = NullValueHandling.Ignore)]
+        public string? Algorithm { get; set; }
+
+        [JsonProperty(PropertyName = "signature", NullValueHandling = NullValueHandling.Ignore)]
+        public string? Signature { get; set; }
+    }
+
+    public class Dependency
+    {
+        [JsonProperty(PropertyName = "package", NullValueHandling = NullValueHandling.Ignore)]
+        public string? Package { get; set; }
+    }
+
+    public class Command
+    {
+        [JsonProperty(PropertyName = "command", NullValueHandling = NullValueHandling.Ignore)]
+        public string? CommandLine { get; set; }
+
+        [JsonProperty(PropertyName = "arguments", NullValueHandling = NullValueHandling.Ignore)]
+        public List<string>? Arguments { get; set; }
     }
 }

--- a/src/Shared/Model/Repository.cs
+++ b/src/Shared/Model/Repository.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using Microsoft.CST.OpenSource.Shared;
 using System.Threading.Tasks;
 using Octokit;
-using Functional.Maybe;
 
 using CSTRepository = Microsoft.CST.OpenSource.Model.Repository;
 using GHRepository = Octokit.Repository;

--- a/src/Shared/Model/Repository.cs
+++ b/src/Shared/Model/Repository.cs
@@ -1,0 +1,159 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using Microsoft.CST.OpenSource.Shared;
+using System.Threading.Tasks;
+using Octokit;
+
+using CSTRepository = Microsoft.CST.OpenSource.Model.Repository;
+using GHRepository = Octokit.Repository;
+using NLog;
+
+namespace Microsoft.CST.OpenSource.Model
+{
+    public class Repository
+    {
+        public const string ENV_GITHUB_ENDPOINT = "https://github.com";
+        public static NLog.ILogger Logger { get; set; } = NLog.LogManager.GetCurrentClassLogger();
+
+        // JSON properties
+        [JsonProperty(PropertyName = "Id", NullValueHandling = NullValueHandling.Ignore)]
+        public long? Id { get; set; }
+
+        [JsonProperty(PropertyName = "name", NullValueHandling = NullValueHandling.Ignore)]
+        public string? Name { get; set; }
+
+        [JsonProperty(PropertyName = "description", NullValueHandling = NullValueHandling.Ignore)]
+        public string? Description { get; set; }
+
+        [JsonProperty(PropertyName = "archived_flag", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? Archived { get; set; }
+
+        [JsonProperty(PropertyName = "contributors", NullValueHandling = NullValueHandling.Ignore)]
+        public List<User>? Contributors { get; set; }
+
+        [JsonProperty(PropertyName = "created_at", NullValueHandling = NullValueHandling.Ignore)]
+        public DateTimeOffset? CreatedAt { get; set; }
+
+        [JsonProperty(PropertyName = "downloads", NullValueHandling = NullValueHandling.Ignore)]
+        public Downloads? Downloads { get; set; }
+
+        [JsonProperty(PropertyName = "followers", NullValueHandling = NullValueHandling.Ignore)]
+        public int? FollowersCount { get; set; }
+
+        [JsonProperty(PropertyName = "forks_count", NullValueHandling = NullValueHandling.Ignore)]
+        public int? Forks { get; set; }
+
+        [JsonProperty(PropertyName = "homepage", NullValueHandling = NullValueHandling.Ignore)]
+        public string? Homepage { get; set; }
+
+        [JsonProperty(PropertyName = "is_fork", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? IsFork { get; set; }
+
+        [JsonProperty(PropertyName = "language", NullValueHandling = NullValueHandling.Ignore)]
+        public string? Language { get; set; }
+
+        [JsonProperty(PropertyName = "licenses", NullValueHandling = NullValueHandling.Ignore)]
+        public List<License>? Licenses { get; set; }
+
+        [JsonProperty(PropertyName = "linked_data", NullValueHandling = NullValueHandling.Ignore)]
+        public LinkedData? LinkedData { get; set; }
+
+        [JsonProperty(PropertyName = "maintainers", NullValueHandling = NullValueHandling.Ignore)]
+        public List<User>? Maintainers { get; set; }
+
+        [JsonProperty(PropertyName = "openissues_count", NullValueHandling = NullValueHandling.Ignore)]
+        public int? OpenIssuesCount { get; set; }
+
+        [JsonProperty(PropertyName = "owner", NullValueHandling = NullValueHandling.Ignore)]
+        public User? Owner { get; set; }
+
+        [JsonProperty(PropertyName = "parent", NullValueHandling = NullValueHandling.Ignore)]
+        public string? Parent { get; set; }
+
+        [JsonProperty(PropertyName = "purl", NullValueHandling = NullValueHandling.Ignore)]
+        public string? Purl { get; set; }
+
+        [JsonProperty(PropertyName = "pushed_at", NullValueHandling = NullValueHandling.Ignore)]
+        public DateTimeOffset? PushedAt { get; set; }
+
+        [JsonProperty(PropertyName = "rank", NullValueHandling = NullValueHandling.Ignore)]
+        public double? Rank { get; set; }
+
+        [JsonProperty(PropertyName = "size", NullValueHandling = NullValueHandling.Ignore)]
+        public long? Size { get; set; }
+
+        [JsonProperty(PropertyName = "stakeholders_count", NullValueHandling = NullValueHandling.Ignore)]
+        public int? StakeholdersCount { get; set; }
+
+        [JsonProperty(PropertyName = "type", NullValueHandling = NullValueHandling.Ignore)]
+        public string? Type { get; set; }
+
+        [JsonProperty(PropertyName = "updated_at", NullValueHandling = NullValueHandling.Ignore)]
+        public DateTimeOffset? UpdatedAt { get; set; }
+
+        [JsonProperty(PropertyName = "url", NullValueHandling = NullValueHandling.Ignore)]
+        public string? Uri { get; set; }
+
+        public async Task<CSTRepository?> GetGithubRepositoryMetadata(PackageURL purl)
+        {
+            CSTRepository repository = new CSTRepository();
+            Purl = purl.ToString();
+
+            if (purl.Type != "github")
+            {
+                Logger.Warn("Only github repos are handled currently");
+                return repository;
+            }
+            try
+            {
+                var github = new GitHubClient(new ProductHeaderValue("OSSGadget"));
+                var ghRepository = await github.Repository.Get(purl.Namespace, purl.Name);
+
+                if (ghRepository is null) { return null; }
+                Archived = ghRepository.Archived;
+                CreatedAt = ghRepository.CreatedAt;
+                UpdatedAt = ghRepository.UpdatedAt;
+                Description = Utilities.GetMaxClippedLength(ghRepository.Description);
+                IsFork = ghRepository.Fork;
+                Forks = ghRepository.ForksCount;
+                Homepage = Utilities.GetMaxClippedLength(ghRepository.Homepage);
+                Id = ghRepository.Id;
+                Language = Utilities.GetMaxClippedLength(ghRepository.Language);
+                Name = ghRepository.Name;
+                OpenIssuesCount = ghRepository.OpenIssuesCount;
+                Parent = ghRepository.Parent?.Url;
+                PushedAt = ghRepository.PushedAt;
+                Size = ghRepository.Size;
+                FollowersCount = ghRepository.StargazersCount;
+                Uri = Utilities.GetMaxClippedLength(ghRepository.Url);
+                StakeholdersCount = ghRepository.WatchersCount;
+
+                if (ghRepository.License is not null)
+                {
+                    Licenses ??= new List<License>();
+                    Licenses.Add(new License()
+                    {
+                        Name = ghRepository.License.Name,
+                        Url = ghRepository.License.Url,
+                        SPIX_ID = ghRepository.License.SpdxId
+                    });
+                }
+
+                Owner ??= new User()
+                {
+                    Id = ghRepository.Owner.Id,
+                    Name = ghRepository.Owner.Name,
+                    Email = ghRepository.Owner.Email,
+                    Url = ghRepository.Owner.Url,
+                    Active = !ghRepository.Owner.Suspended
+                };
+            }
+            catch (Exception ex)
+            {
+                Logger.Warn($"Exception occurred while retrieving repository data: {ex.ToString()}");
+            }
+            return repository;
+        }
+    }
+}

--- a/src/Shared/PackageManagers/BaseProjectManager.cs
+++ b/src/Shared/PackageManagers/BaseProjectManager.cs
@@ -402,7 +402,7 @@ The package-url specifier is described at https://github.com/package-url/purl-sp
         /// </summary>
         /// <param name="purl"> </param>
         /// <returns> </returns>
-        public virtual Task<PackageMetadata?> GetPackageMetadata(PackageURL purl)
+        public virtual Task<PackageMetadata> GetPackageMetadata(PackageURL purl)
         {
             throw new NotImplementedException("BaseProjectManager does not implement GetPackageMetadata.");
         }
@@ -449,7 +449,7 @@ The package-url specifier is described at https://github.com/package-url/purl-sp
             // Check the specific PackageManager-specific implementation first
             try
             {
-                foreach (var result in await PackageMetadataSearch(purl, rawMetadataString))
+                foreach (var result in await SearchRepoUrlsInPackageMetadata(purl, rawMetadataString))
                 {
                     sourceRepositoryMap.Add(result.Key, result.Value);
                 }
@@ -543,7 +543,7 @@ The package-url specifier is described at https://github.com/package-url/purl-sp
         ///     result for the package repository, or return a null in case of failure/nothing to do.
         /// </summary>
         /// <returns> </returns>
-        protected virtual Task<Dictionary<PackageURL, double>> PackageMetadataSearch(PackageURL purl, string metadata)
+        protected virtual Task<Dictionary<PackageURL, double>> SearchRepoUrlsInPackageMetadata(PackageURL purl, string metadata)
         {
             return Task.FromResult(new Dictionary<PackageURL, double>());
         }

--- a/src/Shared/PackageManagers/BaseProjectManager.cs
+++ b/src/Shared/PackageManagers/BaseProjectManager.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 
 using F23.StringSimilarity;
+using Microsoft.CST.OpenSource.Model;
 using Microsoft.CST.RecursiveExtractor;
 using Microsoft.Extensions.Caching.Memory;
 using System;
@@ -12,6 +13,7 @@ using System.Net.Http;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Version = SemVer.Version;
 
 namespace Microsoft.CST.OpenSource.Shared
 {
@@ -330,7 +332,7 @@ The package-url specifier is described at https://github.com/package-url/purl-sp
                 {
                     fullPath = fullPath.Replace(c, '-');    // ignore: lgtm [cs/string-concatenation-in-loop]
                 }
-                
+
                 var filePathToWrite = Path.Combine(TopLevelExtractionDirectory, fullPath);
                 filePathToWrite = filePathToWrite.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
 
@@ -347,6 +349,32 @@ The package-url specifier is described at https://github.com/package-url/purl-sp
             Logger.Debug("Archive extracted to {0}", fullExtractionPath);
 
             return fullExtractionPath;
+        }
+
+        /// <summary>
+        ///     Gets the latest version from the package metadata
+        /// </summary>
+        /// <param name="metadata"> </param>
+        /// <returns> </returns>
+        public Version? GetLatestVersion(JsonDocument metadata)
+        {
+            List<Version> versions = GetVersions(metadata);
+            return GetLatestVersion(versions);
+        }
+
+        /// <summary>
+        ///     overload for getting the latest version
+        /// </summary>
+        /// <param name="versions"> </param>
+        /// <returns> </returns>
+        public Version? GetLatestVersion(List<Version> versions)
+        {
+            if (versions != null && versions?.Count > 0)
+            {
+                Version? maxVersion = versions.Max();
+                return maxVersion;
+            }
+            return null;
         }
 
         /// <summary>
@@ -367,6 +395,38 @@ The package-url specifier is described at https://github.com/package-url/purl-sp
         public virtual Uri? GetPackageAbsoluteUri(PackageURL purl)
         {
             throw new NotImplementedException("BaseProjectManager does not implement GetPackageAbsoluteUri.");
+        }
+
+        /// <summary>
+        ///     Return a normalized package metadata.
+        /// </summary>
+        /// <param name="purl"> </param>
+        /// <returns> </returns>
+        public virtual Task<PackageMetadata?> GetPackageMetadata(PackageURL purl)
+        {
+            throw new NotImplementedException("BaseProjectManager does not implement GetPackageMetadata.");
+        }
+
+        /// <summary>
+        ///     Gets everything contained in a JSON element for the package version
+        /// </summary>
+        /// <param name="metadata"> </param>
+        /// <param name="version"> </param>
+        /// <returns> </returns>
+        public virtual JsonElement? GetVersionElement(JsonDocument contentJSON, Version version)
+        {
+            throw new NotImplementedException("BaseProjectManager does not implement GetVersions.");
+        }
+
+        /// <summary>
+        ///     Gets all the versions of a package
+        /// </summary>
+        /// <param name="metadata"> </param>
+        /// <param name="version"> </param>
+        /// <returns> </returns>
+        public virtual List<Version> GetVersions(JsonDocument metadata)
+        {
+            throw new NotImplementedException("BaseProjectManager does not implement GetVersions.");
         }
 
         /// <summary>

--- a/src/Shared/PackageManagers/BaseProjectManager.cs
+++ b/src/Shared/PackageManagers/BaseProjectManager.cs
@@ -356,7 +356,7 @@ The package-url specifier is described at https://github.com/package-url/purl-sp
         /// </summary>
         /// <param name="metadata"> </param>
         /// <returns> </returns>
-        public Version? GetLatestVersion(JsonDocument metadata)
+        public Version? GetLatestVersion(JsonDocument? metadata)
         {
             List<Version> versions = GetVersions(metadata);
             return GetLatestVersion(versions);
@@ -369,7 +369,7 @@ The package-url specifier is described at https://github.com/package-url/purl-sp
         /// <returns> </returns>
         public Version? GetLatestVersion(List<Version> versions)
         {
-            if (versions != null && versions?.Count > 0)
+            if (versions?.Count > 0)
             {
                 Version? maxVersion = versions.Max();
                 return maxVersion;
@@ -424,7 +424,7 @@ The package-url specifier is described at https://github.com/package-url/purl-sp
         /// <param name="metadata"> </param>
         /// <param name="version"> </param>
         /// <returns> </returns>
-        public virtual List<Version> GetVersions(JsonDocument metadata)
+        public virtual List<Version> GetVersions(JsonDocument? metadata)
         {
             throw new NotImplementedException("BaseProjectManager does not implement GetVersions.");
         }

--- a/src/Shared/PackageManagers/NPMProjectManager.cs
+++ b/src/Shared/PackageManagers/NPMProjectManager.cs
@@ -430,7 +430,7 @@ namespace Microsoft.CST.OpenSource.Shared
         /// <summary>
         ///     Internal Node.js modules that should be ignored when searching metadata.
         /// </summary>
-        private static readonly List<string> NODEJS_INTERNAL_MODULES = new List<string>()
+        private static readonly List<string> npm_internal_modules = new List<string>()
         {
             "assert",
             "async_hooks",

--- a/src/Shared/PackageManagers/NuGetProjectManager.cs
+++ b/src/Shared/PackageManagers/NuGetProjectManager.cs
@@ -123,7 +123,7 @@ namespace Microsoft.CST.OpenSource.Shared
             return new Uri($"{ENV_NUGET_HOMEPAGE}/{purl?.Name}");
         }
 
-        protected async override Task<Dictionary<PackageURL, double>> PackageMetadataSearch(PackageURL purl, string metadata)
+        protected async override Task<Dictionary<PackageURL, double>> SearchRepoUrlsInPackageMetadata(PackageURL purl, string metadata)
         {
             Dictionary<PackageURL, double> mapping = new Dictionary<PackageURL, double>();
             try

--- a/src/Shared/PackageManagers/PyPIProjectManager.cs
+++ b/src/Shared/PackageManagers/PyPIProjectManager.cs
@@ -1,11 +1,17 @@
 ﻿// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 
+using Microsoft.CST.OpenSource.Model;
+using Octokit;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
+using License = Microsoft.CST.OpenSource.Model.License;
+using Repository = Microsoft.CST.OpenSource.Model.Repository;
+using User = Microsoft.CST.OpenSource.Model.User;
+using Version = SemVer.Version;
 
 namespace Microsoft.CST.OpenSource.Shared
 {
@@ -114,7 +120,8 @@ namespace Microsoft.CST.OpenSource.Shared
                     info.TryGetProperty("version", out JsonElement version))
                 {
                     Logger.Debug("Identified {0} version {1}.", packageName, version.GetString());
-                    versionList.Add(version.GetString());
+                    if (version.GetString() is string versionString && !string.IsNullOrWhiteSpace(versionString))
+                        versionList.Add(versionString);
                 }
 
                 return SortVersions(versionList.Distinct());
@@ -135,6 +142,145 @@ namespace Microsoft.CST.OpenSource.Shared
             catch (Exception ex)
             {
                 Logger.Warn(ex, "Error fetching PyPI metadata: {0}", ex.Message);
+                return null;
+            }
+        }
+
+        public override async Task<PackageMetadata> GetPackageMetadata(PackageURL purl)
+        {
+            PackageMetadata metadata = new PackageMetadata();
+            string? content = await GetMetadata(purl);
+            if (string.IsNullOrEmpty(content)) { return metadata; }
+
+            // convert NPM package data to normalized form
+            JsonDocument contentJSON = JsonDocument.Parse(content);
+            JsonElement root = contentJSON.RootElement;
+
+            JsonElement infoElement = root.GetProperty("info");
+
+            metadata.Name = Utilities.GetJSONPropertyStringIfExists(infoElement, "name");
+            metadata.Description = Utilities.GetJSONPropertyStringIfExists(infoElement, "description");
+            string? summary = Utilities.GetJSONPropertyStringIfExists(infoElement, "summary");
+            if (summary?.Length > metadata.Description?.Length)
+            { // longer string might be the actual description
+                metadata.Description = summary;
+            }
+            metadata.PackageManagerUri = ENV_PYPI_ENDPOINT;
+            metadata.Package_Uri = Utilities.GetJSONPropertyStringIfExists(infoElement, "package_url");
+            metadata.Keywords = Utilities.ConvertJSONToList(Utilities.GetJSONPropertyIfExists(infoElement, "keywords"));
+
+            // author
+            User author = new User()
+            {
+                Name = Utilities.GetJSONPropertyStringIfExists(infoElement, "author"),
+                Email = Utilities.GetJSONPropertyStringIfExists(infoElement, "author_email"),
+            };
+            metadata.Authors ??= new List<Model.User>();
+            metadata.Authors.Add(author);
+
+            // maintainers
+            User maintainer = new User()
+            {
+                Name = Utilities.GetJSONPropertyStringIfExists(infoElement, "maintainer"),
+                Email = Utilities.GetJSONPropertyStringIfExists(infoElement, "maintainer_email"),
+            };
+            metadata.Maintainers ??= new List<User>();
+            metadata.Maintainers.Add(maintainer);
+
+            // repository
+            var repoMappings = await SearchRepoUrlsInPackageMetadata(purl, content);
+            foreach (var repoMapping in repoMappings)
+            {
+                Repository repository = new Repository
+                {
+                    Rank = repoMapping.Value,
+                    Type = repoMapping.Key.Type
+                };
+                await repository.ExtractRepositoryMetadata(repoMapping.Key);
+
+                metadata.Repository ??= new List<Repository>();
+                metadata.Repository.Add(repository);
+            }
+
+            // license
+            var licenseType = Utilities.GetJSONPropertyStringIfExists(infoElement, "license");
+            if (!string.IsNullOrWhiteSpace(licenseType))
+            {
+                metadata.Licenses ??= new List<License>();
+                metadata.Licenses.Add(new License()
+                {
+                    Name = licenseType
+                });
+            }
+
+            // get the version
+            var versions = GetVersions(contentJSON);
+            var latestVersion = GetLatestVersion(versions);
+
+            if (purl.Version != null)
+            {
+                // find the version object from the collection
+                metadata.PackageVersion = purl.Version;
+            }
+            else
+            {
+                metadata.PackageVersion = latestVersion is null ? purl.Version : latestVersion?.ToString();
+            }
+
+            // if we found any version at all, get the deets
+            if (metadata.PackageVersion is not null)
+            {
+                Version versionToGet = new Version(metadata.PackageVersion);
+                JsonElement? versionElement = GetVersionElement(contentJSON, versionToGet);
+                if (versionElement is not null)
+                {
+                    // fill the version specific entries
+
+                    // digests
+                    if (Utilities.GetJSONPropertyIfExists(versionElement, "digests")?.EnumerateObject()
+                        is JsonElement.ObjectEnumerator digests)
+                    {
+                        metadata.Signature ??= new List<Digest>();
+                        foreach (var digest in digests)
+                        {
+                            metadata.Signature.Add(new Digest()
+                            {
+                                Algorithm = digest.Name,
+                                Signature = digest.Value.ToString()
+                            });
+                        }
+                    }
+
+                    // downloads
+                    if (Utilities.GetJSONPropertyIfExists(versionElement, "downloads")?.GetInt64() is long downloads
+                        && downloads != -1)
+                    {
+                        metadata.Downloads ??= new Downloads()
+                        {
+                            Overall = downloads
+                        };
+                    }
+
+                    metadata.Size = Utilities.GetJSONPropertyIfExists(versionElement, "size")?.GetInt64();
+                    metadata.UploadTime = Utilities.GetJSONPropertyStringIfExists(versionElement, "upload_time");
+                    metadata.Active = !Utilities.GetJSONPropertyIfExists(versionElement, "yanked")?.GetBoolean();
+                    metadata.VersionUri = $"{ENV_PYPI_ENDPOINT}/project/{purl.Name}/{purl.Version}";
+                    metadata.VersionDownloadUri = Utilities.GetJSONPropertyStringIfExists(versionElement, "url");
+                }
+            }
+
+            return metadata;
+        }
+
+        public override JsonElement? GetVersionElement(JsonDocument contentJSON, Version version)
+        {
+            try
+            {
+                var versionElement = contentJSON.RootElement.GetProperty("releases").GetProperty(version.ToString());
+                return versionElement;
+            }
+            catch (KeyNotFoundException)
+            {
                 return null;
             }
         }

--- a/src/Shared/PackageManagers/PyPIProjectManager.cs
+++ b/src/Shared/PackageManagers/PyPIProjectManager.cs
@@ -144,7 +144,7 @@ namespace Microsoft.CST.OpenSource.Shared
             return new Uri($"{ENV_PYPI_ENDPOINT}/project/{purl?.Name}");
         }
 
-        protected async override Task<Dictionary<PackageURL, double>> PackageMetadataSearch(PackageURL purl, string metadata)
+        protected async override Task<Dictionary<PackageURL, double>> SearchRepoUrlsInPackageMetadata(PackageURL purl, string metadata)
         {
             var mapping = new Dictionary<PackageURL, double>();
             if (purl.Name?.StartsWith('_') ?? false) // TODO: there are internal modules which do not start with _

--- a/src/Shared/Shared.csproj
+++ b/src/Shared/Shared.csproj
@@ -35,6 +35,7 @@
     <PackageReference Include="NLog" Version="4.7.5" />
     <PackageReference Include="NLog.Schema" Version="4.7.5" />
     <PackageReference Include="NuGet.Versioning" Version="5.8.0" />
+    <PackageReference Include="Octokit" Version="0.48.0" />
     <PackageReference Include="Sarif.Sdk" Version="2.3.8" />
     <PackageReference Include="SemanticVersioning" Version="1.3.0" />
     <PackageReference Include="sharpcompress" Version="0.26.0" />

--- a/src/Shared/Shared.csproj
+++ b/src/Shared/Shared.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/Microsoft/OSSGadget</RepositoryUrl>
     <Configurations>Debug;Release</Configurations>
     <AssemblyName>Shared</AssemblyName>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
   </PropertyGroup>
 

--- a/src/Shared/Shared.csproj
+++ b/src/Shared/Shared.csproj
@@ -35,6 +35,7 @@
     <PackageReference Include="NLog" Version="4.7.4" />
     <PackageReference Include="NLog.Schema" Version="4.7.4" />
     <PackageReference Include="NuGet.Versioning" Version="5.8.0-preview.2.6776" />
+    <PackageReference Include="Octokit" Version="0.48.0" />
     <PackageReference Include="Sarif.Sdk" Version="2.3.4" />
     <PackageReference Include="SemanticVersioning" Version="1.2.2" />
     <PackageReference Include="sharpcompress" Version="0.26.0" />

--- a/src/Shared/Shared.csproj
+++ b/src/Shared/Shared.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="AngleSharp" Version="1.0.0-alpha-827" />
     <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
     <PackageReference Include="F23.StringSimilarity" Version="3.1.0" />
+    <PackageReference Include="Functional.Maybe" Version="2.0.20" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.24" />
     <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0034" />
     <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.0.36" />

--- a/src/Shared/Utilities/Utilities.cs
+++ b/src/Shared/Utilities/Utilities.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.CST.OpenSource.Model;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -11,23 +12,94 @@ namespace Microsoft.CST.OpenSource.Shared
     {
         public static JsonElement? GetJSONPropertyIfExists(JsonElement? element, string keyName)
         {
-            try
+            if (element is JsonElement elem && string.IsNullOrWhiteSpace(keyName))
             {
-                if (element?.GetProperty(keyName) is JsonElement res)
+                try
                 {
-                    return res;
+                    if (elem.GetProperty(keyName) is JsonElement res)
+                    {
+                        return res;
+                    }
                 }
-            }
-            catch (KeyNotFoundException)
-            {
+                catch (KeyNotFoundException)
+                {
+                }
             }
             return null;
         }
 
+        public static string? GetJSONPropertyStringIfExists(JsonElement? element, string keyName)
+        {
+            return GetJSONPropertyIfExists(element, keyName)?.ToString();
+        }
+
         public static string GetMaxClippedLength(string str)
         {
+            if (string.IsNullOrEmpty(str)) { return str; }
             int MaxLength = Math.Min(str.Length, MAX_FIELD_LENGTH);
             return str[0..MaxLength];
+        }
+
+        /// <summary>
+        ///     Convert a JSON array (or a csv string) into an POCO array
+        /// </summary>
+        /// <param name="jsonElement"> </param>
+        /// <returns> </returns>
+        public static List<string>? ConvertJSONToList(JsonElement? jsonElement)
+        {
+            List<string> items = new List<string>();
+
+            if (jsonElement.ToString() is string str)
+            {
+                if (GetJSONEnumerator(jsonElement) is JsonElement.ArrayEnumerator enumerator)
+                {
+                    foreach (JsonElement itemElement in enumerator)
+                    {
+                        if (itemElement.GetString() is string item)
+                        {
+                            items.Add(item);
+                        }
+                    }
+                }
+                else if (str.Contains(","))
+                {
+                    // split the string as a csv
+                    items = str.Split(',').ToList();
+                }
+                else
+                {
+                    return null;
+                }
+            }
+
+            return items;
+        }
+
+        public static JsonElement.ArrayEnumerator? GetJSONEnumerator(JsonElement? jsonElement)
+        {
+            if (jsonElement is not null && jsonElement?.ToString() is string str && !string.IsNullOrEmpty(str))
+            {
+                if (str.Contains("["))
+                {
+                    if (jsonElement?.EnumerateArray() is JsonElement.ArrayEnumerator enumerator)
+                    {
+                        return enumerator;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        public static bool ValueExists<T>(T? item, out T retItem) where T : new()
+        {
+            if (item is T x && x != null)
+            {
+                retItem = x;
+                return true;
+            }
+            retItem = default(T) ?? new T();
+            return false;
         }
 
         private const int MAX_FIELD_LENGTH = 65535;

--- a/src/Shared/Utilities/Utilities.cs
+++ b/src/Shared/Utilities/Utilities.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace Microsoft.CST.OpenSource.Shared
+{
+    internal class Utilities
+    {
+        public static JsonElement? GetJSONPropertyIfExists(JsonElement? element, string keyName)
+        {
+            try
+            {
+                if (element?.GetProperty(keyName) is JsonElement res)
+                {
+                    return res;
+                }
+            }
+            catch (KeyNotFoundException)
+            {
+            }
+            return null;
+        }
+    }
+}

--- a/src/Shared/Utilities/Utilities.cs
+++ b/src/Shared/Utilities/Utilities.cs
@@ -23,5 +23,13 @@ namespace Microsoft.CST.OpenSource.Shared
             }
             return null;
         }
+
+        public static string GetMaxClippedLength(string str)
+        {
+            int MaxLength = Math.Min(str.Length, MAX_FIELD_LENGTH);
+            return str[0..MaxLength];
+        }
+
+        private const int MAX_FIELD_LENGTH = 65535;
     }
 }

--- a/src/oss-characteristics/oss-characteristic.csproj
+++ b/src/oss-characteristics/oss-characteristic.csproj
@@ -11,7 +11,7 @@
     <RepositoryUrl>https://github.com/Microsoft/OSSGadget</RepositoryUrl>
     <StartupObject>Microsoft.CST.OpenSource.CharacteristicTool</StartupObject>
     <Configurations>Debug;Release</Configurations>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
   </PropertyGroup>
 

--- a/src/oss-defog/oss-defog.csproj
+++ b/src/oss-defog/oss-defog.csproj
@@ -11,7 +11,7 @@
     <RepositoryUrl>https://github.com/Microsoft/OSSGadget</RepositoryUrl>
     <StartupObject>Microsoft.CST.OpenSource.DefoggerTool</StartupObject>
     <Configurations>Debug;Release</Configurations>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
   </PropertyGroup>
 

--- a/src/oss-detect-backdoor/oss-detect-backdoor.csproj
+++ b/src/oss-detect-backdoor/oss-detect-backdoor.csproj
@@ -11,7 +11,7 @@
     <RepositoryUrl>https://github.com/Microsoft/OSSGadget</RepositoryUrl>
     <StartupObject>Microsoft.CST.OpenSource.DetectBackdoorTool</StartupObject>
     <Configurations>Debug;Release</Configurations>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
   </PropertyGroup>
 

--- a/src/oss-detect-cryptography/oss-detect-cryptography.csproj
+++ b/src/oss-detect-cryptography/oss-detect-cryptography.csproj
@@ -10,7 +10,7 @@
     <RepositoryType>GitHub</RepositoryType>
     <RepositoryUrl>https://github.com/Microsoft/OSSGadget</RepositoryUrl>
     <StartupObject>Microsoft.CST.OpenSource.DetectCryptographyTool</StartupObject>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
   </PropertyGroup>
 

--- a/src/oss-find-source/oss-find-source.csproj
+++ b/src/oss-find-source/oss-find-source.csproj
@@ -11,7 +11,7 @@
     <RepositoryUrl>https://github.com/Microsoft/OSSGadget</RepositoryUrl>
     <StartupObject>Microsoft.CST.OpenSource.FindSourceTool</StartupObject>
     <Configurations>Debug;Release</Configurations>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
   </PropertyGroup>
 

--- a/src/oss-health/oss-health.csproj
+++ b/src/oss-health/oss-health.csproj
@@ -11,7 +11,7 @@
     <RepositoryUrl>https://github.com/Microsoft/OSSGadget</RepositoryUrl>
     <StartupObject>Microsoft.CST.OpenSource.HealthTool</StartupObject>
     <Configurations>Debug;Release</Configurations>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
   </PropertyGroup>
 

--- a/src/oss-metadata/MetadataTool.cs
+++ b/src/oss-metadata/MetadataTool.cs
@@ -1,0 +1,96 @@
+﻿using CommandLine;
+using CommandLine.Text;
+using Microsoft.CST.OpenSource.Model;
+using Microsoft.CST.OpenSource.Shared;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Microsoft.CST.OpenSource
+{
+    public class MetadataTool : OSSGadget
+    {
+        public class Options
+        {
+            [Usage()]
+            public static IEnumerable<Example> Examples
+            {
+                get
+                {
+                    return new List<Example>() {
+                        new Example("Find the normalized metadata for the given package",
+                        new Options { Targets = new List<string>() {"[options]", "package-url..." } })};
+                }
+            }
+
+            [Option('o', "output-file", Required = false, Default = "",
+                HelpText = "send the command output to a file instead of stdout")]
+            public string OutputFile { get; set; } = "";
+
+            [Value(0, Required = true,
+                HelpText = "PackgeURL(s) specifier to analyze (required, repeats OK)", Hidden = true)] // capture all targets to analyze
+            public IEnumerable<string> Targets { get => targets; set => targets = value; }
+
+            private IEnumerable<string> targets;
+        }
+
+        public MetadataTool() : base()
+        {
+        }
+
+        private static async Task<PackageMetadata> GetPackageMetadata(PackageURL purl)
+        {
+            PackageMetadata metadata = null;
+            try
+            {
+                // Use reflection to find the correct downloader class
+                var projectManager = ProjectManagerFactory.CreateProjectManager(purl, null);
+                if (projectManager != null)
+                {
+                    metadata = await projectManager.GetPackageMetadata(purl);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Warn(ex, "Error identifying source repository for {0}: {1}", purl, ex.Message);
+            }
+
+            return metadata;
+        }
+
+        /// <summary>
+        ///     Main entrypoint for the download program.
+        /// </summary>
+        /// <param name="args"> parameters passed in from the user </param>
+        private static async Task Main(string[] args)
+        {
+            var metadataTool = new MetadataTool();
+            await metadataTool.ParseOptions<Options>(args).WithParsedAsync(metadataTool.RunAsync);
+        }
+
+        private async Task RunAsync(Options options)
+        {
+            // select output destination and format
+            SelectOutput(options.OutputFile);
+            PackageMetadata metadata = null;
+            if (options.Targets is IList<string> targetList && targetList.Count > 0)
+            {
+                foreach (var target in targetList)
+                {
+                    try
+                    {
+                        var purl = new PackageURL(target);
+                        metadata = await GetPackageMetadata(purl);
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Warn(ex, "Error processing {0}: {1}", target, ex.Message);
+                    }
+                }
+                Console.WriteLine(metadata?.ToString());
+            }
+
+            RestoreOutput();
+        }
+    }
+}

--- a/src/oss-metadata/oss-metadata.csproj
+++ b/src/oss-metadata/oss-metadata.csproj
@@ -4,23 +4,21 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Microsoft.CST.OpenSource</RootNamespace>
+    <Nullable>warnings</Nullable>
+    <Authors>Suraj Jacob</Authors>
     <Company>Microsoft Corporation</Company>
-    <Description>OSS Gadget - Package Downloader</Description>
-    <Authors>Michael Scovetta</Authors>
-    <RepositoryType>GitHub</RepositoryType>
-    <RepositoryUrl>https://github.com/Microsoft/OSSGadget</RepositoryUrl>
-    <StartupObject>Microsoft.CST.OpenSource.DownloadTool</StartupObject>
+    <Description>OSS Gadget - Package Metadata Collector</Description>
     <LangVersion>9.0</LangVersion>
-    <Nullable>Enable</Nullable>
+    <RepositoryUrl>https://github.com/Microsoft/OSSGadget</RepositoryUrl>
+    <RepositoryType>Github</RepositoryType>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <NoWarn>1701;1702</NoWarn>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <Optimize>false</Optimize>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
-    <PackageReference Include="System.Console" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/oss-risk-calculator/oss-risk-calculator.csproj
+++ b/src/oss-risk-calculator/oss-risk-calculator.csproj
@@ -11,7 +11,7 @@
     <RepositoryUrl>https://github.com/Microsoft/OSSGadget</RepositoryUrl>
     <StartupObject>Microsoft.CST.OpenSource.RiskCalculatorTool</StartupObject>
     <Configurations>Debug;Release</Configurations>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
   </PropertyGroup>
 

--- a/src/oss-tests/FindSourceTests.cs
+++ b/src/oss-tests/FindSourceTests.cs
@@ -56,7 +56,16 @@ namespace Microsoft.CST.OpenSource.Tests
 
             Assert.IsNotNull(sarif);
             Assert.IsNotNull(sarif.Runs.FirstOrDefault().Tool.Driver.Name);
-            Assert.AreEqual(sarif.Runs.FirstOrDefault().Results.FirstOrDefault().Message.Text, targetResult);
+            // make sure atleast one of the result repos match the actual one
+            bool found = false;
+            foreach (var result in sarif.Runs.FirstOrDefault().Results)
+            {
+                if (result.Message.Text == targetResult)
+                {
+                    found = true;
+                }
+            }
+            Assert.IsTrue(found);
         }
 
         [DataTestMethod]


### PR DESCRIPTION
This is the initial commit PR for the oss-metadata tool, and the common package metadata schema. The common package metadata schema is an effort to represent any package (npm, pypi, nuget, etc), in a common schema, so that they can be analyzed and stored according to a common set of rules. 
Much like how PURL combines different package urls into one unified schema, metadata tool tries to combine most of the package metadata into a common JSON schema. The changes in this PR are:
1) Proposal for a common schema for storing package metadata (POCO format in Model/PackageMetadata.cs)
2) Initial commit for the oss-metadata tool, which extracts metadata for the package and outputs the JSON format.
3) Update the C# version of all projects to 9
4) Implement the NPM provider for the package metadata

For now, only NPM package provider implements oss-metadata. I'll fork off from this branch and implement the other package providers, and finish PRs, before merging to main.

Few of the things that need to be done:
1) Come up with and register the JSON schema with a schema provider.
2) Other fields might be added as I go through the other package providers
3) Add tests
