### PR TITLE
Add RuntimeIdentifiers to each project.

### DIFF
--- a/Pipelines/core-pipeline.yml
+++ b/Pipelines/core-pipeline.yml
@@ -29,7 +29,7 @@ stages:
   - template: templates/dotnet-test-job.yml
     parameters:
       projectPath: 'src/oss-tests/oss-tests.csproj'
-      arguments: '--runtime linux-x64'
+      arguments: '--runtime win-x64'
 
 - stage: SDL
   dependsOn: Test

--- a/Pipelines/core-pipeline.yml
+++ b/Pipelines/core-pipeline.yml
@@ -29,6 +29,7 @@ stages:
   - template: templates/dotnet-test-job.yml
     parameters:
       projectPath: 'src/oss-tests/oss-tests.csproj'
+      arguments: '--runtime linux-x64'
 
 - stage: SDL
   dependsOn: Test

--- a/Pipelines/core-pipeline.yml
+++ b/Pipelines/core-pipeline.yml
@@ -53,6 +53,7 @@ stages:
       projectName: 'OSSGadget'
       preBuild:
       - template: templates/nbgv-set-version-steps.yml
+      buildArguments: '-p:SelfContained=false -p:PublishSingleFile=false'
 
 - stage: Release
   dependsOn:

--- a/Pipelines/core-pipeline.yml
+++ b/Pipelines/core-pipeline.yml
@@ -64,7 +64,7 @@ stages:
   - job: sign_hash_release
     displayName: Code Sign, Generate Hashes, Publish Public Releases
     pool:
-      vmImage: 'windows-latest'
+      vmImage: 'ubuntu-latest'
     steps:
     - task: UseDotNet@2
       inputs:
@@ -79,16 +79,29 @@ stages:
           $version = (nbgv get-version -v AssemblyInformationalVersion).split('+')[0]
           Write-Host "##vso[task.setvariable variable=ReleaseVersion;]$version"
     - task: DownloadBuildArtifacts@0
-      displayName: Download Unsigned Archives
+      displayName: Download Unsigned Win/Netcoreapp Archives
       inputs:
         buildType: 'current'
         downloadType: 'specific'
         itemPattern: 'Unsigned_Binaries/*.zip'
         downloadPath: '$(Build.BinariesDirectory)'
+    - task: DownloadBuildArtifacts@0
+      displayName: Download Unsigned Nix Archives
+      inputs:
+        buildType: 'current'
+        downloadType: 'specific'
+        itemPattern: 'Unsigned_Binaries/*.tar.gz'
+        downloadPath: '$(Build.BinariesDirectory)'
     - task: ExtractFiles@1
-      displayName: Extract Artifacts for Signing
+      displayName: Extract Win/Netcoreapp Artifacts for Signing
       inputs:
         archiveFilePatterns: '$(Build.BinariesDirectory)\Unsigned_Binaries\*.zip'
+        destinationFolder: '$(Build.BinariesDirectory)'
+        cleanDestinationFolder: false
+    - task: ExtractFiles@1
+      displayName: Extract Nix Artifacts for Signing
+      inputs:
+        archiveFilePatterns: '$(Build.BinariesDirectory)\Unsigned_Binaries\*.tar.gz'
         destinationFolder: '$(Build.BinariesDirectory)'
         cleanDestinationFolder: false
     - task: AntiMalware@3
@@ -245,16 +258,16 @@ stages:
       inputs:
         rootFolderOrFile: '$(Build.BinariesDirectory)/linux/OSSGadget_linux_$(ReleaseVersion)'
         includeRootFolder: true
-        archiveType: 'zip'
-        archiveFile: '$(Build.StagingDirectory)/OSSGadget_linux_$(ReleaseVersion).zip'
+        archiveType: 'tar'
+        archiveFile: '$(Build.StagingDirectory)/OSSGadget_linux_$(ReleaseVersion).tar.gz'
         replaceExistingArchive: true
     - task: ArchiveFiles@2
       displayName: Archive Artifact - MacOS
       inputs:
         rootFolderOrFile: '$(Build.BinariesDirectory)/macos/OSSGadget_macos_$(ReleaseVersion)'
         includeRootFolder: true
