### PR TITLE
Fix #245 (output to console on full path)

### DIFF
--- a/src/Shared/Helpers/OutputBuilder/SarifOutputBuilder.cs
+++ b/src/Shared/Helpers/OutputBuilder/SarifOutputBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.CodeAnalysis.Sarif;
+using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
@@ -15,11 +16,11 @@ namespace Microsoft.CST.OpenSource.Shared
 
         // default = text
         /// <summary>
-        ///     Build a SARIF Result.Location object for the purl package
+        /// Build a SARIF Result.Location object for the purl package
         /// </summary>
-        /// <param name="purl"> </param>
-        /// <returns> Location list with single location object </returns>
-        /// <returns> Location list with single location object </returns>
+        /// <param name="purl"></param>
+        /// <returns>Location list with single location object</returns>
+        /// <returns>Location list with single location object</returns>
         public static List<Location> BuildPurlLocation(PackageURL purl)
         {
             BaseProjectManager? projectManager = ProjectManagerFactory.CreateProjectManager(purl, null);
@@ -44,18 +45,18 @@ namespace Microsoft.CST.OpenSource.Shared
             };
         }
 
-        /// <summary> Adds the sarif results to the the Sarif Log. An incompatible object input will result in
-        /// InvalidCast exception </summary> <param name="output">An IEnumerable<Result> object of sarif
-        /// results </param>
+        /// <summary> Adds the sarif results to the the Sarif Log. An incompatible object input will
+        /// result in InvalidCast exception </summary> <param name="output">An IEnumerable<Result>
+        /// object of sarif results </param>
         public void AppendOutput(IEnumerable<object> output)
         {
             sarifResults.AddRange((IEnumerable<SarifResult>)output);
         }
 
         /// <summary>
-        ///     Builds a SARIF log object with the stored results
+        /// Builds a SARIF log object with the stored results
         /// </summary>
-        /// <returns> </returns>
+        /// <returns></returns>
         public SarifLog BuildSingleRunSarifLog()
         {
             Tool thisTool = new Tool
@@ -84,9 +85,9 @@ namespace Microsoft.CST.OpenSource.Shared
         }
 
         /// <summary>
-        ///     Gets the string representation of the sarif
+        /// Gets the string representation of the sarif
         /// </summary>
-        /// <returns> </returns>
+        /// <returns></returns>
         public string GetOutput()
         {
             SarifLog completedSarif = BuildSingleRunSarifLog();
@@ -104,7 +105,7 @@ namespace Microsoft.CST.OpenSource.Shared
         }
 
         /// <summary>
-        ///     Prints to the sarif output as string
+        /// Prints to the sarif output as string
         /// </summary>
         public void PrintOutput()
         {
@@ -112,7 +113,7 @@ namespace Microsoft.CST.OpenSource.Shared
         }
 
         /// <summary>
-        ///     Write the output to the given file. Creating directory if needed.
+        /// Write the output to the given file. Creating directory if needed.
         /// </summary>
         public void WriteOutput(string fileName)
         {
@@ -122,17 +123,20 @@ namespace Microsoft.CST.OpenSource.Shared
         }
 
         /// <summary>
-        ///     Print the whole SARIF log to the stream
+        /// Print the whole SARIF log to the stream.
         /// </summary>
-        /// <param name="writeStream"> </param>
+        /// <param name="writeStream">StreamWriter to write the SARIF result to.</param>
         public void PrintSarifLog(StreamWriter writeStream)
         {
             SarifLog completedSarif = BuildSingleRunSarifLog();
-            completedSarif.Save(writeStream);
+
+            var serializer = new JsonSerializer() { Formatting = Formatting.Indented };
+            using var writer = new JsonTextWriter(writeStream);
+            serializer.Serialize(writer, completedSarif);
         }
 
         /// <summary>
-        ///     Class logger
+        /// Class logger
         /// </summary>
         protected static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
 
@@ -141,8 +145,8 @@ namespace Microsoft.CST.OpenSource.Shared
         // cache variables to avoid reflection
         private static readonly string AssemblyName = Assembly.GetEntryAssembly()?.GetName().Name ?? string.Empty;
 
-        private static readonly string Company = Assembly.GetEntryAssembly()?.GetCustomAttribute<AssemblyCompanyAttribute>()?.Company ?? string.Empty;
-        private static readonly string Version = Assembly.GetEntryAssembly()?.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version.ToString() ?? string.Empty;
+        private static readonly string Company = "Microsoft Corporation";
+        private static readonly string Version = OSSGadget.GetToolVersion();
         private readonly SarifVersion currentSarifVersion = SarifVersion.Current;
         private List<Result> sarifResults = new List<Result>();
     }

--- a/src/Shared/OSSGadget.cs
+++ b/src/Shared/OSSGadget.cs
@@ -101,29 +101,22 @@ namespace Microsoft.CST.OpenSource
         /// <param name="outputFile"></param>
         protected void SelectOutput(string outputFile)
         {
-            // output to console or file?
-            this.redirectConsole = false;
+            // If outputFile is valid, then redirect output there.
             if (string.IsNullOrWhiteSpace(outputFile) ||
                 outputFile.IndexOfAny(Path.GetInvalidPathChars()) < 0 ||
                 Path.GetFileName(outputFile).IndexOfAny(Path.GetInvalidFileNameChars()) < 0)
             {
                 this.redirectConsole = true;
+                if (!ConsoleHelper.RedirectConsole(outputFile))
+                {
+                    Logger.Debug("Could not switch output from console to file");
+                    // continue with current output
+                }
             }
-
-            if (redirectConsole)
+            else
             {
-                if (outputFile is string outputLoc)
-                {
-                    if (!ConsoleHelper.RedirectConsole(outputLoc))
-                    {
-                        Logger.Debug("Could not switch output from console to file");
-                        // continue with current output
-                    }
-                }
-                else
-                {
-                    Logger.Debug("Invalid outputFile {0}. Switching to console.", outputFile);
-                }
+                this.redirectConsole = false;
+                Logger.Debug("Invalid file, {0}, writing to console instead.", outputFile);
             }
         }
 

--- a/src/Shared/OSSGadget.cs
+++ b/src/Shared/OSSGadget.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CST.OpenSource
                 h.AddPostOptionsLines(BaseProjectManager.GetCommonSupportedHelpTextLines());
                 return HelpText.DefaultParsingErrorsHandler(result, h);
             });
-            Console.Error.Write(helpText);
+            Console.Write(helpText);
         }
 
         /// <summary>
@@ -129,10 +129,10 @@ namespace Microsoft.CST.OpenSource
 
         public static void ShowToolBanner()
         {
-            Console.Error.WriteLine(OSSGadget.GetBanner());
+            Console.WriteLine(OSSGadget.GetBanner());
             var toolName = GetToolName();
             var toolVersion = GetToolVersion();
-            Console.Error.WriteLine($"OSS Gadget - {toolName} {toolVersion} - github.com/Microsoft/OSSGadget");
+            Console.WriteLine($"OSS Gadget - {toolName} {toolVersion} - github.com/Microsoft/OSSGadget");
         }
 
         /// <summary>

--- a/src/Shared/OSSGadget.cs
+++ b/src/Shared/OSSGadget.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CST.OpenSource
         }
 
         /// <summary>
-        /// Restores the output stream to Console, if it was changed to something else
+        /// Restores the output stream to Console, if it was changed to something else.
         /// </summary>
         protected void RestoreOutput()
         {
@@ -72,9 +72,9 @@ namespace Microsoft.CST.OpenSource
         }
 
         /// <summary>
-        /// Use the OutputBuilder to select the given format and return a output builder The format
+        /// Use the OutputBuilder to select the given format and return a output builder. The format
         /// should be compatible with one of the enum entries in OutputFormat text format will be
