### PR TITLE
Added mutation support to the scope for scoped npm packages.

### DIFF
--- a/src/Shared/Helpers/StringExtensions.cs
+++ b/src/Shared/Helpers/StringExtensions.cs
@@ -2,6 +2,8 @@
 
 namespace Microsoft.CST.OpenSource.Helpers
 {
+    using System.Diagnostics.CodeAnalysis;
+
     /// <summary>
     /// A utilities class for string extension functions.
     /// </summary>
@@ -28,6 +30,16 @@ namespace Microsoft.CST.OpenSource.Helpers
             {
                 return str;
             }
+        }
+
+        public static bool IsBlank([NotNullWhen(false)]this string? str)
+        {
+            return string.IsNullOrWhiteSpace(str);
+        }
+
+        public static bool IsNotBlank([NotNullWhen(true)]this string? str)
+        {
+            return !str.IsBlank();
         }
     }
 }

--- a/src/oss-tests/FindSquatsTests.cs
+++ b/src/oss-tests/FindSquatsTests.cs
@@ -4,9 +4,9 @@ using Microsoft.CST.OpenSource.FindSquats;
 using Microsoft.CST.OpenSource.FindSquats.ExtensionMethods;
 using Microsoft.CST.OpenSource.FindSquats.Mutators;
 using Microsoft.CST.OpenSource.PackageManagers;
-using Microsoft.CST.OpenSource.Shared;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Microsoft.CST.OpenSource.Tests
@@ -28,6 +28,25 @@ namespace Microsoft.CST.OpenSource.Tests
             };
             (string output, int numSquats) result = await fst.RunAsync(options);
             Assert.IsTrue(expectedToHaveSquats ? result.numSquats > 0 : result.numSquats == 0);
+        }
+
+        [DataTestMethod]
+        [DataRow("pkg:npm/%40angular/core", "@engular/core", "@angullar/core")]
+        [DataRow("pkg:npm/lodash", "odash", "lodah")]
+        [DataRow("pkg:npm/%40babel/runtime", "@abel/runtime", "@bable/runtime")]
+        public void ScopedNpmPackageSquats(string packageUrl, params string[] expectedSquats)
+        {
+            FindPackageSquats findPackageSquats =
+                new(new DefaultHttpClientFactory(), new PackageURL(packageUrl));
+
+            IDictionary<string, IList<Mutation>>? squatsCandidates = findPackageSquats.GenerateSquatCandidates();
+
+            Assert.IsNotNull(squatsCandidates);
+
+            foreach (string expectedSquat in expectedSquats)
+            {
+                Assert.IsTrue(squatsCandidates.ContainsKey(expectedSquat));
+            }
         }
 
         [DataTestMethod]


### PR DESCRIPTION
For an npm package e.g. `@angular/core` the typo squats were generating mutations that were just variations on `core` returning things like `coree` and `cort`, etc. but for scoped npm packages we want the mutations to be more like `@engular/core` and `@angullar/core`. With the mutations on the scope/namespace, not the package name.