-        archiveType: 'zip'
-        archiveFile: '$(Build.StagingDirectory)/OSSGadget_macos_$(ReleaseVersion).zip'
+        archiveType: 'tar'
+        archiveFile: '$(Build.StagingDirectory)/OSSGadget_macos_$(ReleaseVersion).tar.gz'
         replaceExistingArchive: true
     - task: ArchiveFiles@2
       displayName: Archive Artifact - Windows
@@ -298,6 +311,7 @@ stages:
         tag: 'v$(ReleaseVersion)'
         title: 'OSS Gadget v$(ReleaseVersion)'
         assets: |
+          $(Build.StagingDirectory)/*.tar.gz
           $(Build.StagingDirectory)/*.zip
           $(Build.StagingDirectory)/HASHES.txt
         changeLogCompareToRelease: 'lastNonDraftRelease'

--- a/Pipelines/core-pipeline.yml
+++ b/Pipelines/core-pipeline.yml
@@ -111,7 +111,7 @@ stages:
       inputs:
         ConnectedServiceName: 'OSSGadget_CodeSign'
         FolderPath: '$(Build.BinariesDirectory)/linux/OSSGadget_linux_$(ReleaseVersion)'
-        Pattern: 'oss-characteristic.dll, oss-defog.dll, oss-detect-backdoor.dll, oss-download.dll, oss-find-source.dll, oss-health.dll, RecursiveExtractor.dll'
+        Pattern: 'oss-characteristic.dll, oss-defog.dll, oss-detect-backdoor.dll, oss-detect-cryptography.dll, oss-diff.dll, oss-download.dll, oss-find-domain-squats.dll, oss-find-source.dll, oss-find-squats.dll, oss-health.dll, oss-metadata.dll, oss-risk-calculator.dll, Shared.dll'
         signConfigType: 'inlineSignParams'
         inlineOperation: |
           [
@@ -144,7 +144,7 @@ stages:
       inputs:
         ConnectedServiceName: 'OSSGadget_CodeSign'
         FolderPath: '$(Build.BinariesDirectory)/macos/OSSGadget_macos_$(ReleaseVersion)'
-        Pattern: 'oss-characteristic.dll, oss-defog.dll, oss-detect-backdoor.dll, oss-download.dll, oss-find-source.dll, oss-health.dll, RecursiveExtractor.dll'
+        Pattern: 'oss-characteristic.dll, oss-defog.dll, oss-detect-backdoor.dll, oss-detect-cryptography.dll, oss-diff.dll, oss-download.dll, oss-find-domain-squats.dll, oss-find-source.dll, oss-find-squats.dll, oss-health.dll, oss-metadata.dll, oss-risk-calculator.dll, Shared.dll'
         signConfigType: 'inlineSignParams'
         inlineOperation: |
           [
@@ -177,7 +177,7 @@ stages:
       inputs:
         ConnectedServiceName: 'OSSGadget_CodeSign'
         FolderPath: '$(Build.BinariesDirectory)/win/OSSGadget_win_$(ReleaseVersion)'
-        Pattern: 'oss-characteristic.exe, oss-characteristic.dll, oss-defog.exe, oss-defog.dll, oss-detect-backdoor.exe, oss-detect-backdoor.dll, oss-download.exe, oss-download.dll, oss-find-source.exe, oss-find-source.dll, oss-health.exe, oss-health.dll, RecursiveExtractor.dll'
+        Pattern: 'oss-characteristic.dll, oss-defog.dll, oss-detect-backdoor.dll, oss-detect-cryptography.dll, oss-diff.dll, oss-download.dll, oss-find-domain-squats.dll, oss-find-source.dll, oss-find-squats.dll, oss-health.dll, oss-metadata.dll, oss-risk-calculator.dll, Shared.dll'
         signConfigType: 'inlineSignParams'
         inlineOperation: |
           [
@@ -210,7 +210,7 @@ stages:
       inputs:
         ConnectedServiceName: 'OSSGadget_CodeSign'
         FolderPath: '$(Build.BinariesDirectory)/netcoreapp/OSSGadget_netcoreapp_$(ReleaseVersion)'
-        Pattern: 'oss-characteristic.exe, oss-characteristic.dll, oss-defog.exe, oss-defog.dll, oss-detect-backdoor.exe, oss-detect-backdoor.dll, oss-download.exe, oss-download.dll, oss-find-source.exe, oss-find-source.dll, oss-health.exe, oss-health.dll, RecursiveExtractor.dll'
+        Pattern: 'oss-characteristic.dll, oss-defog.dll, oss-detect-backdoor.dll, oss-detect-cryptography.dll, oss-diff.dll, oss-download.dll, oss-find-domain-squats.dll, oss-find-source.dll, oss-find-squats.dll, oss-health.dll, oss-metadata.dll, oss-risk-calculator.dll, Shared.dll'
         signConfigType: 'inlineSignParams'
         inlineOperation: |
           [

--- a/Pipelines/templates/dotnet-publish-linux-mac-job.yml
+++ b/Pipelines/templates/dotnet-publish-linux-mac-job.yml
@@ -81,8 +81,8 @@ jobs:
     inputs:
       rootFolderOrFile: 'bin'
       includeRootFolder: false
-      archiveType: 'zip'
-      archiveFile: 'Archives/${{ parameters.projectName }}_Nix.zip'
+      archiveType: 'tar'
+      archiveFile: 'Archives/${{ parameters.projectName }}_Nix.tar.gz'
       replaceExistingArchive: true
   - task: PublishBuildArtifacts@1
     displayName: Pipeline Publish Archive

--- a/Pipelines/templates/dotnet-publish-win-netcore-job.yml
+++ b/Pipelines/templates/dotnet-publish-win-netcore-job.yml
@@ -39,6 +39,14 @@ parameters:
 - name: artifactName
   type: string
   default: 'Unsigned_Binaries'
+# Additional 'dotnet publish' arguments
+- name: publishArguments
+  type: string
+  default: ''
+# Additional 'dotnet build' arguments
+- name: buildArguments
+  type: string
+  default: ''
 
 jobs:
 - job: ${{ parameters.jobName }}
@@ -67,14 +75,14 @@ jobs:
     displayName: Publish Win x64
     inputs:
       command: 'publish'
-      arguments: '${{ parameters.projectPath }} -c ${{ parameters.buildConfiguration }} -o bin/win/${{ parameters.projectName }}_win_$(ReleaseVersion) -r win-x64'
+      arguments: '${{ parameters.projectPath }} -c ${{ parameters.buildConfiguration }} -o bin/win/${{ parameters.projectName }}_win_$(ReleaseVersion) -r win-x64 ${{ parameters.publishArguments }}'
       publishWebProjects: false
       zipAfterPublish: false
   - task: DotNetCoreCLI@2
     displayName: Build .NET Core App
     inputs:
       command: 'build'
-      arguments: '${{ parameters.projectPath }} -c ${{ parameters.buildConfiguration }} -o bin/netcoreapp/${{ parameters.projectName }}_netcoreapp_$(ReleaseVersion)'
+      arguments: '${{ parameters.projectPath }} -c ${{ parameters.buildConfiguration }} -o bin/netcoreapp/${{ parameters.projectName }}_netcoreapp_$(ReleaseVersion) ${{ parameters.buildArguments }}'
       publishWebProjects: false
       zipAfterPublish: false
   - task: AntiMalware@3

--- a/Pipelines/templates/dotnet-test-job.yml
+++ b/Pipelines/templates/dotnet-test-job.yml
@@ -15,6 +15,10 @@ parameters:
 - name: projectPath
   type: string
   default: ''
+# Additional 'dotnet test' arguments
+- name: arguments
+  type: string
+  default: ''
 
 jobs:
 - job: ${{ parameters.jobName }}
@@ -39,3 +43,4 @@ jobs:
     inputs:
       command: 'test'
       projects: ${{ parameters.projectPath }}
+      arguments: ${{ parameters.arguments }}

--- a/src/Shared/Shared.csproj
+++ b/src/Shared/Shared.csproj
@@ -12,6 +12,7 @@
     <AssemblyName>Shared</AssemblyName>
     <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
+    <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Shared/Shared.csproj
+++ b/src/Shared/Shared.csproj
@@ -13,6 +13,8 @@
     <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Shared/Shared.csproj
+++ b/src/Shared/Shared.csproj
@@ -13,7 +13,6 @@
     <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
-    <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
   </PropertyGroup>
 

--- a/src/oss-characteristics/oss-characteristic.csproj
+++ b/src/oss-characteristics/oss-characteristic.csproj
@@ -13,6 +13,7 @@
     <Configurations>Debug;Release</Configurations>
     <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
+    <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/oss-characteristics/oss-characteristic.csproj
+++ b/src/oss-characteristics/oss-characteristic.csproj
@@ -14,7 +14,6 @@
     <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
-    <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
   </PropertyGroup>
 

--- a/src/oss-characteristics/oss-characteristic.csproj
+++ b/src/oss-characteristics/oss-characteristic.csproj
@@ -14,6 +14,8 @@
     <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/oss-defog/oss-defog.csproj
+++ b/src/oss-defog/oss-defog.csproj
@@ -13,6 +13,7 @@
     <Configurations>Debug;Release</Configurations>
     <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
+    <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/oss-defog/oss-defog.csproj
+++ b/src/oss-defog/oss-defog.csproj
@@ -14,6 +14,9 @@
     <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
+    <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/oss-defog/oss-defog.csproj
+++ b/src/oss-defog/oss-defog.csproj
@@ -14,7 +14,6 @@
     <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
-    <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
   </PropertyGroup>
 

--- a/src/oss-defog/oss-defog.csproj
+++ b/src/oss-defog/oss-defog.csproj
@@ -16,7 +16,6 @@
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
-    <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/oss-detect-backdoor/oss-detect-backdoor.csproj
+++ b/src/oss-detect-backdoor/oss-detect-backdoor.csproj
@@ -13,6 +13,7 @@
     <Configurations>Debug;Release</Configurations>
     <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
+    <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/oss-detect-backdoor/oss-detect-backdoor.csproj
+++ b/src/oss-detect-backdoor/oss-detect-backdoor.csproj
@@ -14,6 +14,9 @@
     <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
+    <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/oss-detect-backdoor/oss-detect-backdoor.csproj
+++ b/src/oss-detect-backdoor/oss-detect-backdoor.csproj
@@ -14,7 +14,6 @@
     <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
-    <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
   </PropertyGroup>
 

--- a/src/oss-detect-backdoor/oss-detect-backdoor.csproj
+++ b/src/oss-detect-backdoor/oss-detect-backdoor.csproj
@@ -16,7 +16,6 @@
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
-    <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/oss-detect-cryptography/oss-detect-cryptography.csproj
+++ b/src/oss-detect-cryptography/oss-detect-cryptography.csproj
@@ -12,6 +12,7 @@
     <StartupObject>Microsoft.CST.OpenSource.DetectCryptographyTool</StartupObject>
     <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
+    <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/oss-detect-cryptography/oss-detect-cryptography.csproj
+++ b/src/oss-detect-cryptography/oss-detect-cryptography.csproj
@@ -13,6 +13,8 @@
     <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/oss-detect-cryptography/oss-detect-cryptography.csproj
+++ b/src/oss-detect-cryptography/oss-detect-cryptography.csproj
@@ -13,7 +13,6 @@
     <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
-    <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
   </PropertyGroup>
 

--- a/src/oss-diff/oss-diff.csproj
+++ b/src/oss-diff/oss-diff.csproj
@@ -9,7 +9,6 @@
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
-    <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/oss-diff/oss-diff.csproj
+++ b/src/oss-diff/oss-diff.csproj
@@ -7,6 +7,9 @@
     <Nullable>enable</Nullable>
     <LangVersion>9.0</LangVersion>
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
+    <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/oss-diff/oss-diff.csproj
+++ b/src/oss-diff/oss-diff.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>Microsoft.CST.OpenSource</RootNamespace>
     <Nullable>enable</Nullable>
     <LangVersion>9.0</LangVersion>
+    <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/oss-diff/oss-diff.csproj
+++ b/src/oss-diff/oss-diff.csproj
@@ -7,7 +7,6 @@
     <Nullable>enable</Nullable>
     <LangVersion>9.0</LangVersion>
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
-    <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
   </PropertyGroup>
 

--- a/src/oss-download/oss-download.csproj
+++ b/src/oss-download/oss-download.csproj
@@ -12,6 +12,7 @@
     <StartupObject>Microsoft.CST.OpenSource.DownloadTool</StartupObject>
     <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
+    <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/oss-download/oss-download.csproj
+++ b/src/oss-download/oss-download.csproj
@@ -15,7 +15,6 @@
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
-    <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/oss-download/oss-download.csproj
+++ b/src/oss-download/oss-download.csproj
@@ -13,6 +13,9 @@
     <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
+    <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/oss-download/oss-download.csproj
+++ b/src/oss-download/oss-download.csproj
@@ -13,7 +13,6 @@
     <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
-    <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
   </PropertyGroup>
 

--- a/src/oss-find-domain-squats/oss-find-domain-squats.csproj
+++ b/src/oss-find-domain-squats/oss-find-domain-squats.csproj
@@ -9,7 +9,6 @@
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
-    <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/oss-find-domain-squats/oss-find-domain-squats.csproj
+++ b/src/oss-find-domain-squats/oss-find-domain-squats.csproj
@@ -7,6 +7,9 @@
     <Nullable>enable</Nullable>
     <LangVersion>9.0</LangVersion>
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
+    <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/oss-find-domain-squats/oss-find-domain-squats.csproj
+++ b/src/oss-find-domain-squats/oss-find-domain-squats.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>Microsoft.CST.OpenSource.FindDomainSquats</RootNamespace>
     <Nullable>enable</Nullable>
     <LangVersion>9.0</LangVersion>
+    <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/oss-find-domain-squats/oss-find-domain-squats.csproj
+++ b/src/oss-find-domain-squats/oss-find-domain-squats.csproj
@@ -7,7 +7,6 @@
     <Nullable>enable</Nullable>
     <LangVersion>9.0</LangVersion>
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
-    <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
   </PropertyGroup>
 

--- a/src/oss-find-source/oss-find-source.csproj
+++ b/src/oss-find-source/oss-find-source.csproj
@@ -13,6 +13,7 @@
     <Configurations>Debug;Release</Configurations>
     <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
+    <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/oss-find-source/oss-find-source.csproj
+++ b/src/oss-find-source/oss-find-source.csproj
@@ -14,6 +14,9 @@
     <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
+    <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/oss-find-source/oss-find-source.csproj
+++ b/src/oss-find-source/oss-find-source.csproj
@@ -14,7 +14,6 @@
     <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
-    <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
   </PropertyGroup>
 

--- a/src/oss-find-source/oss-find-source.csproj
+++ b/src/oss-find-source/oss-find-source.csproj
@@ -16,7 +16,6 @@
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
-    <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/oss-find-squats/oss-find-squats.csproj
+++ b/src/oss-find-squats/oss-find-squats.csproj
@@ -13,6 +13,9 @@
     <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
+    <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/oss-find-squats/oss-find-squats.csproj
+++ b/src/oss-find-squats/oss-find-squats.csproj
@@ -12,6 +12,7 @@
     <Configurations>Debug;Release</Configurations>
     <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
+    <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/oss-find-squats/oss-find-squats.csproj
+++ b/src/oss-find-squats/oss-find-squats.csproj
@@ -15,7 +15,6 @@
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
-    <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/oss-find-squats/oss-find-squats.csproj
+++ b/src/oss-find-squats/oss-find-squats.csproj
@@ -13,7 +13,6 @@
     <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
-    <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
   </PropertyGroup>
 

--- a/src/oss-health/oss-health.csproj
+++ b/src/oss-health/oss-health.csproj
@@ -13,6 +13,7 @@
     <Configurations>Debug;Release</Configurations>
     <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
+    <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/oss-health/oss-health.csproj
+++ b/src/oss-health/oss-health.csproj
@@ -14,6 +14,9 @@
     <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
+    <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/oss-health/oss-health.csproj
+++ b/src/oss-health/oss-health.csproj
@@ -14,7 +14,6 @@
     <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
-    <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
   </PropertyGroup>
 

--- a/src/oss-health/oss-health.csproj
+++ b/src/oss-health/oss-health.csproj
@@ -16,7 +16,6 @@
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
-    <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/oss-metadata/oss-metadata.csproj
+++ b/src/oss-metadata/oss-metadata.csproj
@@ -14,7 +14,6 @@
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
-    <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/oss-metadata/oss-metadata.csproj
+++ b/src/oss-metadata/oss-metadata.csproj
@@ -12,7 +12,6 @@
     <RepositoryUrl>https://github.com/Microsoft/OSSGadget</RepositoryUrl>
     <RepositoryType>Github</RepositoryType>
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
-    <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
   </PropertyGroup>
 

--- a/src/oss-metadata/oss-metadata.csproj
+++ b/src/oss-metadata/oss-metadata.csproj
@@ -11,6 +11,7 @@
     <LangVersion>9.0</LangVersion>
     <RepositoryUrl>https://github.com/Microsoft/OSSGadget</RepositoryUrl>
     <RepositoryType>Github</RepositoryType>
+    <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/oss-metadata/oss-metadata.csproj
+++ b/src/oss-metadata/oss-metadata.csproj
@@ -12,6 +12,9 @@
     <RepositoryUrl>https://github.com/Microsoft/OSSGadget</RepositoryUrl>
     <RepositoryType>Github</RepositoryType>
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
+    <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/oss-risk-calculator/oss-risk-calculator.csproj
+++ b/src/oss-risk-calculator/oss-risk-calculator.csproj
@@ -13,6 +13,7 @@
     <Configurations>Debug;Release</Configurations>
     <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
+    <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/oss-risk-calculator/oss-risk-calculator.csproj
+++ b/src/oss-risk-calculator/oss-risk-calculator.csproj
@@ -14,6 +14,9 @@
     <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
+    <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/oss-risk-calculator/oss-risk-calculator.csproj
+++ b/src/oss-risk-calculator/oss-risk-calculator.csproj
@@ -14,7 +14,6 @@
     <LangVersion>9.0</LangVersion>
     <Nullable>Enable</Nullable>
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
-    <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
   </PropertyGroup>
 

--- a/src/oss-risk-calculator/oss-risk-calculator.csproj
+++ b/src/oss-risk-calculator/oss-risk-calculator.csproj
@@ -16,7 +16,6 @@
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
-    <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/oss-tests/oss-tests.csproj
+++ b/src/oss-tests/oss-tests.csproj
@@ -6,6 +6,7 @@
     <IsPackable>false</IsPackable>
     <LangVersion>8.0</LangVersion>
     <Nullable>Enable</Nullable>
+    <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/oss-tests/oss-tests.csproj
+++ b/src/oss-tests/oss-tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-
     <IsPackable>false</IsPackable>
     <LangVersion>8.0</LangVersion>
     <Nullable>Enable</Nullable>


### PR DESCRIPTION
This PR adds RuntimeIdentifiers to each project to enable self-contained cross-project publishing.

From [here](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-publish):

> --self-contained [true|false]
> 
> Publishes the .NET runtime with your application so the runtime doesn't need to be installed on the target machine. Default is true if a runtime identifier is specified and the project is an executable project (not a library project). For more information, see .NET application publishing and Publish .NET apps with the .NET CLI.
> 

More information in [dotnet/sdk#10902](https://github.com/dotnet/sdk/issues/10902).

This should fix #213.
