### PR TITLE
OSS Detect Backdoor Improvements

### DIFF
--- a/src/Shared/nlog.config
+++ b/src/Shared/nlog.config
@@ -11,7 +11,7 @@
 				detectConsoleAvailable="true"
 				detectOutputRedirected="true"
 				enableAnsiOutput="true"
-				layout="${pad:padding=-5:inner=${level::uppercase=true}} - ${message}"
+				layout="${pad:padding=-5:inner=${level:uppercase=true}} - ${message}"
 				useDefaultRowHighlightingRules="true">
 		</target>
 		<target xsi:type="File"
@@ -19,7 +19,7 @@
 				layout="${date}|${level:uppercase=true}|${message} ${exception}|${all-event-properties}"
 				encoding="utf-8"
 				lineEnding="default"
-				fileName="oss-gadget.log">
+				fileName="${currentdir}/oss-gadget.log">
 		</target>
 	</targets>
 

--- a/src/oss-characteristics/CharacteristicTool.cs
+++ b/src/oss-characteristics/CharacteristicTool.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CST.OpenSource
             public bool UseCache { get; set; }
 
             [Option('x', "exclude", Required = false,
-                HelpText = "exclude specific files or paths.")]
+                HelpText = "exclude files or paths which match provided glob patterns.")]
             public string FilePathExclusions { get; set; } = "";
 
             public bool TreatEverythingAsCode { get; set; } = true;

--- a/src/oss-characteristics/CharacteristicTool.cs
+++ b/src/oss-characteristics/CharacteristicTool.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CST.OpenSource
                 HelpText = "exclude specific files or paths.")]
             public string FilePathExclusions { get; set; } = "";
 
-            public bool TreatEverythingAsCode { get; set; }
+            public bool TreatEverythingAsCode { get; set; } = true;
 
             public bool AllowDupTags { get; set; } = false;
 
@@ -98,15 +98,16 @@ namespace Microsoft.CST.OpenSource
             // Call Application Inspector using the NuGet package
             var analyzeOptions = new AnalyzeOptions()
             {
-                ConsoleVerbosityLevel = "None",
-                LogFileLevel = "Off",
+                ConsoleVerbosityLevel = "High",
+                LogFileLevel = "trace",
                 SourcePath = new[] { directory },
-                IgnoreDefaultRules = options.DisableDefaultRules == true,
+                IgnoreDefaultRules = options.DisableDefaultRules,
                 CustomRulesPath = options.CustomRuleDirectory,
                 ConfidenceFilters = "high,medium,low",
+                ScanUnknownTypes = true,
                 TreatEverythingAsCode = options.TreatEverythingAsCode,
-                SingleThread = true,
-                TagsOnly = true
+                SingleThread = false,
+                FilePathExclusions = options.FilePathExclusions?.Split(',') ?? Array.Empty<string>()
             };
 
             try

--- a/src/oss-detect-backdoor/DetectBackdoorTool.cs
+++ b/src/oss-detect-backdoor/DetectBackdoorTool.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using static Crayon.Output;
 
 namespace Microsoft.CST.OpenSource
 {
@@ -81,14 +82,19 @@ namespace Microsoft.CST.OpenSource
 
                     if (parsedOptions.Format == "text")
                     {
-                        foreach (var match in entry.Value.Metadata.Matches.OrderByDescending(x => x.Confidence))
+                        var matchEntries = entry.Value.Metadata.Matches.OrderByDescending(x => x.Confidence);
+                        var matchEntriesCount = matchEntries.Count();
+                        int matchIndex = 1;
+
+                        foreach (var match in matchEntries)
                         {
-                            WriteMatch(match);
+                            WriteMatch(match, matchIndex, matchEntriesCount);
+                            matchIndex++;
                         }
                         Console.WriteLine($"{entry.Value.Metadata.TotalMatchesCount} matches found.");
                     }
 
-                    void WriteMatch(MatchRecord match)
+                    void WriteMatch(MatchRecord match, int index, int matchCount)
                     {
                         var filename = match.FileName;
                         if (filename == null)
@@ -103,7 +109,16 @@ namespace Microsoft.CST.OpenSource
                                 filename = filename[sourcePathLength.Value..];
                             }
                         }
