### PR TITLE
Gfs/dependencies

### DIFF
--- a/src/Shared/Shared.csproj
+++ b/src/Shared/Shared.csproj
@@ -28,20 +28,20 @@
 
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.0.0-alpha-844" />
-    <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
+    <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Crayon" Version="2.0.62" />
     <PackageReference Include="F23.StringSimilarity" Version="4.1.0" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.36" />
-    <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.1.4" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.37" />
+    <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.1.5" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.0-preview.5.21301.5" />
     <PackageReference Include="NLog" Version="4.7.11" />
     <PackageReference Include="NLog.Schema" Version="4.7.11" />
     <PackageReference Include="NuGet.Versioning" Version="5.11.0" />
     <PackageReference Include="Octokit" Version="0.50.0" />
-    <PackageReference Include="Sarif.Sdk" Version="2.4.11" />
+    <PackageReference Include="Sarif.Sdk" Version="2.4.12" />
     <PackageReference Include="SemanticVersioning" Version="2.0.0" />
     <PackageReference Include="System.Console" Version="4.3.1" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.231">
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.240">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Shared/Shared.csproj
+++ b/src/Shared/Shared.csproj
@@ -40,8 +40,6 @@
     <PackageReference Include="Octokit" Version="0.50.0" />
     <PackageReference Include="Sarif.Sdk" Version="2.4.10" />
     <PackageReference Include="SemanticVersioning" Version="2.0.0" />
-    <PackageReference Include="sharpcompress" Version="0.29.0" />
-    <PackageReference Include="SharpZipLib" Version="1.3.2" />
     <PackageReference Include="System.Console" Version="4.3.1" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.220">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Shared/Shared.csproj
+++ b/src/Shared/Shared.csproj
@@ -31,17 +31,17 @@
     <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
     <PackageReference Include="Crayon" Version="2.0.62" />
     <PackageReference Include="F23.StringSimilarity" Version="4.1.0" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.34" />
-    <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.1.1" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.36" />
+    <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.1.3" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.0-preview.5.21301.5" />
-    <PackageReference Include="NLog" Version="4.7.10" />
-    <PackageReference Include="NLog.Schema" Version="4.7.10" />
-    <PackageReference Include="NuGet.Versioning" Version="5.10.0" />
+    <PackageReference Include="NLog" Version="4.7.11" />
+    <PackageReference Include="NLog.Schema" Version="4.7.11" />
+    <PackageReference Include="NuGet.Versioning" Version="5.11.0" />
     <PackageReference Include="Octokit" Version="0.50.0" />
-    <PackageReference Include="Sarif.Sdk" Version="2.4.10" />
+    <PackageReference Include="Sarif.Sdk" Version="2.4.11" />
     <PackageReference Include="SemanticVersioning" Version="2.0.0" />
     <PackageReference Include="System.Console" Version="4.3.1" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.220">
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.231">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Shared/Shared.csproj
+++ b/src/Shared/Shared.csproj
@@ -34,8 +34,8 @@
     <PackageReference Include="HtmlAgilityPack" Version="1.11.37" />
     <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.1.5" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.0-preview.5.21301.5" />
-    <PackageReference Include="NLog" Version="4.7.11" />
-    <PackageReference Include="NLog.Schema" Version="4.7.11" />
+    <PackageReference Include="NLog" Version="4.7.12" />
+    <PackageReference Include="NLog.Schema" Version="4.7.12" />
     <PackageReference Include="NuGet.Versioning" Version="5.11.0" />
     <PackageReference Include="Octokit" Version="0.50.0" />
     <PackageReference Include="Sarif.Sdk" Version="2.4.12" />

--- a/src/Shared/Shared.csproj
+++ b/src/Shared/Shared.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="Crayon" Version="2.0.62" />
     <PackageReference Include="F23.StringSimilarity" Version="4.1.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.36" />
-    <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.1.3" />
+    <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.1.4" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.0-preview.5.21301.5" />
     <PackageReference Include="NLog" Version="4.7.11" />
     <PackageReference Include="NLog.Schema" Version="4.7.11" />