-        /// chosen, if the format is invalid
+        /// chosen, if the format is invalid.
         /// </summary>
         /// <param name="format"></param>
         /// <returns></returns>
@@ -95,15 +95,21 @@ namespace Microsoft.CST.OpenSource
         }
 
         /// <summary>
-        /// Change the tool output from the existing one to the passed in file If the outputFile is
-        /// not a valid filename, the output will be switched to Console
+        /// Change the tool output from the existing one to the passed in file. If the outputFile is
+        /// not a valid filename, the output will be switched to Console.
         /// </summary>
         /// <param name="outputFile"></param>
         protected void SelectOutput(string outputFile)
         {
             // output to console or file?
-            this.redirectConsole = !string.IsNullOrEmpty(outputFile) &&
-                outputFile.IndexOfAny(Path.GetInvalidFileNameChars()) < 0;
+            this.redirectConsole = false;
+            if (string.IsNullOrWhiteSpace(outputFile) ||
+                outputFile.IndexOfAny(Path.GetInvalidPathChars()) < 0 ||
+                Path.GetFileName(outputFile).IndexOfAny(Path.GetInvalidFileNameChars()) < 0)
+            {
+                this.redirectConsole = true;
+            }
+
             if (redirectConsole)
             {
                 if (outputFile is string outputLoc)
@@ -116,17 +122,17 @@ namespace Microsoft.CST.OpenSource
                 }
                 else
                 {
-                    Logger.Debug($"Invalid outputFile {outputFile}. Switching to console");
+                    Logger.Debug("Invalid outputFile {0}. Switching to console.", outputFile);
                 }
             }
         }
 
         public static void ShowToolBanner()
         {
-            Console.WriteLine(OSSGadget.GetBanner());
+            Console.Error.WriteLine(OSSGadget.GetBanner());
             var toolName = GetToolName();
             var toolVersion = GetToolVersion();
-            Console.WriteLine($"OSS Gadget - {toolName} {toolVersion} - github.com/Microsoft/OSSGadget");
+            Console.Error.WriteLine($"OSS Gadget - {toolName} {toolVersion} - github.com/Microsoft/OSSGadget");
         }
 
         /// <summary>

