### PR TITLE
Make commands easier to run in Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+/.github/
+/.vs/
+/Pipelines/
+/.gitattributes
+/.gitignore
+/version.json
+/CodeMaid.config
+/*.md
+/*.png
+/*.svg
+/*.txt
+.editorconfig

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,19 @@
 FROM mcr.microsoft.com/dotnet/sdk:5.0
 COPY . /app/
 WORKDIR /app/src
-
-RUN dotnet build
+RUN set -o errexit -o nounset \
+    && dotnet build \
+    && ln --symbolic /app/src/oss-characteristics/bin/Debug/net5.0/oss-characteristic /usr/bin/oss-characteristic \
+    && ln --symbolic /app/src/oss-defog/bin/Debug/net5.0/oss-defog /usr/bin/oss-defog \
+    && ln --symbolic /app/src/oss-detect-backdoor/bin/Debug/net5.0/oss-detect-backdoor /usr/bin/oss-detect-backdoor \
+    && ln --symbolic /app/src/oss-detect-cryptography/bin/Debug/net5.0/oss-detect-cryptography /usr/bin/oss-detect-cryptography \
+    && ln --symbolic /app/src/oss-diff/bin/Debug/net5.0/oss-diff /usr/bin/oss-diff \
+    && ln --symbolic /app/src/oss-download/bin/Debug/net5.0/oss-download /usr/bin/oss-download \
+    && ln --symbolic /app/src/oss-find-domain-squats/bin/Debug/net5.0/oss-find-domain-squats /usr/bin/oss-find-domain-squats \
+    && ln --symbolic /app/src/oss-find-source/bin/Debug/net5.0/oss-find-source /usr/bin/oss-find-source \
+    && ln --symbolic /app/src/oss-find-squats/bin/Debug/net5.0/oss-find-squats /usr/bin/oss-find-squats \
+    && ln --symbolic /app/src/oss-health/bin/Debug/net5.0/oss-health /usr/bin/oss-health \
+    && ln --symbolic /app/src/oss-metadata/bin/Debug/net5.0/oss-metadata /usr/bin/oss-metadata \
+    && ln --symbolic /app/src/oss-risk-calculator/bin/Debug/net5.0/oss-risk-calculator /usr/bin/oss-risk-calculator
+# home directory of root user
+WORKDIR /root


### PR DESCRIPTION
This will allow a user to run a command with something as simple as `oss-download` instead of `./oss-download/bin/Debug/net5.0/oss-download`.

The [wiki page](https://github.com/microsoft/OSSGadget/wiki/Docker-Image) will also need updated to match. I suggest also adding `--rm` to the `run` command. Plus `latest` is the default anyway, so the command could just be ` docker run --rm -it ossgadget` (same as `build`, as far as that goes, i.e. ` docker build -t ossgadget .`).