--- a/src/Shared/Shared.csproj
+++ b/src/Shared/Shared.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.0.0-alpha-844" />
-    <PackageReference Include="CommandLineParser" Version="2.8.0" />
+    <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
     <PackageReference Include="Crayon" Version="2.0.62" />
     <PackageReference Include="F23.StringSimilarity" Version="4.1.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.37" />

--- a/src/oss-characteristics/oss-characteristic.csproj
+++ b/src/oss-characteristics/oss-characteristic.csproj
@@ -18,9 +18,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
+    <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Microsoft.CST.ApplicationInspector.Commands" Version="1.4.9" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.231">
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.240">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/oss-characteristics/oss-characteristic.csproj
+++ b/src/oss-characteristics/oss-characteristic.csproj
@@ -18,7 +18,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Microsoft.CST.ApplicationInspector.Commands" Version="1.4.9" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.240">
       <PrivateAssets>all</PrivateAssets>

--- a/src/oss-characteristics/oss-characteristic.csproj
+++ b/src/oss-characteristics/oss-characteristic.csproj
@@ -19,8 +19,8 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
-    <PackageReference Include="Microsoft.CST.ApplicationInspector.Commands" Version="1.4.4" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.220">
+    <PackageReference Include="Microsoft.CST.ApplicationInspector.Commands" Version="1.4.9" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.231">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/oss-defog/oss-defog.csproj
+++ b/src/oss-defog/oss-defog.csproj
@@ -25,8 +25,8 @@
     <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
     <PackageReference Include="MediaTypeMap.Core" Version="2.3.3" />
     <PackageReference Include="System.Console" Version="4.3.1" />
-    <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.1.1" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.220">
+    <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.1.3" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.231">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/oss-defog/oss-defog.csproj
+++ b/src/oss-defog/oss-defog.csproj
@@ -22,7 +22,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="MediaTypeMap.Core" Version="2.3.3" />
     <PackageReference Include="System.Console" Version="4.3.1" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.240">

--- a/src/oss-defog/oss-defog.csproj
+++ b/src/oss-defog/oss-defog.csproj
@@ -22,10 +22,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
+    <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="MediaTypeMap.Core" Version="2.3.3" />
     <PackageReference Include="System.Console" Version="4.3.1" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.231">
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.240">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/oss-defog/oss-defog.csproj
+++ b/src/oss-defog/oss-defog.csproj
@@ -25,7 +25,6 @@
     <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
     <PackageReference Include="MediaTypeMap.Core" Version="2.3.3" />
     <PackageReference Include="System.Console" Version="4.3.1" />
-    <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.1.3" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.231">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/oss-detect-backdoor/oss-detect-backdoor.csproj
+++ b/src/oss-detect-backdoor/oss-detect-backdoor.csproj
@@ -65,7 +65,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.220">
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.231">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/oss-detect-backdoor/oss-detect-backdoor.csproj
+++ b/src/oss-detect-backdoor/oss-detect-backdoor.csproj
@@ -64,7 +64,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.240">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/oss-detect-backdoor/oss-detect-backdoor.csproj
+++ b/src/oss-detect-backdoor/oss-detect-backdoor.csproj
@@ -64,8 +64,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.231">
+    <PackageReference Include="CommandLineParser" Version="2.8.0" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.240">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/oss-detect-cryptography/oss-detect-cryptography.csproj
+++ b/src/oss-detect-cryptography/oss-detect-cryptography.csproj
@@ -59,15 +59,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
+    <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="ELFSharp" Version="2.13.0" />
     <PackageReference Include="ICSharpCode.Decompiler" Version="7.1.0.6543" />
     <PackageReference Include="Microsoft.CST.ApplicationInspector.Commands" Version="1.4.9" />