--- a/src/Shared/PackageManagers/BaseProjectManager.cs
+++ b/src/Shared/PackageManagers/BaseProjectManager.cs
@@ -13,14 +13,14 @@ using System.Net.Http;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Version = SemVer.Version;
+using Version = SemanticVersioning.Version;
 
 namespace Microsoft.CST.OpenSource.Shared
 {
     public class BaseProjectManager
     {
         /// <summary>
-        ///     Initializes a new project management object.
+        /// Initializes a new project management object.
         /// </summary>
         public BaseProjectManager(string destinationDirectory)
         {
@@ -39,20 +39,20 @@ namespace Microsoft.CST.OpenSource.Shared
         }
 
         /// <summary>
-        ///     Per-object option container.
+        /// Per-object option container.
         /// </summary>
         public Dictionary<string, object> Options { get; private set; }
 
         /// <summary>
-        ///     The location (directory) to extract files to.
+        /// The location (directory) to extract files to.
         /// </summary>
         public string TopLevelExtractionDirectory { get; set; } = ".";
 
         /// <summary>
-        ///     Extracts GitHub URLs from a given piece of text.
+        /// Extracts GitHub URLs from a given piece of text.
         /// </summary>
-        /// <param name="content"> text to analyze </param>
-        /// <returns> PackageURLs (type=GitHub) located in the text. </returns>
+        /// <param name="content">text to analyze</param>
+        /// <returns>PackageURLs (type=GitHub) located in the text.</returns>
         public static IEnumerable<PackageURL> ExtractGitHubPackageURLs(string content)
         {
             Logger.Trace("ExtractGitHubPackageURLs({0})", content?.Substring(0, 30));
@@ -127,10 +127,10 @@ The package-url specifier is described at https://github.com/package-url/purl-sp
         }
 
         /// <summary>
-        ///     Retrieves HTTP content from a given URI.
+        /// Retrieves HTTP content from a given URI.
         /// </summary>
-        /// <param name="uri"> URI to load. </param>
-        /// <returns> </returns>
+        /// <param name="uri">URI to load.</param>
+        /// <returns></returns>
         public static async Task<string?> GetHttpStringCache(string uri, bool useCache = true, bool neverThrow = false)
         {
             Logger.Trace("GetHttpStringCache({0}, {1})", uri, useCache);
@@ -176,10 +176,10 @@ The package-url specifier is described at https://github.com/package-url/purl-sp
         }
 
         /// <summary>
-        ///     Retrieves JSON content from a given URI.
+        /// Retrieves JSON content from a given URI.
         /// </summary>
-        /// <param name="uri"> URI to load. </param>
-        /// <returns> Content, as a JsonDocument, possibly from cache. </returns>
+        /// <param name="uri">URI to load.</param>
+        /// <returns>Content, as a JsonDocument, possibly from cache.</returns>
         public static async Task<JsonDocument> GetJsonCache(string uri, bool useCache = true)
         {
             Logger.Trace("GetJsonCache({0}, {1})", uri, useCache);
@@ -225,10 +225,10 @@ The package-url specifier is described at https://github.com/package-url/purl-sp
         }
 
         /// <summary>
-        ///     Downloads a given PackageURL and extracts it locally to a directory.
+        /// Downloads a given PackageURL and extracts it locally to a directory.
         /// </summary>
-        /// <param name="purl"> PackageURL to download </param>
-        /// <returns> Paths (either files or directory names) pertaining to the downloaded files. </returns>
+        /// <param name="purl">PackageURL to download</param>
+        /// <returns>Paths (either files or directory names) pertaining to the downloaded files.</returns>
         public virtual Task<IEnumerable<string>> DownloadVersion(PackageURL purl, bool doExtract, bool cached = false)
         {
             throw new NotImplementedException("BaseProjectManager does not implement DownloadVersion.");
@@ -240,12 +240,12 @@ The package-url specifier is described at https://github.com/package-url/purl-sp
         }
 
         /// <summary>
-        ///     Extracts an archive (given by 'bytes') into a directory named 'directoryName', recursively,
-        ///     using RecursiveExtractor.
+        /// Extracts an archive (given by 'bytes') into a directory named 'directoryName',
+        /// recursively, using RecursiveExtractor.
         /// </summary>
-        /// <param name="directoryName"> directory to extract content into (within TopLevelExtractionDirectory) </param>
-        /// <param name="bytes"> bytes to extract (should be an archive file) </param>
-        /// <returns> </returns>
+        /// <param name="directoryName">directory to extract content into (within TopLevelExtractionDirectory)</param>
+        /// <param name="bytes">bytes to extract (should be an archive file)</param>
+        /// <returns></returns>
         public async Task<string> ExtractArchive(string directoryName, byte[] bytes, bool cached = false)
         {
             Logger.Trace("ExtractArchive({0}, <bytes> len={1})", directoryName, bytes.Length);
@@ -300,10 +300,10 @@ The package-url specifier is described at https://github.com/package-url/purl-sp
         }
 
         /// <summary>
-        ///     Gets the latest version from the package metadata
+        /// Gets the latest version from the package metadata
         /// </summary>
-        /// <param name="metadata"> </param>
-        /// <returns> </returns>
+        /// <param name="metadata"></param>
+        /// <returns></returns>
         public Version? GetLatestVersion(JsonDocument? metadata)
         {
             List<Version> versions = GetVersions(metadata);
@@ -311,10 +311,10 @@ The package-url specifier is described at https://github.com/package-url/purl-sp
         }
 
         /// <summary>
-        ///     overload for getting the latest version
+        /// overload for getting the latest version
         /// </summary>
-        /// <param name="versions"> </param>
-        /// <returns> </returns>
+        /// <param name="versions"></param>
+        /// <returns></returns>
         public Version? GetLatestVersion(List<Version> versions)
         {
             if (versions?.Count > 0)
@@ -326,10 +326,11 @@ The package-url specifier is described at https://github.com/package-url/purl-sp
         }
 
         /// <summary>
-        ///     This method should return text reflecting metadata for the given package. There is no assumed format.
+        /// This method should return text reflecting metadata for the given package. There is no
+        /// assumed format.
         /// </summary>
-        /// <param name="purl"> PackageURL to search </param>
-        /// <returns> a string containing metadata. </returns>
+        /// <param name="purl">PackageURL to search</param>
+        /// <returns>a string containing metadata.</returns>
         public virtual Task<string?> GetMetadata(PackageURL purl)
         {
             var typeName = GetType().Name;
@@ -337,10 +338,10 @@ The package-url specifier is described at https://github.com/package-url/purl-sp
         }
 
         /// <summary>
-        ///     Get the uri for the package home page (no version)
+        /// Get the uri for the package home page (no version)
         /// </summary>
-        /// <param name="purl"> </param>
-        /// <returns> </returns>
+        /// <param name="purl"></param>
+        /// <returns></returns>
         public virtual Uri? GetPackageAbsoluteUri(PackageURL purl)
         {
             var typeName = GetType().Name;
@@ -348,10 +349,10 @@ The package-url specifier is described at https://github.com/package-url/purl-sp
         }
 
         /// <summary>
-        ///     Return a normalized package metadata.
+        /// Return a normalized package metadata.
         /// </summary>
-        /// <param name="purl"> </param>
-        /// <returns> </returns>
+        /// <param name="purl"></param>
+        /// <returns></returns>
         public virtual Task<PackageMetadata> GetPackageMetadata(PackageURL purl)
         {
             var typeName = GetType().Name;
@@ -359,11 +360,11 @@ The package-url specifier is described at https://github.com/package-url/purl-sp
         }
 
         /// <summary>
-        ///     Gets everything contained in a JSON element for the package version
+        /// Gets everything contained in a JSON element for the package version
         /// </summary>
-        /// <param name="metadata"> </param>
-        /// <param name="version"> </param>
-        /// <returns> </returns>
+        /// <param name="metadata"></param>
+        /// <param name="version"></param>
+        /// <returns></returns>
         public virtual JsonElement? GetVersionElement(JsonDocument contentJSON, Version version)
         {
             var typeName = GetType().Name;
@@ -371,11 +372,11 @@ The package-url specifier is described at https://github.com/package-url/purl-sp
         }
 
         /// <summary>
-        ///     Gets all the versions of a package
+        /// Gets all the versions of a package
         /// </summary>
-        /// <param name="metadata"> </param>
-        /// <param name="version"> </param>
-        /// <returns> </returns>
+        /// <param name="metadata"></param>
+        /// <param name="version"></param>
+        /// <returns></returns>
         public virtual List<Version> GetVersions(JsonDocument? metadata)
         {
             var typeName = GetType().Name;
@@ -383,14 +384,14 @@ The package-url specifier is described at https://github.com/package-url/purl-sp
         }
 
         /// <summary>
-        ///     Tries to find out the package repository from the metadata of the package. Check with the
-        ///     specific package manager, if they have any specific extraction to do, w.r.t the metadata. If
-        ///     they found some package specific well defined metadata, use that. If that doesn't work, do a
-        ///     search across the metadata to find probable source repository urls
+        /// Tries to find out the package repository from the metadata of the package. Check with
+        /// the specific package manager, if they have any specific extraction to do, w.r.t the
+        /// metadata. If they found some package specific well defined metadata, use that. If that
+        /// doesn't work, do a search across the metadata to find probable source repository urls
         /// </summary>
-        /// <param name="purl"> PackageURL to search </param>
+        /// <param name="purl">PackageURL to search</param>
         /// <returns>
-        ///     A dictionary, mapping each possible repo source entry to its probability/empty dictionary
+        /// A dictionary, mapping each possible repo source entry to its probability/empty dictionary
         /// </returns>
         public async Task<Dictionary<PackageURL, double>> IdentifySourceRepository(PackageURL purl)
         {
@@ -428,7 +429,7 @@ The package-url specifier is described at https://github.com/package-url/purl-sp
         }
 
         /// <summary>
-        ///     Protected memory cache to make subsequent loads of the same URL fast and transparent.
+        /// Protected memory cache to make subsequent loads of the same URL fast and transparent.
         /// </summary>
         protected static readonly MemoryCache DataCache = new MemoryCache(
             new MemoryCacheOptions
@@ -438,13 +439,13 @@ The package-url specifier is described at https://github.com/package-url/purl-sp
         );
 
         /// <summary>
-        ///     Logger for each of the subclasses
+        /// Logger for each of the subclasses
         /// </summary>
         protected static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
 
         /// <summary>
-        ///     Static HttpClient for use in all HTTP connections.
-        ///      Class throws a NullExceptionError in the constructor if this is null.
+        /// Static HttpClient for use in all HTTP connections. Class throws a NullExceptionError in
+        /// the constructor if this is null.
         /// </summary>
 #nullable disable
         protected static HttpClient WebClient;
@@ -452,11 +453,11 @@ The package-url specifier is described at https://github.com/package-url/purl-sp
 #nullable enable
 
         /// <summary>
-        ///     Rank the source repo entry candidates by their edit distance.
+        /// Rank the source repo entry candidates by their edit distance.
         /// </summary>
-        /// <param name="purl"> the package </param>
-        /// <param name="rawMetadataString"> metadata of the package </param>
-        /// <returns> Possible candidates of the package/empty dictionary </returns>
+        /// <param name="purl">the package</param>
+        /// <param name="rawMetadataString">metadata of the package</param>
+        /// <returns>Possible candidates of the package/empty dictionary</returns>
         protected Dictionary<PackageURL, double> ExtractRankedSourceRepositories(PackageURL purl, string rawMetadataString)
         {
             Logger.Trace("ExtractRankedSourceRepositories({0})", purl);
@@ -477,11 +478,12 @@ The package-url specifier is described at https://github.com/package-url/purl-sp
 
                 foreach (var group in sourceUrls.GroupBy(item => item))
                 {
-                    // the cumulative boosts should be < 0.2; otherwise it'd be an 1.0 score by Levenshtein distance
+                    // the cumulative boosts should be < 0.2; otherwise it'd be an 1.0 score by
+                    // Levenshtein distance
                     double similarityBoost = levenshtein.Similarity(purl.Name, group.Key.Name) * 0.0001;
 
-                    // give a similarly weighted boost based on the number of times a particular candidate
-                    // appear in the metadata
+                    // give a similarly weighted boost based on the number of times a particular
+                    // candidate appear in the metadata
                     double countBoost = (double)(group.Count()) * 0.0001;
 
                     sourceRepositoryMap.Add(group.Key, baseScore + similarityBoost + countBoost);
@@ -491,10 +493,11 @@ The package-url specifier is described at https://github.com/package-url/purl-sp
         }
 
         /// <summary>
-        ///     Implemented by all package managers to search the metadata, and either return a successful
-        ///     result for the package repository, or return a null in case of failure/nothing to do.
+        /// Implemented by all package managers to search the metadata, and either return a
+        /// successful result for the package repository, or return a null in case of
+        /// failure/nothing to do.
         /// </summary>
-        /// <returns> </returns>
+        /// <returns></returns>
         protected virtual Task<Dictionary<PackageURL, double>> SearchRepoUrlsInPackageMetadata(PackageURL purl, string metadata)
         {
             return Task.FromResult(new Dictionary<PackageURL, double>());

--- a/src/Shared/PackageManagers/MavenProjectManager.cs
+++ b/src/Shared/PackageManagers/MavenProjectManager.cs
@@ -19,10 +19,10 @@ namespace Microsoft.CST.OpenSource.Shared
         }
 
         /// <summary>
-        ///     Download one Maven package and extract it to the target directory.
+        /// Download one Maven package and extract it to the target directory.
         /// </summary>
-        /// <param name="purl"> Package URL of the package to download. </param>
-        /// <returns> n/a </returns>
+        /// <param name="purl">Package URL of the package to download.</param>
+        /// <returns>n/a</returns>
         public override async Task<IEnumerable<string>> DownloadVersion(PackageURL purl, bool doExtract, bool cached = false)
         {
             Logger.Trace("DownloadVersion {0}", purl?.ToString());
@@ -49,7 +49,8 @@ namespace Microsoft.CST.OpenSource.Shared
                     result.EnsureSuccessStatusCode();
                     Logger.Debug($"Downloading {purl}...");
 
-                    var targetName = $"maven-{packageNamespace}/{packageName}{suffix}@{packageVersion}";
+                    var targetName = $"maven-{packageNamespace}-{packageName}{suffix}@{packageVersion}";
+                    targetName = targetName.Replace('/', '-');
                     string extractionPath = Path.Combine(TopLevelExtractionDirectory, targetName);
                     if (doExtract && Directory.Exists(extractionPath) && cached == true)
                     {

--- a/src/Shared/PackageManagers/NPMProjectManager.cs
+++ b/src/Shared/PackageManagers/NPMProjectManager.cs
@@ -9,7 +9,7 @@ using System.Linq;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Threading.Tasks;
-using Version = SemVer.Version;
+using Version = SemanticVersioning.Version;
 
 namespace Microsoft.CST.OpenSource.Shared
 {
@@ -23,10 +23,10 @@ namespace Microsoft.CST.OpenSource.Shared
         }
 
         /// <summary>
-        ///     Download one NPM package and extract it to the target directory.
+        /// Download one NPM package and extract it to the target directory.
         /// </summary>
-        /// <param name="purl"> Package URL of the package to download. </param>
-        /// <returns> n/a </returns>
+        /// <param name="purl">Package URL of the package to download.</param>
+        /// <returns>n/a</returns>
         public override async Task<IEnumerable<string>> DownloadVersion(PackageURL purl, bool doExtract, bool cached = false)
         {
             Logger.Trace("DownloadVersion {0}", purl?.ToString());
@@ -109,10 +109,10 @@ namespace Microsoft.CST.OpenSource.Shared
         }
 
         /// <summary>
-        ///     Gets the latest version of the package
+        /// Gets the latest version of the package
         /// </summary>
-        /// <param name="contentJSON"> </param>
-        /// <returns> </returns>
+        /// <param name="contentJSON"></param>
+        /// <returns></returns>
         public JsonElement? GetLatestVersionElement(JsonDocument contentJSON)
         {
             List<Version> versions = GetVersions(contentJSON);
@@ -142,10 +142,10 @@ namespace Microsoft.CST.OpenSource.Shared
         }
 
         /// <summary>
-        ///     Gets the structured metadata for the npm package
+        /// Gets the structured metadata for the npm package
         /// </summary>
         /// <param name="purl">PackageURL to retrieve metadata for</param>
-        /// <returns> </returns>
+        /// <returns></returns>
         public override async Task<PackageMetadata> GetPackageMetadata(PackageURL purl)
         {
             PackageMetadata metadata = new PackageMetadata();
@@ -363,11 +363,11 @@ namespace Microsoft.CST.OpenSource.Shared
         }
 
         /// <summary>
-        ///     Searches the package manager metadata to figure out the source code repository
+        /// Searches the package manager metadata to figure out the source code repository
         /// </summary>
-        /// <param name="purl"> the package for which we need to find the source code repository </param>
+        /// <param name="purl">the package for which we need to find the source code repository</param>
         /// <returns>
-        ///     A dictionary, mapping each possible repo source entry to its probability/empty dictionary
+        /// A dictionary, mapping each possible repo source entry to its probability/empty dictionary
         /// </returns>
 
         protected async override Task<Dictionary<PackageURL, double>> SearchRepoUrlsInPackageMetadata(PackageURL purl,
@@ -394,8 +394,8 @@ namespace Microsoft.CST.OpenSource.Shared
                 return mapping;
             }
 
-            // if a version is provided, search that JSONElement, otherwise, just search the latest version,
-            // which is more likely best maintained
+            // if a version is provided, search that JSONElement, otherwise, just search the latest
+            // version, which is more likely best maintained
             // TODO: If the latest version JSONElement doesnt have the repo infor, should we search all elements
             // on that chance that one of them might have it?
             JsonElement? versionJSON = string.IsNullOrEmpty(purl?.Version) ? GetLatestVersionElement(contentJSON) :
@@ -413,8 +413,8 @@ namespace Microsoft.CST.OpenSource.Shared
                     if (repoType == "git" && repoURL is not null)
                     {
                         PackageURL gitPURL = GitHubProjectManager.ParseUri(new Uri(repoURL));
-                        // we got a repository value the author specified in the metadata - so no further
-                        // processing needed
+                        // we got a repository value the author specified in the metadata - so no
+                        // further processing needed
                         if (gitPURL != null)
                         {
                             mapping.Add(gitPURL, 1.0F);
@@ -430,7 +430,7 @@ namespace Microsoft.CST.OpenSource.Shared
         }
 
         /// <summary>
-        ///     Internal Node.js modules that should be ignored when searching metadata.
+        /// Internal Node.js modules that should be ignored when searching metadata.
         /// </summary>
         private static readonly List<string> npm_internal_modules = new List<string>()
         {

--- a/src/Shared/PackageManagers/PyPIProjectManager.cs
+++ b/src/Shared/PackageManagers/PyPIProjectManager.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 using License = Microsoft.CST.OpenSource.Model.License;
 using Repository = Microsoft.CST.OpenSource.Model.Repository;
 using User = Microsoft.CST.OpenSource.Model.User;
-using Version = SemVer.Version;
+using Version = SemanticVersioning.Version;
 
 namespace Microsoft.CST.OpenSource.Shared
 {
@@ -25,10 +25,10 @@ namespace Microsoft.CST.OpenSource.Shared
         }
 
         /// <summary>
-        ///     Download one PyPI package and extract it to the target directory.
+        /// Download one PyPI package and extract it to the target directory.
         /// </summary>
-        /// <param name="purl"> Package URL of the package to download. </param>
-        /// <returns> the path or file written. </returns>
+        /// <param name="purl">Package URL of the package to download.</param>
+        /// <returns>the path or file written.</returns>
         public override async Task<IEnumerable<string>> DownloadVersion(PackageURL purl, bool doExtract, bool cached = false)
         {
             Logger.Trace("DownloadVersion {0}", purl?.ToString());
@@ -272,7 +272,6 @@ namespace Microsoft.CST.OpenSource.Shared
             return metadata;
         }
 
-
         public override List<Version> GetVersions(JsonDocument? contentJSON)
         {
             List<Version> allVersions = new List<Version>();
@@ -293,7 +292,6 @@ namespace Microsoft.CST.OpenSource.Shared
 
             return allVersions;
         }
-
 
         public override JsonElement? GetVersionElement(JsonDocument contentJSON, Version version)
         {

--- a/src/Shared/Shared.csproj
+++ b/src/Shared/Shared.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="NuGet.Versioning" Version="5.10.0" />
     <PackageReference Include="Octokit" Version="0.50.0" />
     <PackageReference Include="Sarif.Sdk" Version="2.4.10" />
-    <PackageReference Include="SemanticVersioning" Version="2.0.0-alpha.1" />
+    <PackageReference Include="SemanticVersioning" Version="2.0.0" />
     <PackageReference Include="sharpcompress" Version="0.28.3" />
     <PackageReference Include="SharpZipLib" Version="1.3.2" />
     <PackageReference Include="System.Console" Version="4.3.1" />

--- a/src/Shared/Shared.csproj
+++ b/src/Shared/Shared.csproj
@@ -27,23 +27,26 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AngleSharp" Version="1.0.0-alpha-827" />
+    <PackageReference Include="AngleSharp" Version="1.0.0-alpha-844" />
     <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
     <PackageReference Include="Crayon" Version="2.0.62" />
-    <PackageReference Include="F23.StringSimilarity" Version="4.0.0" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.31" />
-    <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.0.58" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="5.0.0" />
-    <PackageReference Include="NLog" Version="4.7.8" />
-    <PackageReference Include="NLog.Schema" Version="4.7.8" />
-    <PackageReference Include="NuGet.Versioning" Version="5.9.1" />
+    <PackageReference Include="F23.StringSimilarity" Version="4.1.0" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.34" />
+    <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.0-preview.5.21301.5" />
+    <PackageReference Include="NLog" Version="4.7.10" />
+    <PackageReference Include="NLog.Schema" Version="4.7.10" />
+    <PackageReference Include="NuGet.Versioning" Version="5.10.0" />
     <PackageReference Include="Octokit" Version="0.50.0" />
-    <PackageReference Include="Sarif.Sdk" Version="2.4.5" />
-    <PackageReference Include="SemanticVersioning" Version="1.3.0" />
-    <PackageReference Include="sharpcompress" Version="0.28.1" />
-    <PackageReference Include="SharpZipLib" Version="1.3.1" />
+    <PackageReference Include="Sarif.Sdk" Version="2.4.10" />
+    <PackageReference Include="SemanticVersioning" Version="2.0.0-alpha.1" />
+    <PackageReference Include="sharpcompress" Version="0.28.3" />
+    <PackageReference Include="SharpZipLib" Version="1.3.2" />
     <PackageReference Include="System.Console" Version="4.3.1" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.220">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/oss-characteristics/oss-characteristic.csproj
+++ b/src/oss-characteristics/oss-characteristic.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
-    <PackageReference Include="Microsoft.CST.ApplicationInspector.Commands" Version="1.2.100" />
+    <PackageReference Include="Microsoft.CST.ApplicationInspector.Commands" Version="1.4.4" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.220">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/oss-characteristics/oss-characteristic.csproj
+++ b/src/oss-characteristics/oss-characteristic.csproj
@@ -20,7 +20,10 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
     <PackageReference Include="Microsoft.CST.ApplicationInspector.Commands" Version="1.2.100" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.220">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/oss-defog/DefoggerTool.cs
+++ b/src/oss-defog/DefoggerTool.cs
@@ -16,47 +16,47 @@ namespace Microsoft.CST.OpenSource
     public class DefoggerTool : OSSGadget
     {
         /// <summary>
-        ///     String with placeholders that matches Base64-encoded text.
+        /// String with placeholders that matches Base64-encoded text.
         /// </summary>
         private static readonly string BASE64_REGEX_STRING = "(([A-Z0-9+\\/]{B})+(([A-Z0-9+\\/]{3}=)|([A-Z0-9+\\/]{2}==))?)";
 
         /// <summary>
-        ///     String with placeholders that matches hex-encoded text.
+        /// String with placeholders that matches hex-encoded text.
         /// </summary>
         private static readonly string HEX_REGEX_STRING = "(0x)?(([A-F0-9][A-F0-9]{B,})|(([A-F0-9][A-F0-9]-){C,}[A-F0-9][A-F0-9]))";
 
         /// <summary>
-        ///     Regular expression that matches Base64-encoded text.
+        /// Regular expression that matches Base64-encoded text.
         /// </summary>
-        private static Regex BASE64_REGEX = new Regex(BASE64_REGEX_STRING.Replace("B","4"), RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(5000));
+        private static Regex BASE64_REGEX = new Regex(BASE64_REGEX_STRING.Replace("B", "4"), RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(5000));
 
         /// <summary>
-        ///     Regular expression that matches hex-encoded text.
+        /// Regular expression that matches hex-encoded text.
         /// </summary>
-        private static Regex HEX_REGEX = new Regex(HEX_REGEX_STRING.Replace("B","8").Replace("C","7"), RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+        private static Regex HEX_REGEX = new Regex(HEX_REGEX_STRING.Replace("B", "8").Replace("C", "7"), RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
         /// <summary>
-        ///     Short strings must match this regular expression to be reported.
+        /// Short strings must match this regular expression to be reported.
         /// </summary>
         private static readonly Regex SHORT_INTERESTING_STRINGS_REGEX = new Regex(@"^[A-Z0-9\-:]+$", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(5000));
 
         /// <summary>
-        ///     Do not analyze binary files (those with a MIME type that matches this regular expression).
+        /// Do not analyze binary files (those with a MIME type that matches this regular expression).
         /// </summary>
         private static readonly Regex IGNORE_MIME_REGEX = new Regex(@"audio|video|x-msdownload", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(5000));
 
         /// <summary>
-        ///     Only report detected strings this length or longer.
+        /// Only report detected strings this length or longer.
         /// </summary>
         private const int DEFAULT_MINIMUM_STRING_LENGTH = 8;
 
         /// <summary>
-        ///     Strings longer than this are interesting.
+        /// Strings longer than this are interesting.
         /// </summary>
         private const int INTERESTING_STRINGS_CUTOFF = 24;
 
         /// <summary>
-        ///     Enum of executable types
+        /// Enum of executable types
         /// </summary>
         public enum ExecutableType
         {
@@ -76,17 +76,17 @@ namespace Microsoft.CST.OpenSource
         }
 
         /// <summary>
-        ///     Linux Elf
+        /// Linux Elf
         /// </summary>
         public static readonly byte[] ElfMagicNumber = HexStringToBytes("7F454C46");
 
         /// <summary>
-        ///     Java Classes
+        /// Java Classes
         /// </summary>
         public static readonly byte[] JavaMagicNumber = HexStringToBytes("CAFEBABE");
 
         /// <summary>
-        ///     Mac Binary Magic numbers
+        /// Mac Binary Magic numbers
         /// </summary>
         public static readonly List<byte[]> MacMagicNumbers = new List<byte[]>()
         {
@@ -103,12 +103,12 @@ namespace Microsoft.CST.OpenSource
         };
 
         /// <summary>
-        ///     Windows Binary header
+        /// Windows Binary header
         /// </summary>
         public static readonly byte[] WindowsMagicNumber = HexStringToBytes("4D5A");
 
         /// <summary>
-        ///     Gets the executable type of the given stream.
+        /// Gets the executable type of the given stream.
         /// </summary>
         /// <param name="input">Stream bytes to check</param>
         /// <returns>The executable type</returns>
@@ -151,7 +151,7 @@ namespace Microsoft.CST.OpenSource
         }
 
         /// <summary>
-        ///     Command line options passed into this tool.
+        /// Command line options passed into this tool.
         /// </summary>
         private readonly IDictionary<string, object?> Options = new Dictionary<string, object?>()
         {
@@ -167,16 +167,16 @@ namespace Microsoft.CST.OpenSource
         };
 
         /// <summary>
-        ///     Identified findings from the analysis.
+        /// Identified findings from the analysis.
         /// </summary>
         public IList<EncodedString> Findings { get; private set; }
+
         public List<EncodedBinary> BinaryFindings { get; }
         public List<EncodedArchive> ArchiveFindings { get; }
         public List<EncodedBlob> NonTextFindings { get; private set; }
 
-
         /// <summary>
-        ///     The specific type of encoding detected.
+        /// The specific type of encoding detected.
         /// </summary>
         public enum EncodedStringType
         {
@@ -186,7 +186,7 @@ namespace Microsoft.CST.OpenSource
         }
 
         /// <summary>
-        ///     The encoded string and type.
+        /// The encoded string and type.
         /// </summary>
         public class EncodedString
         {
@@ -205,7 +205,7 @@ namespace Microsoft.CST.OpenSource
         }
 
         /// <summary>
-        ///     The encoded string and type.
+        /// The encoded string and type.
         /// </summary>
         public class EncodedBlob
         {
@@ -222,7 +222,7 @@ namespace Microsoft.CST.OpenSource
         }
 
         /// <summary>
-        ///     The encoded archive and type.
+        /// The encoded archive and type.
         /// </summary>
         public class EncodedArchive
         {
@@ -241,7 +241,7 @@ namespace Microsoft.CST.OpenSource
         }
 
         /// <summary>
-        ///     The encoded binary and type.
+        /// The encoded binary and type.
         /// </summary>
         public class EncodedBinary
         {
@@ -304,7 +304,7 @@ namespace Microsoft.CST.OpenSource
                                 Directory.CreateDirectory(binaryDir);
                                 var path = Path.Combine(binaryDir, binaryFinding.Filename, $"binary-{binaryNumber}");
                                 Logger.Info("Saving to {0}", path);
-                                var fs = new FileStream(path,System.IO.FileMode.OpenOrCreate);
+                                var fs = new FileStream(path, System.IO.FileMode.OpenOrCreate);
                                 binaryFinding.DecodedBinary.CopyTo(fs);
                                 binaryNumber++;
                             }
@@ -358,7 +358,7 @@ namespace Microsoft.CST.OpenSource
         }
 
         /// <summary>
-        ///     Initializes a new DefoggerTool instance.
+        /// Initializes a new DefoggerTool instance.
         /// </summary>
         public DefoggerTool() : base()
         {
@@ -369,10 +369,10 @@ namespace Microsoft.CST.OpenSource
         }
 
         /// <summary>
-        ///     Analyze a package by downloading it first.
+        /// Analyze a package by downloading it first.
         /// </summary>
-        /// <param name="purl"> The package-url of the package to analyze. </param>
-        /// <returns> n/a </returns>
+        /// <param name="purl">The package-url of the package to analyze.</param>
+        /// <returns>n/a</returns>
         public async Task AnalyzePackage(PackageURL purl, string? destinationDirectory, bool doCaching)
         {
             Logger.Trace("AnalyzePackage({0})", purl.ToString());
@@ -398,9 +398,9 @@ namespace Microsoft.CST.OpenSource
         }
 
         /// <summary>
-        ///     Analyzes a directory of files.
+        /// Analyzes a directory of files.
         /// </summary>
-        /// <param name="directory"> directory to analyze. </param>
+        /// <param name="directory">directory to analyze.</param>
         public void AnalyzeDirectory(string directory)
         {
             Logger.Trace("AnalyzeDirectory({0})", directory);
@@ -419,9 +419,9 @@ namespace Microsoft.CST.OpenSource
         }
 
         /// <summary>
-        ///     Analyzes a single file.
+        /// Analyzes a single file.
         /// </summary>
-        /// <param name="filename"> filename to analyze </param>
+        /// <param name="filename">filename to analyze</param>
         public void AnalyzeFile(string filename)
         {
             Logger.Trace("AnalyzeFile({0})", filename);
@@ -454,8 +454,9 @@ namespace Microsoft.CST.OpenSource
                     continue;
                 }
 
-                // Try to decode and then re-encode. Are we successful, and do we get the same value we
-                // started out with? This will filter out Base64-encoded binary data, which is what we want.
+                // Try to decode and then re-encode. Are we successful, and do we get the same value
+                // we started out with? This will filter out Base64-encoded binary data, which is
+                // what we want.
                 try
                 {
                     var bytes = Convert.FromBase64String(match.Value);
@@ -464,7 +465,7 @@ namespace Microsoft.CST.OpenSource
 
                     if (match.Value.Equals(reencoded))
                     {
-                        var entry = new FileEntry("bytes", new MemoryStream(bytes),new FileEntry(filename,new MemoryStream()));
+                        var entry = new FileEntry("bytes", new MemoryStream(bytes), new FileEntry(filename, new MemoryStream()));
 
                         var exeType = GetExecutableType(entry.Content);
 
@@ -506,7 +507,7 @@ namespace Microsoft.CST.OpenSource
                                         DecodedText: decoded
                                     ));
 
-                                    AnalyzeFile(Path.Combine(filename,match.Value), decoded);
+                                    AnalyzeFile(Path.Combine(filename, match.Value), decoded);
                                 }
                                 // Bail out early if the decoded string isn't interesting.
                                 if (!IsInterestingString(decoded))
@@ -555,7 +556,7 @@ namespace Microsoft.CST.OpenSource
         }
 
         /// <summary>
-        ///     Converts hex data to a string
+        /// Converts hex data to a string
         /// </summary>
         /// <param name="hex">The Hex data to decode</param>
         /// <returns>The decoded string</returns>
@@ -590,10 +591,10 @@ namespace Microsoft.CST.OpenSource
         }
 
         /// <summary>
-        ///     Decides whether the given string is interesting or not
+        /// Decides whether the given string is interesting or not
         /// </summary>
-        /// <param name="s"> string to check </param>
-        /// <returns> </returns>
+        /// <param name="s">string to check</param>
+        /// <returns></returns>
         private static bool IsInterestingString(string s)
         {
             if (string.IsNullOrWhiteSpace(s))
@@ -632,9 +633,9 @@ namespace Microsoft.CST.OpenSource
         }
 
         /// <summary>
-        ///     Parses options for this program.
+        /// Parses options for this program.
         /// </summary>
-        /// <param name="args"> arguments (passed in from the user) </param>
+        /// <param name="args">arguments (passed in from the user)</param>
         private void ParseOptions(string[] args)
         {
             if (args == null)
@@ -655,7 +656,7 @@ namespace Microsoft.CST.OpenSource
 
                     case "-v":
                     case "--version":
-                        Console.Error.WriteLine($"{GetToolName()} {GetToolVersion()}");
+                        Console.WriteLine($"{GetToolName()} {GetToolVersion()}");
                         Environment.Exit(1);
                         break;
 
@@ -708,11 +709,11 @@ namespace Microsoft.CST.OpenSource
         }
 
         /// <summary>
-        ///     Displays usage information for the program.
+        /// Displays usage information for the program.
         /// </summary>
         private static void ShowUsage()
         {
-            Console.Error.WriteLine($@"
+            Console.WriteLine($@"
 {ToolName} {ToolVersion}
 
 Usage: {ToolName} [options] package-url...
@@ -733,7 +734,7 @@ optional arguments:
   --use-cache                   do not download the package if it is already present in the destination directory
   --help                        show this help message and exit
   --version                     show version number
-  
+
 ");
         }
     }

--- a/src/oss-defog/oss-defog.csproj
+++ b/src/oss-defog/oss-defog.csproj
@@ -25,8 +25,11 @@
     <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
     <PackageReference Include="MediaTypeMap.Core" Version="2.3.3" />
     <PackageReference Include="System.Console" Version="4.3.1" />
-    <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.0.58" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" />
+    <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.1.1" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.220">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/oss-detect-backdoor/oss-detect-backdoor.csproj
+++ b/src/oss-detect-backdoor/oss-detect-backdoor.csproj
@@ -65,7 +65,10 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.220">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/oss-detect-cryptography/DetectCryptographyTool.cs
+++ b/src/oss-detect-cryptography/DetectCryptographyTool.cs
@@ -118,11 +118,11 @@ namespace Microsoft.CST.OpenSource
                         }
                         else
                         {
-                            var shortTags = results.SelectMany(r => r.Issue.Rule.Tags ?? Array.Empty<string>())
+                            var shortTags = results.SelectMany(r => r.Issue.Rule.Tags ?? new List<string>())
                                                    .Distinct()
                                                    .Where(t => t.StartsWith("Cryptography.Implementation."))
                                                    .Select(t => t.Replace("Cryptography.Implementation.", ""));
-                            var otherTags = results.SelectMany(r => r.Issue.Rule.Tags ?? Array.Empty<string>())
+                            var otherTags = results.SelectMany(r => r.Issue.Rule.Tags ?? new List<string>())
                                                    .Distinct()
                                                    .Where(t => !t.StartsWith("Cryptography.Implementation."));
 
@@ -511,7 +511,7 @@ namespace Microsoft.CST.OpenSource
                                     Id = "_CRYPTO_DENSITY",
                                     Name = "Cryptographic symbols",
                                     Description = cryptoOperationLikelihood.ToString(),
-                                    Tags = new string[]
+                                    Tags = new List<string>()
                                     {
                                         "Cryptography.GenericImplementation.HighDensityOperators"
                                     }

--- a/src/oss-detect-cryptography/DetectCryptographyTool.cs
+++ b/src/oss-detect-cryptography/DetectCryptographyTool.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CST.OpenSource
     public class DetectCryptographyTool : OSSGadget
     {
         /// <summary>
-        ///     Command line options
+        /// Command line options
         /// </summary>
         public Dictionary<string, object?> Options = new Dictionary<string, object?>()
         {
@@ -43,9 +43,9 @@ namespace Microsoft.CST.OpenSource
         };
 
         /// <summary>
-        ///     Main entrypoint for the download program.
+        /// Main entrypoint for the download program.
         /// </summary>
-        /// <param name="args"> parameters passed in from the user </param>
+        /// <param name="args">parameters passed in from the user</param>
         private static async Task Main(string[] args)
         {
             ShowToolBanner();
@@ -223,10 +223,10 @@ namespace Microsoft.CST.OpenSource
         }
 
         /// <summary>
-        ///     Analyze a package by downloading it first.
+        /// Analyze a package by downloading it first.
         /// </summary>
-        /// <param name="purl"> The package-url of the package to analyze. </param>
-        /// <returns> List of tags identified </returns>
+        /// <param name="purl">The package-url of the package to analyze.</param>
+        /// <returns>List of tags identified</returns>
         public async Task<List<IssueRecord>> AnalyzePackage(PackageURL purl, string? targetDirectoryName, bool doCaching)
         {
             Logger.Trace("AnalyzePackage({0})", purl.ToString());
@@ -328,7 +328,7 @@ namespace Microsoft.CST.OpenSource
                 {
                     // Maybe it's WebAseembly -- @TODO Make this less random.
                     using var webAssemblyByteStream = new MemoryStream(buffer);
-                    
+
                     var m = WebAssembly.Module.ReadFromBinary(webAssemblyByteStream);
 
                     foreach (var data in m.Data)
@@ -357,11 +357,11 @@ namespace Microsoft.CST.OpenSource
                     }
                     return string.Join('\n', resultStrings);
                 }
-                catch(WebAssembly.ModuleLoadException)
+                catch (WebAssembly.ModuleLoadException)
                 {
                     // OK to ignore
                 }
-                catch (Exception ex) 
+                catch (Exception ex)
                 {
                     Logger.Warn("Unable to analyze WebAssembly {0}: {1}", filename, ex.Message);
                 }
@@ -379,10 +379,10 @@ namespace Microsoft.CST.OpenSource
         }
 
         /// <summary>
-        ///     Analyzes a directory of files.
+        /// Analyzes a directory of files.
         /// </summary>
-        /// <param name="directory"> directory to analyze. </param>
-        /// <returns> List of tags identified </returns>
+        /// <param name="directory">directory to analyze.</param>
+        /// <returns>List of tags identified</returns>
         public async Task<List<IssueRecord>> AnalyzeDirectory(string directory)
         {
             Logger.Trace("AnalyzeDirectory({0})", directory);
@@ -463,7 +463,7 @@ namespace Microsoft.CST.OpenSource
                 Logger.Warn("{0} is neither a directory nor a file.", directory);
                 return analysisResults; // empty
             }
-            
+
             foreach (var filename in fileList)
             {
                 Logger.Trace($"Processing {filename}");
@@ -564,11 +564,11 @@ namespace Microsoft.CST.OpenSource
         }
 
         /// <summary>
-        ///     Calculates the density of cryptographic operators within the buffer.
+        /// Calculates the density of cryptographic operators within the buffer.
         /// </summary>
-        /// <param name="buffer"> Buffer to analyze </param>
-        /// <param name="windowSize"> Size of the window to use </param>
-        /// <returns> Ratio (0-1) of the most dense windowSize characters of the buffer. </returns>
+        /// <param name="buffer">Buffer to analyze</param>
+        /// <param name="windowSize">Size of the window to use</param>
+        /// <returns>Ratio (0-1) of the most dense windowSize characters of the buffer.</returns>
         private double CalculateCryptoOpDensity(string buffer, int windowSize = 50)
         {
             Logger.Trace("CalculateCryptoOpDensity()");
@@ -595,8 +595,8 @@ namespace Microsoft.CST.OpenSource
             windowSize = windowSize >= buffer.Length ? buffer.Length : windowSize;
             windowSize = windowSize <= 0 ? 50 : windowSize;
 
-            // This is a horrible regular expression, but the intent is to capture symbol characters that
-            // probably mean something within cryptographic code, but not within other code.
+            // This is a horrible regular expression, but the intent is to capture symbol characters
+            // that probably mean something within cryptographic code, but not within other code.
             var cryptoChars = new Regex("(?<=[a-z0-9_])\\^=?(?=[a-z_])|(?<=[a-z0-9_])(>{2,3}|<{2,3})=?(?=[a-z0-9])|(?<=[a-z0-9_])([&^~|])=?(?=[a-z0-9])", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
             // We report on the highest ratio of symbol to total characters
@@ -619,11 +619,11 @@ namespace Microsoft.CST.OpenSource
         }
 
         /// <summary>
-        ///     Extract unique strings (alphabetic) from a string
-        ///     TODO: This is ASCII-only.
+        /// Extract unique strings (alphabetic) from a string
+        /// TODO: This is ASCII-only.
         /// </summary>
-        /// <param name="buffer"> string to scan </param>
-        /// <returns> unique strings </returns>
+        /// <param name="buffer">string to scan</param>
+        /// <returns>unique strings</returns>
         private IEnumerable<string> UniqueStringsFromBinary(byte[] buffer)
         {
             var bufferString = Encoding.ASCII.GetString(buffer);
@@ -632,9 +632,9 @@ namespace Microsoft.CST.OpenSource
         }
 
         /// <summary>
-        ///     Parses options for this program.
+        /// Parses options for this program.
         /// </summary>
-        /// <param name="args"> arguments (passed in from the user) </param>
+        /// <param name="args">arguments (passed in from the user)</param>
         private void ParseOptions(string[] args)
         {
             if (args == null)
@@ -655,7 +655,7 @@ namespace Microsoft.CST.OpenSource
 
                     case "-v":
                     case "--version":
-                        Console.Error.WriteLine($"{ToolName} {ToolVersion}");
+                        Console.WriteLine($"{ToolName} {ToolVersion}");
                         Environment.Exit(1);
                         break;
 
@@ -690,11 +690,11 @@ namespace Microsoft.CST.OpenSource
         }
 
         /// <summary>
-        ///     Displays usage information for the program.
+        /// Displays usage information for the program.
         /// </summary>
         private static void ShowUsage()
         {
-            Console.Error.WriteLine($@"
+            Console.WriteLine($@"
 {ToolName} {ToolVersion}
 
 Usage: {ToolName} [options] package-url...

--- a/src/oss-detect-cryptography/oss-detect-cryptography.csproj
+++ b/src/oss-detect-cryptography/oss-detect-cryptography.csproj
@@ -60,14 +60,17 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
-    <PackageReference Include="ELFSharp" Version="2.12.0" />
-    <PackageReference Include="ICSharpCode.Decompiler" Version="6.2.1.6137" />
+    <PackageReference Include="ELFSharp" Version="2.12.1" />
+    <PackageReference Include="ICSharpCode.Decompiler" Version="7.1.0.6543" />
     <PackageReference Include="Microsoft.CST.ApplicationInspector.Commands" Version="1.2.100" />
-    <PackageReference Include="Microsoft.CST.DevSkim" Version="0.4.234" />
-    <PackageReference Include="PeNet" Version="2.6.2" />
+    <PackageReference Include="Microsoft.CST.DevSkim" Version="0.4.238" />
+    <PackageReference Include="PeNet" Version="2.6.3" />
     <PackageReference Include="SharpDisasm" Version="1.1.11" />
-    <PackageReference Include="WebAssembly" Version="0.11.0" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" />
+    <PackageReference Include="WebAssembly" Version="1.2.0" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.220">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/oss-detect-cryptography/oss-detect-cryptography.csproj
+++ b/src/oss-detect-cryptography/oss-detect-cryptography.csproj
@@ -62,7 +62,7 @@
     <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
     <PackageReference Include="ELFSharp" Version="2.12.1" />
     <PackageReference Include="ICSharpCode.Decompiler" Version="7.1.0.6543" />
-    <PackageReference Include="Microsoft.CST.ApplicationInspector.Commands" Version="1.2.100" />
+    <PackageReference Include="Microsoft.CST.ApplicationInspector.Commands" Version="1.4.4" />
     <PackageReference Include="Microsoft.CST.DevSkim" Version="0.4.238" />
     <PackageReference Include="PeNet" Version="2.6.3" />
     <PackageReference Include="SharpDisasm" Version="1.1.11" />

--- a/src/oss-diff/oss-diff.csproj
+++ b/src/oss-diff/oss-diff.csproj
@@ -25,4 +25,8 @@
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.220" />
+  </ItemGroup>
+
 </Project>

--- a/src/oss-download/oss-download.csproj
+++ b/src/oss-download/oss-download.csproj
@@ -23,7 +23,10 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
     <PackageReference Include="System.Console" Version="4.3.1" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.220">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/oss-find-domain-squats/oss-find-domain-squats.csproj
+++ b/src/oss-find-domain-squats/oss-find-domain-squats.csproj
@@ -26,4 +26,8 @@
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.220" />
+  </ItemGroup>
+
 </Project>

--- a/src/oss-find-source/oss-find-source.csproj
+++ b/src/oss-find-source/oss-find-source.csproj
@@ -27,7 +27,10 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
-    <PackageReference Include="Sarif.Sdk" Version="2.4.5" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" />
+    <PackageReference Include="Sarif.Sdk" Version="2.4.10" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.220">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/src/oss-find-squats/oss-find-squats.csproj
+++ b/src/oss-find-squats/oss-find-squats.csproj
@@ -17,12 +17,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Sarif.Sdk" Version="2.4.5" />
-    <PackageReference Include="Scriban" Version="3.5.0" />
+    <PackageReference Include="Sarif.Sdk" Version="2.4.10" />
+    <PackageReference Include="Scriban" Version="4.0.1" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.220" />
   </ItemGroup>
 
 </Project>

--- a/src/oss-health/oss-health.csproj
+++ b/src/oss-health/oss-health.csproj
@@ -25,7 +25,10 @@
     <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
     <PackageReference Include="Octokit" Version="0.50.0" />
     <PackageReference Include="System.Console" Version="4.3.1" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.220">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/oss-metadata/oss-metadata.csproj
+++ b/src/oss-metadata/oss-metadata.csproj
@@ -21,7 +21,10 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.220">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/oss-reproducible/ReproducibleTool.cs
+++ b/src/oss-reproducible/ReproducibleTool.cs
@@ -530,12 +530,12 @@ namespace Microsoft.CST.OpenSource
                     catch (Exception ex)
                     {
                         Logger.Warn(ex, "Unable to write to {0}. Writing to console instead.", options.OutputFile);
-                        Console.Error.WriteLine(jsonResults);
+                        Console.WriteLine(jsonResults);
                     }
                 }
                 else if (string.Equals(options.OutputFile, "-", StringComparison.InvariantCultureIgnoreCase))
                 {
-                    Console.Error.WriteLine(jsonResults);
+                    Console.WriteLine(jsonResults);
                 }
             }
             else

--- a/src/oss-reproducible/oss-reproducible.csproj
+++ b/src/oss-reproducible/oss-reproducible.csproj
@@ -62,13 +62,17 @@
   <ItemGroup>
     <PackageReference Include="DiffPlex" Version="1.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="SharpCompress" Version="0.28.1" />
+    <PackageReference Include="SharpCompress" Version="0.28.3" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\oss-download\oss-download.csproj" />
     <ProjectReference Include="..\oss-find-source\oss-find-source.csproj" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.220" />
   </ItemGroup>
 
 </Project>

--- a/src/oss-risk-calculator/oss-risk-calculator.csproj
+++ b/src/oss-risk-calculator/oss-risk-calculator.csproj
@@ -19,7 +19,10 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.220">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/oss-tests/DetectCryptographyTests.cs
+++ b/src/oss-tests/DetectCryptographyTests.cs
@@ -3,6 +3,7 @@
 using Microsoft.CST.OpenSource.Shared;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -40,7 +41,7 @@ namespace Microsoft.CST.OpenSource.Tests
             var results = await detectCryptographyTool.AnalyzePackage(new PackageURL(purl), targetDirectoryName, false);
 
             var distinctTargets = expectedTags.Distinct();
-            var distinctFindings = results.SelectMany(s => s.Issue.Rule.Tags ?? Array.Empty<string>())
+            var distinctFindings = results.SelectMany(s => s.Issue.Rule.Tags ?? new List<string>())
                                           .Where(s => s.StartsWith("Cryptography.Implementation"))
                                           .Distinct();
 

--- a/src/oss-tests/oss-tests.csproj
+++ b/src/oss-tests/oss-tests.csproj
@@ -12,18 +12,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DiscUtils.Btrfs" Version="0.15.1-ci0002" />
-    <PackageReference Include="DiscUtils.HfsPlus" Version="0.15.1-ci0002" />
-    <PackageReference Include="DiscUtils.SquashFs" Version="0.15.1-ci0002" />
-    <PackageReference Include="DiscUtils.Xfs" Version="0.15.1-ci0002" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="DiscUtils.Btrfs" Version="0.16.4" />
+    <PackageReference Include="DiscUtils.HfsPlus" Version="0.16.4" />
+    <PackageReference Include="DiscUtils.SquashFs" Version="0.16.4" />
+    <PackageReference Include="DiscUtils.Xfs" Version="0.16.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0-release-20210626-04" />
     <PackageReference Include="coverlet.collector" Version="3.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.220">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR has two changes:
- When we accept an output filename, we check to see if it contains invalid chars, and if so, we write to the console instead. (Perhaps we should just error out?). In any case, if the user provides a full path, those slashes cause that check to fail, and the output goes to the screen. This PR fixes that.

- Change banner to stderr (from stdout) - This way, for sarif output (or text for that matter), redirecting can work too.