### PR TITLE
Fix #274

### DIFF
--- a/src/oss-download/DownloadTool.cs
+++ b/src/oss-download/DownloadTool.cs
@@ -14,9 +14,9 @@ namespace Microsoft.CST.OpenSource
     {
         public enum ErrorCode
         {
-            OK,
-            PROCESSING_EXCEPTION,
-            NO_TARGETS
+            Ok,
+            ProcessingException,
+            NoTargets
         }
 
         public class Options
@@ -98,16 +98,16 @@ namespace Microsoft.CST.OpenSource
                     catch (Exception ex)
                     {
                         Logger.Warn(ex, "Error processing {0}: {1}", target, ex.Message);
-                        return ErrorCode.PROCESSING_EXCEPTION;
+                        return ErrorCode.ProcessingException;
                     }
                 }
             }
             else
             {
                 Logger.Error("No targets were specified for downloading.");
-                return ErrorCode.NO_TARGETS;
+                return ErrorCode.NoTargets;
             }
-            return ErrorCode.OK;
+            return ErrorCode.Ok;
         }
     }
 }

--- a/src/oss-download/DownloadTool.cs
+++ b/src/oss-download/DownloadTool.cs
@@ -61,12 +61,12 @@ namespace Microsoft.CST.OpenSource
         ///     Main entrypoint for the download program.
         /// </summary>
         /// <param name="args"> parameters passed in from the user </param>
-        static async Task<ErrorCode> Main(string[] args)
+        static async Task<int> Main(string[] args)
         {
             ShowToolBanner();
             var downloadTool = new DownloadTool();
             var opts = downloadTool.ParseOptions<Options>(args).Value;
-            return await downloadTool.RunAsync(opts);
+            return (int)(await downloadTool.RunAsync(opts));
         }
 
         private async Task<ErrorCode> RunAsync(Options options)

--- a/src/oss-download/DownloadTool.cs
+++ b/src/oss-download/DownloadTool.cs
@@ -104,6 +104,7 @@ namespace Microsoft.CST.OpenSource
             }
             else
             {
+                Logger.Error("No targets were specified for downloading.");
                 return ErrorCode.NO_TARGETS;
             }
             return ErrorCode.OK;


### PR DESCRIPTION
Return a non-zero error code when hitting a fatal error downloading.

If there are sub-fatal errors they will remain just as logged messages.