-    <PackageReference Include="Microsoft.CST.DevSkim" Version="0.4.254" />
-    <PackageReference Include="PeNet" Version="2.8.1" />
+    <PackageReference Include="Microsoft.CST.DevSkim" Version="0.5.1" />
+    <PackageReference Include="PeNet" Version="2.9.1" />
     <PackageReference Include="SharpDisasm" Version="1.1.11" />
     <PackageReference Include="WebAssembly" Version="1.2.0" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.231">
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.240">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/oss-detect-cryptography/oss-detect-cryptography.csproj
+++ b/src/oss-detect-cryptography/oss-detect-cryptography.csproj
@@ -62,7 +62,7 @@
     <PackageReference Include="ELFSharp" Version="2.13.0" />
     <PackageReference Include="ICSharpCode.Decompiler" Version="7.1.0.6543" />
     <PackageReference Include="Microsoft.CST.ApplicationInspector.Commands" Version="1.4.9" />
-    <PackageReference Include="Microsoft.CST.DevSkim" Version="0.5.1" />
+    <PackageReference Include="Microsoft.CST.DevSkim" Version="0.5.3" />
     <PackageReference Include="PeNet" Version="2.9.1" />
     <PackageReference Include="SharpDisasm" Version="1.1.11" />
     <PackageReference Include="WebAssembly" Version="1.2.0" />

--- a/src/oss-detect-cryptography/oss-detect-cryptography.csproj
+++ b/src/oss-detect-cryptography/oss-detect-cryptography.csproj
@@ -63,7 +63,7 @@
     <PackageReference Include="ELFSharp" Version="2.13.0" />
     <PackageReference Include="ICSharpCode.Decompiler" Version="7.1.0.6543" />
     <PackageReference Include="Microsoft.CST.ApplicationInspector.Commands" Version="1.4.9" />
-    <PackageReference Include="Microsoft.CST.DevSkim" Version="0.4.253" />
+    <PackageReference Include="Microsoft.CST.DevSkim" Version="0.4.254" />
     <PackageReference Include="PeNet" Version="2.8.1" />
     <PackageReference Include="SharpDisasm" Version="1.1.11" />
     <PackageReference Include="WebAssembly" Version="1.2.0" />

--- a/src/oss-detect-cryptography/oss-detect-cryptography.csproj
+++ b/src/oss-detect-cryptography/oss-detect-cryptography.csproj
@@ -62,7 +62,7 @@
     <PackageReference Include="ELFSharp" Version="2.13.0" />
     <PackageReference Include="ICSharpCode.Decompiler" Version="7.1.0.6543" />
     <PackageReference Include="Microsoft.CST.ApplicationInspector.Commands" Version="1.4.9" />
-    <PackageReference Include="Microsoft.CST.DevSkim" Version="0.5.3" />
+    <PackageReference Include="Microsoft.CST.DevSkim" Version="0.6.1" />
     <PackageReference Include="PeNet" Version="2.9.1" />
     <PackageReference Include="SharpDisasm" Version="1.1.11" />
     <PackageReference Include="WebAssembly" Version="1.2.0" />

--- a/src/oss-detect-cryptography/oss-detect-cryptography.csproj
+++ b/src/oss-detect-cryptography/oss-detect-cryptography.csproj
@@ -59,7 +59,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="ELFSharp" Version="2.13.0" />
     <PackageReference Include="ICSharpCode.Decompiler" Version="7.1.0.6543" />
     <PackageReference Include="Microsoft.CST.ApplicationInspector.Commands" Version="1.4.9" />

--- a/src/oss-detect-cryptography/oss-detect-cryptography.csproj
+++ b/src/oss-detect-cryptography/oss-detect-cryptography.csproj
@@ -60,14 +60,14 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
-    <PackageReference Include="ELFSharp" Version="2.12.1" />
+    <PackageReference Include="ELFSharp" Version="2.13.0" />
     <PackageReference Include="ICSharpCode.Decompiler" Version="7.1.0.6543" />