-                        Console.WriteLine($"{match.Tags?.First()} - {filename}:{match.StartLocationLine} - {match.RuleName} ({match.Severity} - {match.Confidence})");
+                        Console.WriteLine(Red($"--[ ") + Blue("Match #") + Yellow(index.ToString()) + Blue(" of ") + Yellow(matchCount.ToString()) + Red(" ]--"));
+                        Console.WriteLine("       Tag: " + Blue(match.Tags?.First()));
+                        Console.WriteLine("  Severity: " + Cyan(match.Severity.ToString()) + ", Confidence: " + Cyan(match.Confidence.ToString()));
+                        Console.WriteLine("  Filename: " + Yellow(filename));
+                        Console.WriteLine("   Pattern: " + Green(match.MatchingPattern.Pattern));
+                        foreach (var line in match.Excerpt.Split(new[] {"\r", "\n", "\r\n"}, StringSplitOptions.None))
+                        {
+                            Console.WriteLine(Bright.Black("  | ") + Magenta(line));
+                        }
+                        Console.WriteLine();
                     }
                 }
             }

--- a/src/oss-detect-backdoor/Resources/BackdoorRules/backdoor_signatures.json
+++ b/src/oss-detect-backdoor/Resources/BackdoorRules/backdoor_signatures.json
@@ -37,7 +37,7 @@
   },
   {
     "name": "Backdoor: gohack.xyz",
-    "id": "BD000201",
+    "id": "BD000202",
     "description": "Backdoor: gohack.xyz",
     "tags": [
       "Security.Backdoor.Signature.gohackxyz"

--- a/src/oss-detect-backdoor/Resources/BackdoorRules/code_execution.json
+++ b/src/oss-detect-backdoor/Resources/BackdoorRules/code_execution.json
@@ -58,7 +58,7 @@
         "type": "string",
         "scopes": [ "code" ],
         "modifiers": [ "i" ],
-        "confidence": "high"
+        "confidence": "medium"
       }
     ]
   },

--- a/src/oss-detect-backdoor/Resources/BackdoorRules/data_exfiltration.json
+++ b/src/oss-detect-backdoor/Resources/BackdoorRules/data_exfiltration.json
@@ -247,7 +247,7 @@
   },
   {
     "name": "Backdoor: Data Exfiltration (Whoami)",
-    "id": "BD000710",
+    "id": "BD000711",
     "description": "Backdoor: Data Exfiltration (Whoami)",
     "tags": [
       "Security.Backdoor.DataExfiltration.Whoami"
@@ -266,7 +266,7 @@
   },
   {
     "name": "Backdoor: Data Exfiltration (Dep Confusion Test)",
-    "id": "BD000711",
+    "id": "BD000712",
     "description": "Backdoor: Data Exfiltration (Dep Confusion Test)",
     "tags": [
       "Security.Backdoor.DataExfiltration.DepConfusionTest"

--- a/src/oss-detect-backdoor/Resources/BackdoorRules/dependency_confusion.json
+++ b/src/oss-detect-backdoor/Resources/BackdoorRules/dependency_confusion.json
@@ -47,7 +47,7 @@
         "type": "regex",
         "scopes": [ "code", "comment" ],
         "modifiers": [ "i" ],
-        "confidence": "low"
+        "confidence": "high"
       }
     ]
   }  

