### PR TITLE
Gfs/bump devskim

### DIFF
--- a/src/oss-characteristics/CharacteristicTool.cs
+++ b/src/oss-characteristics/CharacteristicTool.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CST.OpenSource
                 HelpText = "exclude files or paths which match provided glob patterns.")]
             public string FilePathExclusions { get; set; } = "";
 
-            public bool TreatEverythingAsCode { get; set; } = true;
+            public bool AllowTagsInBuildFiles { get; set; } = true;
 
             public bool AllowDupTags { get; set; } = false;
 
@@ -105,7 +105,7 @@ namespace Microsoft.CST.OpenSource
                 CustomRulesPath = options.CustomRuleDirectory,
                 ConfidenceFilters = "high,medium,low",
                 ScanUnknownTypes = true,
-                TreatEverythingAsCode = options.TreatEverythingAsCode,
+                AllowAllTagsInBuildFiles = options.AllowTagsInBuildFiles,
                 SingleThread = false,
                 FilePathExclusions = options.FilePathExclusions?.Split(',') ?? Array.Empty<string>()
             };

--- a/src/oss-characteristics/oss-characteristic.csproj
+++ b/src/oss-characteristics/oss-characteristic.csproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CST.ApplicationInspector.Commands" Version="1.4.13" />
+    <PackageReference Include="Microsoft.CST.ApplicationInspector.Commands" Version="1.4.14" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.240">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/oss-characteristics/oss-characteristic.csproj
+++ b/src/oss-characteristics/oss-characteristic.csproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CST.ApplicationInspector.Commands" Version="1.4.9" />
+    <PackageReference Include="Microsoft.CST.ApplicationInspector.Commands" Version="1.4.13" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.240">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -42,7 +42,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\LICENSE.txt" Pack="true" PackagePath=""/>
-    <None Include="..\..\icon-128.png" Pack="true" PackagePath=""/>
+    <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="" />
+    <None Include="..\..\icon-128.png" Pack="true" PackagePath="" />
   </ItemGroup>
 </Project>

--- a/src/oss-detect-backdoor/DetectBackdoorTool.cs
+++ b/src/oss-detect-backdoor/DetectBackdoorTool.cs
@@ -144,7 +144,7 @@ namespace Microsoft.CST.OpenSource
                     UseCache = options.UseCache,
                     Format = options.Format == "text" ? "none" : options.Format,
                     OutputFile = options.OutputFile,
-                    TreatEverythingAsCode = true,
+                    AllowTagsInBuildFiles = true,
                     FilePathExclusions = ".md,LICENSE,.txt",
                     AllowDupTags = true,
                     SarifLevel = CodeAnalysis.Sarif.FailureLevel.Warning

--- a/src/oss-detect-cryptography/oss-detect-cryptography.csproj
+++ b/src/oss-detect-cryptography/oss-detect-cryptography.csproj
@@ -70,11 +70,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ELFSharp" Version="2.13.0" />
+    <PackageReference Include="ELFSharp" Version="2.13.2" />
     <PackageReference Include="ICSharpCode.Decompiler" Version="7.1.0.6543" />
-    <PackageReference Include="Microsoft.CST.ApplicationInspector.Commands" Version="1.4.9" />
-    <PackageReference Include="Microsoft.CST.DevSkim" Version="0.6.1" />
-    <PackageReference Include="PeNet" Version="2.9.1" />
+    <PackageReference Include="Microsoft.CST.ApplicationInspector.Commands" Version="1.4.12" />
+    <PackageReference Include="Microsoft.CST.DevSkim" Version="0.6.5" />
+    <PackageReference Include="PeNet" Version="2.9.2" />
     <PackageReference Include="SharpDisasm" Version="1.1.11" />
     <PackageReference Include="WebAssembly" Version="1.2.0" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.240">
@@ -89,7 +89,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\LICENSE.txt" Pack="true" PackagePath=""/>
-    <None Include="..\..\icon-128.png" Pack="true" PackagePath=""/>
+    <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="" />
+    <None Include="..\..\icon-128.png" Pack="true" PackagePath="" />
   </ItemGroup>
 </Project>

--- a/src/oss-detect-cryptography/oss-detect-cryptography.csproj
+++ b/src/oss-detect-cryptography/oss-detect-cryptography.csproj
@@ -72,7 +72,7 @@
   <ItemGroup>
     <PackageReference Include="ELFSharp" Version="2.13.2" />
     <PackageReference Include="ICSharpCode.Decompiler" Version="7.1.0.6543" />
-    <PackageReference Include="Microsoft.CST.ApplicationInspector.Commands" Version="1.4.12" />
+    <PackageReference Include="Microsoft.CST.ApplicationInspector.Commands" Version="1.4.13" />
     <PackageReference Include="Microsoft.CST.DevSkim" Version="0.6.5" />
     <PackageReference Include="PeNet" Version="2.9.2" />
     <PackageReference Include="SharpDisasm" Version="1.1.11" />


### PR DESCRIPTION
OSS-Detect-Cryptography
Applies the fix made in devskim to Fix #290.

Bump some other dependencies.