-    <PackageReference Include="Microsoft.CST.ApplicationInspector.Commands" Version="1.4.4" />
-    <PackageReference Include="Microsoft.CST.DevSkim" Version="0.4.238" />
-    <PackageReference Include="PeNet" Version="2.6.3" />
+    <PackageReference Include="Microsoft.CST.ApplicationInspector.Commands" Version="1.4.9" />
+    <PackageReference Include="Microsoft.CST.DevSkim" Version="0.4.253" />
+    <PackageReference Include="PeNet" Version="2.8.1" />
     <PackageReference Include="SharpDisasm" Version="1.1.11" />
     <PackageReference Include="WebAssembly" Version="1.2.0" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.220">
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.231">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/oss-diff/oss-diff.csproj
+++ b/src/oss-diff/oss-diff.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.231" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.240" />
   </ItemGroup>
 
 </Project>

--- a/src/oss-diff/oss-diff.csproj
+++ b/src/oss-diff/oss-diff.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.220" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.231" />
   </ItemGroup>
 
 </Project>

--- a/src/oss-download/oss-download.csproj
+++ b/src/oss-download/oss-download.csproj
@@ -21,7 +21,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="System.Console" Version="4.3.1" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.240">
       <PrivateAssets>all</PrivateAssets>

--- a/src/oss-download/oss-download.csproj
+++ b/src/oss-download/oss-download.csproj
@@ -21,9 +21,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
+    <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="System.Console" Version="4.3.1" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.231">
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.240">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/oss-download/oss-download.csproj
+++ b/src/oss-download/oss-download.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
     <PackageReference Include="System.Console" Version="4.3.1" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.220">
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.231">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/oss-find-domain-squats/oss-find-domain-squats.csproj
+++ b/src/oss-find-domain-squats/oss-find-domain-squats.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.231" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.240" />
   </ItemGroup>
 
 </Project>

--- a/src/oss-find-domain-squats/oss-find-domain-squats.csproj
+++ b/src/oss-find-domain-squats/oss-find-domain-squats.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.220" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.231" />
   </ItemGroup>
 
 </Project>

--- a/src/oss-find-source/oss-find-source.csproj
+++ b/src/oss-find-source/oss-find-source.csproj
@@ -27,8 +27,8 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
-    <PackageReference Include="Sarif.Sdk" Version="2.4.10" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.220">
+    <PackageReference Include="Sarif.Sdk" Version="2.4.11" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.231">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/oss-find-source/oss-find-source.csproj
+++ b/src/oss-find-source/oss-find-source.csproj
@@ -26,7 +26,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Sarif.Sdk" Version="2.4.12" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.240">
       <PrivateAssets>all</PrivateAssets>

--- a/src/oss-find-source/oss-find-source.csproj
+++ b/src/oss-find-source/oss-find-source.csproj
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
-    <PackageReference Include="Sarif.Sdk" Version="2.4.11" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.231">
+    <PackageReference Include="CommandLineParser" Version="2.8.0" />
+    <PackageReference Include="Sarif.Sdk" Version="2.4.12" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.240">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/oss-find-squats/oss-find-squats.csproj
+++ b/src/oss-find-squats/oss-find-squats.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Sarif.Sdk" Version="2.4.11" />
-    <PackageReference Include="Scriban" Version="4.0.1" />
+    <PackageReference Include="Scriban" Version="4.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/oss-find-squats/oss-find-squats.csproj
+++ b/src/oss-find-squats/oss-find-squats.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Sarif.Sdk" Version="2.4.10" />
+    <PackageReference Include="Sarif.Sdk" Version="2.4.11" />
     <PackageReference Include="Scriban" Version="4.0.1" />
   </ItemGroup>
 
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.220" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.231" />
   </ItemGroup>
 
 </Project>

--- a/src/oss-find-squats/oss-find-squats.csproj
+++ b/src/oss-find-squats/oss-find-squats.csproj
@@ -17,8 +17,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Sarif.Sdk" Version="2.4.11" />
-    <PackageReference Include="Scriban" Version="4.0.2" />
+    <PackageReference Include="Sarif.Sdk" Version="2.4.12" />
+    <PackageReference Include="Scriban" Version="4.1.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.231" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.240" />
   </ItemGroup>
 
 </Project>

