### PR TITLE
Fix _swapOrderOfLetters to not lose a letter

### DIFF
--- a/src/oss-find-squats/Generative.cs
+++ b/src/oss-find-squats/Generative.cs
@@ -221,7 +221,7 @@ namespace Microsoft.CST.OpenSource.FindSquats
 
             for (int i = 1; i < arg.Length - 1; i++)
             {
-                yield return (string.Concat(arg.Substring(0, i - 1), arg[i + 1], arg[i], arg.Substring(i + 2, arg.Length - (i + 2))), "letter swapped");
+                yield return (string.Concat(arg.Substring(0, i), arg[i + 1], arg[i], arg.Substring(i + 2, arg.Length - (i + 2))), "letter swapped");
             }
         }
 


### PR DESCRIPTION
I might be wrong, but it seems there is a mistake here.

The algorithm swaps `arg[i]` and `arg[i +1]`, but the first part of the resulting string is always missing a letter. I.e. it should be of length `i` not `i - 1`. Correct me if I'm wrong.

Please find examples below.

### Before the fix

`lodash`
```
doash ["letter swapped"]
ladsh ["letter swapped"]
losah ["letter swapped"]
lodhs ["letter swapped"]
```

`react-dom`
```
aect-dom ["letter swapped"]
rcat-dom ["letter swapped"]
retc-dom ["letter swapped"]
rea-tdom ["letter swapped"]
reacd-om ["letter swapped"]
reactodm ["letter swapped"]
react-mo ["letter swapped"]
```

### After the fix

`lodash`
```
ldoash ["letter swapped"]
loadsh ["letter swapped"]
lodsah ["letter swapped"]
lodahs ["letter swapped"]
```

`react-dom`
```
raect-dom ["letter swapped"]
recat-dom ["letter swapped"]
reatc-dom ["letter swapped"]
reac-tdom ["letter swapped"]
reactd-om ["letter swapped"]
react-odm ["letter swapped"]
react-dmo ["letter swapped"]
```

P.S. Would be really helpful to add tests for `Generative` class to catch such errors in future, and prevent any regressions in mutations algorithms. (_Unfortunately out of scope for me now_).