### PR TITLE
Fixes #187 and #186.

### DIFF
--- a/src/Shared/PackageManagers/NuGetProjectManager.cs
+++ b/src/Shared/PackageManagers/NuGetProjectManager.cs
@@ -309,8 +309,7 @@ namespace Microsoft.CST.OpenSource.Shared
                         var candidate = ExtractGitHubPackageURLs(repoCandidate).FirstOrDefault();
                         if (candidate != null)
                         {
-                            mapping.Add(candidate as PackageURL, 1.0F);
-                            
+                            mapping[candidate as PackageURL] = 1.0F;
                         }
                     }
                 }

--- a/src/oss-defog/DefoggerTool.cs
+++ b/src/oss-defog/DefoggerTool.cs
@@ -391,7 +391,18 @@ namespace Microsoft.CST.OpenSource
             var packageDownloader = new PackageDownloader(purl, destinationDirectory, doCaching);
             foreach (var directory in await packageDownloader.DownloadPackageLocalCopy(purl, false, true))
             {
-                AnalyzeDirectory(directory);
+                if (Directory.Exists(directory))
+                {
+                    AnalyzeDirectory(directory);
+                }
+                else if (File.Exists(directory))
+                {
+                    AnalyzeFile(directory);
+                }
+                else
+                {
+                    Logger.Warn("{0} is neither a directory nor a file.", directory);
+                }
             }
 
             packageDownloader.ClearPackageLocalCopyIfNoCaching();
@@ -718,7 +729,7 @@ namespace Microsoft.CST.OpenSource
 Usage: {TOOL_NAME} [options] package-url...
 
 positional arguments:
-  package-url                   package url to analyze (required, multiple allowed)
+  package-url                   package url to analyze (required, multiple allowed), or directory.
 
 {BaseProjectManager.GetCommonSupportedHelpText()}
 

--- a/src/oss-metadata/oss-metadata.csproj
+++ b/src/oss-metadata/oss-metadata.csproj
@@ -25,8 +25,4 @@
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.2.31" />
-  </ItemGroup>
 </Project>

--- a/src/oss-tests/DownloadTests.cs
+++ b/src/oss-tests/DownloadTests.cs
@@ -163,6 +163,8 @@ namespace Microsoft.CST.OpenSource.Tests
 
         [DataTestMethod]
         [DataRow("pkg:vsm/ms-vscode/PowerShell", "extension.vsixmanifest", 1)]
+        [DataRow("pkg:vsm/ms-vscode/PowerShell@2020.6.0", "extension.vsixmanifest", 1)]
+        [DataRow("pkg:vsm/liviuschera/noctis@10.39.1", "extension.vsixmanifest", 1)]
         public async Task VSM_Download_Version_Succeeds(string purl, string targetFilename, int expectedDirectoryCount)
         {
             await TestDownload(purl, targetFilename, expectedDirectoryCount);

--- a/src/oss-tests/FindSourceTests.cs
+++ b/src/oss-tests/FindSourceTests.cs
@@ -53,16 +53,21 @@ namespace Microsoft.CST.OpenSource.Tests
             outputBuilder.AppendOutput(sarifResults);
             string sarifJSON = outputBuilder.GetOutput();
             SarifLog sarif = JsonConvert.DeserializeObject<SarifLog>(sarifJSON);
-
             Assert.IsNotNull(sarif);
-            Assert.IsNotNull(sarif.Runs.FirstOrDefault().Tool.Driver.Name);
+
+            var sarifRun = sarif.Runs.FirstOrDefault();
+            Assert.IsNotNull(sarifRun?.Tool.Driver.Name);
+
             // make sure atleast one of the result repos match the actual one
             bool found = false;
-            foreach (var result in sarif.Runs.FirstOrDefault().Results)
+            if (sarifRun != null)
             {
-                if (result.Message.Text == targetResult)
+                foreach (var result in sarifRun.Results)
                 {
-                    found = true;
+                    if (result.Message.Text == targetResult)
+                    {
+                        found = true;
+                    }
                 }
             }
             Assert.IsTrue(found);


### PR DESCRIPTION
This PR fixes an issue related how to VSM files are pulled down. Since they include non-archive files, our assumptions failed, so this PR handles both directories and plain files.

This PR also fixes a minor bug in the find-source tool, which assumed that the same URL would only be found once on a page.