--- a/src/oss-detect-backdoor/Resources/BackdoorRules/dependency_confusion.json
+++ b/src/oss-detect-backdoor/Resources/BackdoorRules/dependency_confusion.json
@@ -34,7 +34,7 @@
   },
   {
     "name": "Dependency Confusion: Attack Pattern (Suspicious Hostname)",
-    "id": "BD001001",
+    "id": "BD001002",
     "description": "Dependency Confusion: Attack Pattern (Suspicious Hostname)",
     "tags": [
       "Security.DependencyConfusion.AttackPattern.SuspiciousHostname"
@@ -43,7 +43,7 @@
     "severity": "critical",
     "patterns": [
       {
-        "pattern": ".{1,45}\\.(pipedream\\.net|ceye\\.io|burpcollaborator\\.net|requestbin\\.net",
+        "pattern": ".{1,45}\\.(pipedream\\.net|ceye\\.io|burpcollaborator\\.net|requestbin\\.net)",
         "type": "regex",
         "scopes": [ "code", "comment" ],
         "modifiers": [ "i" ],

--- a/src/oss-detect-backdoor/Resources/BackdoorRules/ioc.json
+++ b/src/oss-detect-backdoor/Resources/BackdoorRules/ioc.json
@@ -11,7 +11,7 @@
     "patterns": [
       {
         "pattern": "(\\-bxor|cpassword|getnetworkcredential|securestringtobstr|shellexecute|processtartinfo|activexobject|regsvr32|mimikatz|new-scheduledtask|loadlibrary|ptrtostructure|getdelegateforfunctionpointer|unsafenativemethods|structuretoptr|virtualprotect)",
-        "type": "regex-word",
+        "type": "regexword",
         "scopes": [ "code" ],
         "modifiers": [ "i" ],
         "confidence": "medium"

--- a/src/oss-detect-backdoor/Resources/BackdoorRules/ioc.json
+++ b/src/oss-detect-backdoor/Resources/BackdoorRules/ioc.json
@@ -7,7 +7,7 @@
     "tags": [
       "Security.Backdoor.ReverseShell"
     ],
-    "severity": "moderate",
+    "severity": "important",
     "patterns": [
       {
         "pattern": "(\\-bxor|cpassword|getnetworkcredential|securestringtobstr|shellexecute|processtartinfo|activexobject|regsvr32|mimikatz|new-scheduledtask|loadlibrary|ptrtostructure|getdelegateforfunctionpointer|unsafenativemethods|structuretoptr|virtualprotect)",

--- a/src/oss-detect-backdoor/Resources/BackdoorRules/lolbas.json
+++ b/src/oss-detect-backdoor/Resources/BackdoorRules/lolbas.json
@@ -13,7 +13,7 @@
         "type": "regex",
         "scopes": [ "code" ],
         "modifiers": [ "i" ],
-        "confidence": "high"
+        "confidence": "low"
       }
     ]
   },
@@ -31,7 +31,7 @@
         "type": "regex",
         "scopes": [ "code" ],
         "modifiers": [ "i" ],
-        "confidence": "high"
+        "confidence": "low"
       }
     ]
   }

--- a/src/oss-detect-backdoor/Resources/BackdoorRules/obfuscation.json
+++ b/src/oss-detect-backdoor/Resources/BackdoorRules/obfuscation.json
@@ -10,7 +10,7 @@
     "patterns": [
       {
         "pattern": "base64|encodedcommand|obfuscate",
-        "type": "regex",
+        "type": "regexword",
         "scopes": [ "code" ],
         "modifiers": [ "i" ],
         "confidence": "high"
@@ -28,7 +28,7 @@
     "patterns": [
       {
         "pattern": "fromhex.+decode",
-        "type": "regex",
+        "type": "regexword",
         "scopes": [ "code" ],
         "modifiers": [ "i" ],
         "confidence": "high"

--- a/src/oss-detect-backdoor/Resources/BackdoorRules/pastebin.json
+++ b/src/oss-detect-backdoor/Resources/BackdoorRules/pastebin.json
@@ -10,7 +10,7 @@
     "patterns": [
       {
         "pattern": "pastebin|zerobin|ghostbin|hastebin",
-        "type": "regex",
+        "type": "regexword",
         "scopes": [ "code", "comment" ],
         "modifiers": [ "i" ],
         "confidence": "high"

--- a/src/oss-detect-backdoor/Resources/BackdoorRules/reverse_shell.json
+++ b/src/oss-detect-backdoor/Resources/BackdoorRules/reverse_shell.json
@@ -10,7 +10,7 @@
     "patterns": [
       {
         "pattern": "(shell\\.now\\.sh|tcp\\.ngrok\\.io|reverse shell|reverse-shell\\.sh)",
-        "type": "regex-word",
+        "type": "regexword",
         "scopes": [ "code", "comment" ],
         "modifiers": [ "i" ],
         "confidence": "high"

--- a/src/oss-detect-backdoor/oss-detect-backdoor.csproj
+++ b/src/oss-detect-backdoor/oss-detect-backdoor.csproj
@@ -18,7 +18,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="Resources\ad_networks.json" />
     <None Remove="Resources\BackdoorRules\backdoor_signatures.json" />
     <None Remove="Resources\BackdoorRules\code_execution.json" />
     <None Remove="Resources\BackdoorRules\crypto_currency.json" />
@@ -28,6 +27,7 @@
     <None Remove="Resources\BackdoorRules\lolbas.json" />
     <None Remove="Resources\BackdoorRules\obfuscation.json" />
     <None Remove="Resources\BackdoorRules\pastebin.json" />
+	<None Remove="Resources\BackdoorRules\reverse_shell.json" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR improves some of the backdoor detection rules, as well as #253 which was causing us to come back with empty results. A few other tweaks too.