### PR TITLE
Converts OSS Detect Cryptography to use Application Inspector

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning">
-      <Version>3.3.37</Version>
+      <Version>3.4.244</Version>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/Shared/Shared.csproj
+++ b/src/Shared/Shared.csproj
@@ -53,10 +53,6 @@
     <PackageReference Include="Sarif.Sdk" Version="2.4.12" />
     <PackageReference Include="SemanticVersioning" Version="2.0.0" />
     <PackageReference Include="System.Console" Version="4.3.1" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.240">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/oss-characteristics/oss-characteristic.csproj
+++ b/src/oss-characteristics/oss-characteristic.csproj
@@ -30,10 +30,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CST.ApplicationInspector.Commands" Version="1.4.14" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.240">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/oss-defog/oss-defog.csproj
+++ b/src/oss-defog/oss-defog.csproj
@@ -35,10 +35,6 @@
   <ItemGroup>
     <PackageReference Include="MediaTypeMap.Core" Version="2.3.3" />
     <PackageReference Include="System.Console" Version="4.3.1" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.240">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/oss-detect-backdoor/oss-detect-backdoor.csproj
+++ b/src/oss-detect-backdoor/oss-detect-backdoor.csproj
@@ -75,13 +75,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.240">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\oss-characteristics\oss-characteristic.csproj" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>

--- a/src/oss-detect-cryptography/Issue.cs
+++ b/src/oss-detect-cryptography/Issue.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+namespace Microsoft.CST.OpenSource
+{
+    using Microsoft.ApplicationInspector.RulesEngine;
+
+    public record Issue
+    {
+        public Boundary Boundary { get; }
+        public Location StartLocation { get; }
+        public Location EndLocation { get; }
+        public Rule Rule { get; }
+
+        public Issue(Boundary Boundary, Location StartLocation, Location EndLocation, Rule Rule)
+        {
+            this.Boundary = Boundary;
+            this.StartLocation = StartLocation;
+            this.EndLocation = EndLocation;
+            this.Rule = Rule;
+        }
+    }
+}

--- a/src/oss-detect-cryptography/oss-detect-cryptography.csproj
+++ b/src/oss-detect-cryptography/oss-detect-cryptography.csproj
@@ -72,15 +72,11 @@
   <ItemGroup>
     <PackageReference Include="ELFSharp" Version="2.13.2" />
     <PackageReference Include="ICSharpCode.Decompiler" Version="7.1.0.6543" />
-    <PackageReference Include="Microsoft.CST.ApplicationInspector.Commands" Version="1.4.13" />
+    <PackageReference Include="Microsoft.CST.ApplicationInspector.Commands" Version="1.4.14" />
     <PackageReference Include="Microsoft.CST.DevSkim" Version="0.6.5" />
     <PackageReference Include="PeNet" Version="2.9.2" />
     <PackageReference Include="SharpDisasm" Version="1.1.11" />
     <PackageReference Include="WebAssembly" Version="1.2.0" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.240">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/oss-diff/oss-diff.csproj
+++ b/src/oss-diff/oss-diff.csproj
@@ -37,10 +37,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.240" />
-  </ItemGroup>
-  
-  <ItemGroup>
     <None Include="..\..\LICENSE.txt" Pack="true" PackagePath=""/>
     <None Include="..\..\icon-128.png" Pack="true" PackagePath=""/>
   </ItemGroup>

--- a/src/oss-download/oss-download.csproj
+++ b/src/oss-download/oss-download.csproj
@@ -33,10 +33,6 @@
 
   <ItemGroup>
     <PackageReference Include="System.Console" Version="4.3.1" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.240">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/oss-find-domain-squats/oss-find-domain-squats.csproj
+++ b/src/oss-find-domain-squats/oss-find-domain-squats.csproj
@@ -26,8 +26,4 @@
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.240" />
-  </ItemGroup>
-
 </Project>

--- a/src/oss-find-source/oss-find-source.csproj
+++ b/src/oss-find-source/oss-find-source.csproj
@@ -38,10 +38,6 @@
 
   <ItemGroup>
     <PackageReference Include="Sarif.Sdk" Version="2.4.12" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.240">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/oss-find-squats/oss-find-squats.csproj
+++ b/src/oss-find-squats/oss-find-squats.csproj
@@ -32,10 +32,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.240" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="" />
     <None Include="..\..\icon-128.png" Pack="true" PackagePath="" />
   </ItemGroup>

--- a/src/oss-health/oss-health.csproj
+++ b/src/oss-health/oss-health.csproj
@@ -35,10 +35,6 @@
   <ItemGroup>
     <PackageReference Include="Octokit" Version="0.50.0" />
     <PackageReference Include="System.Console" Version="4.3.1" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.240">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/oss-metadata/oss-metadata.csproj
+++ b/src/oss-metadata/oss-metadata.csproj
@@ -31,13 +31,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.240">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
 

--- a/src/oss-reproducible/oss-reproducible.csproj
+++ b/src/oss-reproducible/oss-reproducible.csproj
@@ -83,10 +83,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.240" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Include="..\..\LICENSE.txt" Pack="true" PackagePath=""/>
     <None Include="..\..\icon-128.png" Pack="true" PackagePath=""/>
   </ItemGroup>

--- a/src/oss-risk-calculator/oss-risk-calculator.csproj
+++ b/src/oss-risk-calculator/oss-risk-calculator.csproj
@@ -29,13 +29,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.240">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\oss-characteristics\oss-characteristic.csproj" />
     <ProjectReference Include="..\oss-detect-cryptography\oss-detect-cryptography.csproj" />
     <ProjectReference Include="..\oss-health\oss-health.csproj" />

--- a/src/oss-tests/DetectCryptographyTests.cs
+++ b/src/oss-tests/DetectCryptographyTests.cs
@@ -2,6 +2,7 @@
 
 using Microsoft.CST.OpenSource.Shared;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -40,7 +41,7 @@ namespace Microsoft.CST.OpenSource.Tests
             List<IssueRecord>? results = await detectCryptographyTool.AnalyzePackage(new PackageURL(purl), targetDirectoryName, false);
 
             IEnumerable<string>? distinctTargets = expectedTags.Distinct();
-            IEnumerable<string>? distinctFindings = results.SelectMany(s => s.Issue.Rule.Tags ?? new List<string>())
+            IEnumerable<string>? distinctFindings = results.SelectMany(s => s.Issue.Rule.Tags ?? Array.Empty<string>())
                                           .Where(s => s.StartsWith("Cryptography.Implementation"))
                                           .Distinct();
 

--- a/src/oss-tests/oss-tests.csproj
+++ b/src/oss-tests/oss-tests.csproj
@@ -19,10 +19,6 @@
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.240">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Fix #260.

Removes all the extra references to NBGV. The Directory.Build.Props should handle it.