### PR TITLE
Add oss-find-domain-squats

### DIFF
--- a/src/OSSGadget.sln
+++ b/src/OSSGadget.sln
@@ -32,7 +32,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "oss-metadata", "oss-metadat
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "oss-find-squats", "oss-find-squats\oss-find-squats.csproj", "{23D17E08-9E95-4448-B75D-BABAF1F3C854}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "oss-diff", "oss-diff\oss-diff.csproj", "{17C9F321-8A49-4140-B009-AD476F959D42}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "oss-diff", "oss-diff\oss-diff.csproj", "{17C9F321-8A49-4140-B009-AD476F959D42}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "oss-find-domain-squats", "oss-find-domain-squats\oss-find-domain-squats.csproj", "{E8884AC4-638F-4513-A5BD-4650E19CE071}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -91,6 +93,10 @@ Global
 		{17C9F321-8A49-4140-B009-AD476F959D42}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{17C9F321-8A49-4140-B009-AD476F959D42}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{17C9F321-8A49-4140-B009-AD476F959D42}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E8884AC4-638F-4513-A5BD-4650E19CE071}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E8884AC4-638F-4513-A5BD-4650E19CE071}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E8884AC4-638F-4513-A5BD-4650E19CE071}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E8884AC4-638F-4513-A5BD-4650E19CE071}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/oss-find-domain-squats/FindDomainSquatsTool.cs