--- a/src/oss-health/oss-health.csproj
+++ b/src/oss-health/oss-health.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
     <PackageReference Include="Octokit" Version="0.50.0" />
     <PackageReference Include="System.Console" Version="4.3.1" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.220">
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.231">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/oss-health/oss-health.csproj
+++ b/src/oss-health/oss-health.csproj
@@ -22,10 +22,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
+    <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Octokit" Version="0.50.0" />
     <PackageReference Include="System.Console" Version="4.3.1" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.231">
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.240">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/oss-health/oss-health.csproj
+++ b/src/oss-health/oss-health.csproj
@@ -22,7 +22,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Octokit" Version="0.50.0" />
     <PackageReference Include="System.Console" Version="4.3.1" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.240">

--- a/src/oss-metadata/oss-metadata.csproj
+++ b/src/oss-metadata/oss-metadata.csproj
@@ -20,8 +20,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.231">
+    <PackageReference Include="CommandLineParser" Version="2.8.0" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.240">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/oss-metadata/oss-metadata.csproj
+++ b/src/oss-metadata/oss-metadata.csproj
@@ -20,7 +20,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.240">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/oss-metadata/oss-metadata.csproj
+++ b/src/oss-metadata/oss-metadata.csproj
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.220">
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.231">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/oss-reproducible/oss-reproducible.csproj
+++ b/src/oss-reproducible/oss-reproducible.csproj
@@ -62,7 +62,7 @@
   <ItemGroup>
     <PackageReference Include="DiffPlex" Version="1.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="SharpCompress" Version="0.29.0" />
+    <PackageReference Include="SharpCompress" Version="0.30.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -72,7 +72,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.231" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.240" />
   </ItemGroup>
 
 </Project>

--- a/src/oss-reproducible/oss-reproducible.csproj
+++ b/src/oss-reproducible/oss-reproducible.csproj
@@ -62,7 +62,7 @@
   <ItemGroup>
     <PackageReference Include="DiffPlex" Version="1.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="SharpCompress" Version="0.28.3" />
+    <PackageReference Include="SharpCompress" Version="0.29.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -72,7 +72,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.220" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.231" />
   </ItemGroup>
 
 </Project>

--- a/src/oss-risk-calculator/oss-risk-calculator.csproj
+++ b/src/oss-risk-calculator/oss-risk-calculator.csproj
@@ -18,8 +18,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.231">
+    <PackageReference Include="CommandLineParser" Version="2.8.0" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.240">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/oss-risk-calculator/oss-risk-calculator.csproj
+++ b/src/oss-risk-calculator/oss-risk-calculator.csproj
@@ -18,7 +18,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.240">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/oss-risk-calculator/oss-risk-calculator.csproj
+++ b/src/oss-risk-calculator/oss-risk-calculator.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.220">
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.231">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/oss-tests/oss-tests.csproj
+++ b/src/oss-tests/oss-tests.csproj
@@ -12,10 +12,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DiscUtils.Btrfs" Version="0.16.4" />
-    <PackageReference Include="DiscUtils.HfsPlus" Version="0.16.4" />
-    <PackageReference Include="DiscUtils.SquashFs" Version="0.16.4" />
-    <PackageReference Include="DiscUtils.Xfs" Version="0.16.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0-release-20210626-04" />
     <PackageReference Include="coverlet.collector" Version="3.0.3">
       <PrivateAssets>all</PrivateAssets>

--- a/src/oss-tests/oss-tests.csproj
+++ b/src/oss-tests/oss-tests.csproj
@@ -19,7 +19,7 @@
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.231">
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.240">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/oss-tests/oss-tests.csproj
+++ b/src/oss-tests/oss-tests.csproj
@@ -12,14 +12,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0-release-20210626-04" />
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.220">
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.231">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Bumps dependencies and updates BaseProjectManager to use RecursiveExtrator's directory extraction instead of a custom wrapper.