+++ b/src/oss-find-domain-squats/FindDomainSquatsTool.cs
@@ -1,0 +1,238 @@
+﻿using CommandLine;
+using CommandLine.Text;
+using Microsoft.CodeAnalysis.Sarif;
+using Microsoft.CST.OpenSource.Shared;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using SarifResult = Microsoft.CodeAnalysis.Sarif.Result;
+using System.IO;
+using System.Threading;
+using Microsoft.CST.OpenSource.FindSquats;
+using System.Net;
+using Pastel;
+using System.Drawing;
+using System.Text;
+using Whois;
+
+namespace Microsoft.CST.OpenSource.DomainSquats
+{
+    public class FindDomainSquatsTool : OSSGadget
+    {
+        /// <summary>
+        ///     Name of this tool.
+        /// </summary>
+        private const string TOOL_NAME = "oss-find-domain-squats";
+
+        /// <summary>
+        ///     Holds the version string, from the assembly.
+        /// </summary>
+        private static readonly string VERSION = typeof(FindSquats.FindSquatsTool).Assembly?.GetName().Version?.ToString() ?? string.Empty;
+
+        Generative gen { get; set; }
+
+        public class Options
+        {
+            [Usage()]
+            public static IEnumerable<Example> Examples
+            {
+                get
+                {
+                    return new List<Example>() {
+                            new Example("Find Squat Candidates for the Given Packages",
+                            new Options { Targets = new List<string>() {"[options]", "domains" } })};
+                }
+            }
+
+            [Option('o', "output-file", Required = false, Default = "",
+                HelpText = "send the command output to a file instead of stdout")]
+            public string OutputFile { get; set; } = "";
+
+            [Option('f', "format", Required = false, Default = "text",
+                HelpText = "selct the output format(text|sarifv1|sarifv2)")]
+            public string Format { get; set; } = "text";
+
+            [Option('q', "quiet", Required = false, Default = false,
+                HelpText = "Suppress console output.")]
+            public bool Quiet { get; set; } = false;
+
+            [Option('s', "sleep-delay", Required = false, Default = 0, HelpText = "Number of ms to sleep between checks.")]
+            public int SleepDelay { get; set; }
+
+            [Option('u', "unregistered", Required = false, Default = false, HelpText = "Don't show registered domains.")]
+            public bool Unregistered { get; set; }
+
+            [Option('r', "registered", Required = false, Default = false, HelpText = "Don't show unregistered domains.")]
+            public bool Registered { get; set; }
+
+            [Value(0, Required = true,
+                HelpText = "Domain(s) specifier to analyze (required, repeats OK)", Hidden = true)] // capture all targets to analyze
+            public IEnumerable<string>? Targets { get; set; }
+        }
+
+        public FindDomainSquatsTool() : base()
+        {
+            gen = new Generative();
+        }
+
+        HttpClient client;
+        static async Task Main(string[] args)
+        {
+            var findSquatsTool = new FindDomainSquatsTool();
+            (string output, int numRegisteredSquats, int numUnregisteredSquats) = (string.Empty, 0, 0);
+            await findSquatsTool.ParseOptions<Options>(args).WithParsedAsync<Options>(findSquatsTool.RunAsync);
+        }
+
+        public async Task<(string output, int registeredSquats, int unregisteredSquats)> RunAsync(Options options)
+        {
+            IOutputBuilder outputBuilder = SelectFormat(options.Format);
+            var registeredSquats = 0;
+            var unregisteredSquats = 0;
+            var whois = new WhoisLookup();
+            foreach (var target in options.Targets ?? Array.Empty<string>())
+            {
+                var splits = target.Split('.');
+                var potentials = gen.Mutate(splits[0]);
+                foreach (var potential in potentials)
+                {
+                    if (Uri.IsWellFormedUriString(potential.Key, UriKind.Relative){
+                        var urlBuilder = new StringBuilder();
+                        urlBuilder.Append(potential.Key);
+                        for (int i = 1; i < splits.Length; i++)
+                        {
+                            urlBuilder.Append($".{splits[i]}");
+                        }
+
+                        var url = urlBuilder.ToString();
+
+                        try
+                        {
+                            var response = await whois.LookupAsync(url);
+                            if (response.Registered is DateTime)
+                            {
+                                registeredSquats++;
+
+                                if (!options.Unregistered)
+                                {
+                                    Logger.Info($"Found {url} as a registered domain.".Pastel(Color.MediumAquamarine));
+                                    switch (outputBuilder)
+                                    {
+                                        case StringOutputBuilder s:
+                                            s.AppendOutput(new string[] { $"{url} is registered." });
+                                            break;
+                                        case SarifOutputBuilder sarif:
+                                            SarifResult sarifResult = new SarifResult()
+                                            {
+                                                Message = new Message()
+                                                {
+                                                    Text = $"Potential Squat candidate { url }.",
+                                                    Id = "oss-find-domain-squats"
+                                                },
+                                                Kind = ResultKind.Review,
+                                                Level = FailureLevel.None,
+                                            };
+                                            foreach (var tag in potential.Value)
+                                            {
+                                                sarifResult.Tags.Add(tag);
+                                            }
+                                            sarif.AppendOutput(new SarifResult[] { sarifResult });
+                                            break;
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                unregisteredSquats++;
+
+                                if (!options.Registered)
+                                {
+                                    Logger.Info($"Found {url} as an unregistered domain.".Pastel(Color.LightGoldenrodYellow));
+
+                                    switch (outputBuilder)
+                                    {
+                                        case StringOutputBuilder s:
+
+                                            s.AppendOutput(new string[] { $"{url} is not registered." });
+                                            break;
+                                        case SarifOutputBuilder sarif:
+                                            SarifResult sarifResult = new SarifResult()
+                                            {
+                                                Message = new Message()
+                                                {
+                                                    Text = $"Squat candidate { url } is not registered.",
+                                                    Id = "oss-find-domain-squats"
+                                                },
+                                                Kind = ResultKind.Review,
+                                                Level = FailureLevel.None,
+                                            };
+                                            foreach (var tag in potential.Value)
+                                            {
+                                                sarifResult.Tags.Add(tag);
+                                            }
+                                            sarif.AppendOutput(new SarifResult[] { sarifResult });
+                                            break;
+                                    }
+                                }
+                            }
+                        }
+                        catch (Exception e)
+                        {
+
+                            unregisteredSquats++;
+                            if (!options.Registered)
+                            {
+                                Logger.Info($"Found {url} as an unregistered domain.".Pastel(Color.LightGoldenrodYellow));
+
+                                switch (outputBuilder)
+                                {
+                                    case StringOutputBuilder s:
+                                        s.AppendOutput(new string[] { $"{url} is not registered." });
+                                        break;
+                                    case SarifOutputBuilder sarif:
+                                        SarifResult sarifResult = new SarifResult()
+                                        {
+                                            Message = new Message()
+                                            {
+                                                Text = $"Squat candidate { url } is not registered.",
+                                                Id = "oss-find-domain-squats"
+                                            },
+                                            Kind = ResultKind.Review,
+                                            Level = FailureLevel.None,
+                                        };
+                                        foreach (var tag in potential.Value)
+                                        {
+                                            sarifResult.Tags.Add(tag);
+                                        }
+                                        sarif.AppendOutput(new SarifResult[] { sarifResult });
+                                        break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            if (string.IsNullOrEmpty(options.OutputFile))
+            {
+                options.OutputFile = $"oss-find-domain-squat.{options.Format}";
+            }
+            if (!options.Quiet)
+            {
+                if (registeredSquats > 0 || unregisteredSquats > 0)
+                {
+                    Logger.Warn($"Found {registeredSquats} registered potential squats amd {unregisteredSquats} unregistered potential squats.");
+                }
+                else
+                {
+                    Logger.Info($"No squats detected.");
+                }
+            }
+            using var fw = new StreamWriter(options.OutputFile);
+            var outString = outputBuilder.GetOutput();
+            fw.WriteLine();
+            fw.Close();
+            return (outString, registeredSquats, unregisteredSquats);
+        }
+    }
+}

--- a/src/oss-find-domain-squats/FindDomainSquatsTool.cs
+++ b/src/oss-find-domain-squats/FindDomainSquatsTool.cs
@@ -109,6 +109,7 @@ namespace Microsoft.CST.OpenSource.DomainSquats
 
                         try
                         {
+                            Thread.Sleep(options.SleepDelay);
                             var response = await whois.LookupAsync(url);
                             if (response.Registered is DateTime)
                             {

--- a/src/oss-find-domain-squats/FindDomainSquatsTool.cs
+++ b/src/oss-find-domain-squats/FindDomainSquatsTool.cs
@@ -97,7 +97,8 @@ namespace Microsoft.CST.OpenSource.DomainSquats
                 var potentials = gen.Mutate(splits[0]);
                 foreach (var potential in potentials)
                 {
-                    if (Uri.IsWellFormedUriString(potential.Key, UriKind.Relative){
+                    if (Uri.IsWellFormedUriString(potential.Key, UriKind.Relative))
+                    {
                         var urlBuilder = new StringBuilder();
                         urlBuilder.Append(potential.Key);
                         for (int i = 1; i < splits.Length; i++)

--- a/src/oss-find-domain-squats/oss-find-domain-squats.csproj
+++ b/src/oss-find-domain-squats/oss-find-domain-squats.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+    <RootNamespace>Microsoft.CST.OpenSource.FindDomainSquats</RootNamespace>
+    <Nullable>enable</Nullable>
+    <LangVersion>9.0</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Pastel" Version="2.1.0" />
+    <PackageReference Include="Whois" Version="3.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\oss-find-squats\oss-find-squats.csproj" />
+    <ProjectReference Include="..\Shared\Shared.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/oss-find-squats/FindSquatsTool.cs
+++ b/src/oss-find-squats/FindSquatsTool.cs
@@ -6,15 +6,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
-using System.Reflection;
 using System.Threading.Tasks;
-using Microsoft.CST.OpenSource.FindSquats;
 using SarifResult = Microsoft.CodeAnalysis.Sarif.Result;
-using Scriban.Runtime;
 using System.IO;
 using System.Threading;
 
-namespace Microsoft.CST.OpenSource
+namespace Microsoft.CST.OpenSource.FindSquats
 {
     public class FindSquatsTool : OSSGadget
     {

--- a/src/oss-find-squats/Generative.cs
+++ b/src/oss-find-squats/Generative.cs
@@ -246,7 +246,8 @@ namespace Microsoft.CST.OpenSource.FindSquats
 
                 foreach (var c in n)
                 {
-                    yield return (string.Concat(arg.Substring(0, i), c, arg.Substring(i)), "double hit close letters on keymap");
+                    yield return (string.Concat(arg[0..i], c, arg[i..]), "double hit close letters on keyboard.");
+                    yield return (string.Concat(arg[0..(i+1)], c, arg[(i+1)..]), "double hit close letters on keyboard");
                 }
             }
         }

--- a/src/oss-find-squats/Generative.cs
+++ b/src/oss-find-squats/Generative.cs
@@ -246,8 +246,8 @@ namespace Microsoft.CST.OpenSource.FindSquats
 
                 foreach (var c in n)
                 {
-                    yield return (string.Concat(arg[0..i], c, arg[i..]), "double hit close letters on keyboard.");
-                    yield return (string.Concat(arg[0..(i+1)], c, arg[(i+1)..]), "double hit close letters on keyboard");
+                    yield return (string.Concat(arg[0..i], c, arg[i..]), "double hit close letters on keyboard");
+                    yield return (string.Concat(arg[0..(i + 1)], c, arg[(i + 1)..]), "double hit close letters on keyboard");
                 }
             }
         }
@@ -342,10 +342,17 @@ namespace Microsoft.CST.OpenSource.FindSquats
 
         private IEnumerable<(string, string)> _duplicateEach(string arg)
         {
+            for(int i = 0; i < arg.Length; i++)
+            {
+                yield return (string.Concat(arg[0..i], arg[i], arg[i..]), "letter duplicated");
+            }
+
             for (int i = 0; i < arg.Length - 2; i++)
             {
-                yield return (arg.Substring(0, i + 1) + arg[i].ToString() + arg.Substring(i + 2), "letter duplicated");
+                yield return (string.Concat(arg[0..(i+1)], arg[i], arg[(i+2)..]), "letter duplicated and replaced");
             }
+
+            yield return (string.Concat(arg[0..arg.Length], arg[arg.Length-1]), "letter duplicated and replaced");
         }
 
         private IEnumerable<(string, string)> _bitFlips(string arg)

--- a/src/oss-find-squats/oss-find-squats.csproj
+++ b/src/oss-find-squats/oss-find-squats.csproj
@@ -9,7 +9,6 @@
     <Authors>Gabe Stocco</Authors>
     <RepositoryType>GitHub</RepositoryType>
     <RepositoryUrl>https://github.com/Microsoft/OSSGadget</RepositoryUrl>
-    <StartupObject>Microsoft.CST.OpenSource.FindSquatsTool</StartupObject>
     <Configurations>Debug;Release</Configurations>
     <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>

--- a/src/oss-tests/FindSquatsTests.cs
+++ b/src/oss-tests/FindSquatsTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.CST.OpenSource;
+using Microsoft.CST.OpenSource.FindSquats;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.IO;

--- a/src/oss-tests/FindSquatsTests.cs
+++ b/src/oss-tests/FindSquatsTests.cs
@@ -12,6 +12,7 @@ namespace Microsoft.CST.OpenSource.Tests
         }
 
         [DataTestMethod]
+        [DataRow("pkg:nuget/Microsoft.CST.OAT", false)]
         [DataRow("pkg:npm/microsoft/microsoft-graph-library", false)]
         [DataRow("pkg:npm/foo", true)]
         public async Task DetectSquats(string packageUrl, bool expectedToHaveSquats)

--- a/src/oss-tests/FindSquatsTests.cs
+++ b/src/oss-tests/FindSquatsTests.cs
@@ -1,30 +1,19 @@
-﻿using Microsoft.CST.OpenSource;
-using Microsoft.CST.OpenSource.FindSquats;
+﻿using Microsoft.CST.OpenSource.FindSquats;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
 using System.Threading.Tasks;
-using System.Windows.Markup;
 
 namespace Microsoft.CST.OpenSource.Tests
 {
     [TestClass]
     public class FindSquatsTest
     {
-        string decoded = "The quick brown fox jumped over the lazy dog.";
-
         public FindSquatsTest()
         {
         }
 
         [DataTestMethod]
-        [DataRow("pkg:nuget/Microsoft.CST.OAT", false)]
         [DataRow("pkg:npm/microsoft/microsoft-graph-library", false)]
         [DataRow("pkg:npm/foo", true)]
-
         public async Task DetectSquats(string packageUrl, bool expectedToHaveSquats)
         {
             var fst = new FindSquatsTool();

--- a/src/oss-tests/oss-tests.csproj
+++ b/src/oss-tests/oss-tests.csproj
@@ -8,18 +8,22 @@
     <Nullable>Enable</Nullable>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="DiscUtils.Btrfs" Version="0.15.1-ci0002" />
     <PackageReference Include="DiscUtils.HfsPlus" Version="0.15.1-ci0002" />
     <PackageReference Include="DiscUtils.SquashFs" Version="0.15.1-ci0002" />
     <PackageReference Include="DiscUtils.Xfs" Version="0.15.1-ci0002" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.1" />
     <PackageReference Include="coverlet.collector" Version="3.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.1" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" />
   </ItemGroup>
 


### PR DESCRIPTION
Checks all the typo/bitflip squats for a given domain name "i.e. microsoft.com".  Separates results into three categories.

1. Domains Registered to the same organization
2. Domains registered to other organizations
3. Domains not registered

Future work: currently I'm passing tuples, we could change those to be richer objects which contain more metadata about each whois.