### PR TITLE
Update Metadata Normalization

### DIFF
--- a/src/Shared.CLI/Shared.CLI.csproj
+++ b/src/Shared.CLI/Shared.CLI.csproj
@@ -49,7 +49,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.0" />
     <PackageReference Include="NLog" Version="4.7.13" />
     <PackageReference Include="NLog.Schema" Version="4.7.13" />
-    <PackageReference Include="NuGet.Versioning" Version="6.0.0" />
+    <PackageReference Include="NuGet.Versioning" Version="6.1.0" />
     <PackageReference Include="Octokit" Version="0.50.0" />
     <PackageReference Include="Sarif.Sdk" Version="2.4.12" />
     <PackageReference Include="SemanticVersioning" Version="2.0.0" />

--- a/src/Shared/Model/PackageMetadata.cs
+++ b/src/Shared/Model/PackageMetadata.cs
@@ -87,7 +87,10 @@ namespace Microsoft.CST.OpenSource.Model
         public List<User>? Maintainers { get; set; }
 
         [JsonProperty(PropertyName = "package_uri", NullValueHandling = NullValueHandling.Ignore)]
-        public string? Package_Uri { get; set; }
+        public string? PackageUri { get; set; }
+
+        [JsonProperty(PropertyName = "api_package_uri", NullValueHandling = NullValueHandling.Ignore)]
+        public string? ApiPackageUri { get; set; }
 
         [JsonProperty(PropertyName = "package_manager_uri", NullValueHandling = NullValueHandling.Ignore)]
         public string? PackageManagerUri { get; set; }
@@ -124,6 +127,9 @@ namespace Microsoft.CST.OpenSource.Model
 
         [JsonProperty(PropertyName = "version_uri", NullValueHandling = NullValueHandling.Ignore)]
         public string? VersionUri { get; set; }
+
+        [JsonProperty(PropertyName = "api_version_uri", NullValueHandling = NullValueHandling.Ignore)]
+        public string? ApiVersionUri { get; set; }
 
         [JsonProperty(PropertyName = "active_flag", NullValueHandling = NullValueHandling.Ignore)]
         public bool? Active { get; set; }

--- a/src/Shared/Model/PackageMetadata.cs
+++ b/src/Shared/Model/PackageMetadata.cs
@@ -182,6 +182,9 @@ namespace Microsoft.CST.OpenSource.Model
     {
         [JsonProperty(PropertyName = "package", NullValueHandling = NullValueHandling.Ignore)]
         public string? Package { get; set; }
+        
+        [JsonProperty(PropertyName = "framework", NullValueHandling = NullValueHandling.Ignore)]
+        public string? Framework { get; set; }
     }
 
     public class Command

--- a/src/Shared/Model/PackageMetadata.cs
+++ b/src/Shared/Model/PackageMetadata.cs
@@ -91,6 +91,9 @@ namespace Microsoft.CST.OpenSource.Model
 
         [JsonProperty(PropertyName = "package_manager_uri", NullValueHandling = NullValueHandling.Ignore)]
         public string? PackageManagerUri { get; set; }
+        
+        [JsonProperty(PropertyName = "homepage", NullValueHandling = NullValueHandling.Ignore)]
+        public string? Homepage { get; set; }
 
         [JsonProperty(PropertyName = "package_version", NullValueHandling = NullValueHandling.Ignore)]
         public string? PackageVersion { get; set; }

--- a/src/Shared/PackageManagers/BaseProjectManager.cs
+++ b/src/Shared/PackageManagers/BaseProjectManager.cs
@@ -396,8 +396,8 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         /// <summary>
         /// Return a normalized package metadata.
         /// </summary>
-        /// <param name="purl"></param>
-        /// <returns></returns>
+        /// <param name="purl">The <see cref="PackageURL"/> to get the normalized metadata for.</param>
+        /// <returns>A <see cref="GetPackageMetadata"/> object representing this <see cref="PackageURL"/>.</returns>
         public virtual Task<PackageMetadata> GetPackageMetadata(PackageURL purl)
         {
             string typeName = GetType().Name;

--- a/src/Shared/PackageManagers/GitHubProjectManager.cs
+++ b/src/Shared/PackageManagers/GitHubProjectManager.cs
@@ -2,6 +2,7 @@
 
 namespace Microsoft.CST.OpenSource.PackageManagers
 {
+    using Helpers;
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
@@ -232,6 +233,33 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         public override Uri GetPackageAbsoluteUri(PackageURL purl)
         {
             return new Uri($"{ENV_GITHUB_ENDPOINT}/{purl.Namespace}/{purl.Name}");
+        }
+        
+        /// <summary>
+        /// Gets if the URL is a GitHub repo URL.
+        /// </summary>
+        /// <param name="url">A URL to check if it's from GitHub.</param>
+        /// <param name="purl">The variable to set the purl of if it is a GitHub repo.</param>
+        /// <returns>If the url is a GitHubRepo.</returns>
+        public static bool IsGitHubRepoUrl(string url, out PackageURL? purl)
+        {
+            Check.NotNull(nameof(url), url);
+            purl = null;
+
+            if (url.Contains(ENV_GITHUB_ENDPOINT))
+            {
+                try
+                {
+                    purl = ParseUri(new Uri(url));
+                }
+                catch (ArgumentException)
+                {
+                    return false;
+                }
+
+                return true;
+            }
+            return false;
         }
 
         private static readonly Regex GithubExtractorRegex = new(

--- a/src/Shared/PackageManagers/NPMProjectManager.cs
+++ b/src/Shared/PackageManagers/NPMProjectManager.cs
@@ -167,7 +167,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
         public override Uri GetPackageAbsoluteUri(PackageURL purl)
         {
-            return new Uri($"{ENV_NPM_API_ENDPOINT}/package/{purl?.Name}");
+            return new Uri($"{ENV_NPM_API_ENDPOINT}/{purl?.Name}");
         }
 
         /// <inheritdoc />
@@ -187,7 +187,8 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             metadata.PackageManagerUri = ENV_NPM_ENDPOINT;
             metadata.Platform = "NPM";
             metadata.Language = "JavaScript";
-            metadata.Package_Uri = $"{metadata.PackageManagerUri}/package/{metadata.Name}";
+            metadata.PackageUri = $"{metadata.PackageManagerUri}/package/{metadata.Name}";
+            metadata.ApiPackageUri = $"{ENV_NPM_API_ENDPOINT}/{metadata.Name}";
 
             List<Version> versions = GetVersions(contentJSON);
             Version? latestVersion = GetLatestVersion(versions);
@@ -210,8 +211,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                 if (versionElement != null)
                 {
                     // redo the generic values to version specific values
-                    metadata.Package_Uri = $"{ENV_NPM_ENDPOINT}/package/{metadata.Name}";
+                    metadata.PackageUri = $"{ENV_NPM_ENDPOINT}/package/{metadata.Name}";
                     metadata.VersionUri = $"{ENV_NPM_ENDPOINT}/package/{metadata.Name}/v/{metadata.PackageVersion}";
+                    metadata.ApiVersionUri = $"{ENV_NPM_API_ENDPOINT}/{metadata.Name}/{metadata.PackageVersion}";
 
                     JsonElement? distElement = OssUtilities.GetJSONPropertyIfExists(versionElement, "dist");
                     if (distElement?.GetProperty("tarball") is JsonElement tarballElement)

--- a/src/Shared/PackageManagers/NPMProjectManager.cs
+++ b/src/Shared/PackageManagers/NPMProjectManager.cs
@@ -254,14 +254,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                     }
 
                     // install scripts
+                    List<string>? scripts = OssUtilities.ConvertJSONToList(OssUtilities.GetJSONPropertyIfExists(versionElement, "scripts"));
+                    if (scripts is not null && scripts.Count > 0)
                     {
-                        if (OssUtilities.GetJSONEnumerator(OssUtilities.GetJSONPropertyIfExists(versionElement, "scripts"))
-                                is JsonElement.ArrayEnumerator enumerator &&
-                            enumerator.Any())
-                        {
-                            metadata.Scripts ??= new List<Command>();
-                            enumerator.ToList().ForEach((element) => metadata.Scripts.Add(new Command { CommandLine = element.ToString() }));
-                        }
+                        metadata.Scripts ??= new List<Command>();
+                        scripts.ForEach((element) => metadata.Scripts.Add(new Command { CommandLine = element }));
                     }
 
                     // dependencies
@@ -286,22 +283,20 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                     }
 
                     // maintainers
+                    JsonElement? maintainersElement = OssUtilities.GetJSONPropertyIfExists(versionElement, "maintainers");
+                    if (maintainersElement?.EnumerateArray() is JsonElement.ArrayEnumerator maintainerEnumerator)
                     {
-                        JsonElement? maintainersElement = OssUtilities.GetJSONPropertyIfExists(versionElement, "maintainers");
-                        if (maintainersElement?.EnumerateArray() is JsonElement.ArrayEnumerator enumerator)
+                        metadata.Maintainers ??= new List<User>();
+                        maintainerEnumerator.ToList().ForEach((element) =>
                         {
-                            metadata.Maintainers ??= new List<User>();
-                            enumerator.ToList().ForEach((element) =>
-                            {
-                                metadata.Maintainers.Add(
-                                    new User
-                                    {
-                                        Name = OssUtilities.GetJSONPropertyStringIfExists(element, "name"),
-                                        Email = OssUtilities.GetJSONPropertyStringIfExists(element, "email"),
-                                        Url = OssUtilities.GetJSONPropertyStringIfExists(element, "url")
-                                    });
-                            });
-                        }
+                            metadata.Maintainers.Add(
+                                new User
+                                {
+                                    Name = OssUtilities.GetJSONPropertyStringIfExists(element, "name"),
+                                    Email = OssUtilities.GetJSONPropertyStringIfExists(element, "email"),
+                                    Url = OssUtilities.GetJSONPropertyStringIfExists(element, "url")
+                                });
+                        });
                     }
 
                     // repository

--- a/src/Shared/PackageManagers/NPMProjectManager.cs
+++ b/src/Shared/PackageManagers/NPMProjectManager.cs
@@ -232,6 +232,14 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                             Signature = pair[1]
                         });
                     }
+                    
+                    // check for typescript
+                    List<string>? devDependencies = OssUtilities.ConvertJSONToList(OssUtilities.GetJSONPropertyIfExists(versionElement, "devDependencies"));
+                    if (devDependencies is not null && devDependencies.Count > 0 && devDependencies.Any(stringToCheck => stringToCheck.Contains("\"typescript\":")))
+                    {
+                        metadata.Language = "TypeScript";
+                    }
+                    
                     // size
                     if (OssUtilities.GetJSONPropertyIfExists(distElement, "unpackedSize") is JsonElement sizeElement &&
                         sizeElement.GetInt64() is long size)

--- a/src/Shared/PackageManagers/NPMProjectManager.cs
+++ b/src/Shared/PackageManagers/NPMProjectManager.cs
@@ -239,6 +239,13 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                         metadata.Size = size;
                     }
 
+                    // homepage
+                    if (OssUtilities.GetJSONPropertyStringIfExists(versionElement, "homepage") is string homepage &&
+                        !string.IsNullOrWhiteSpace(homepage))
+                    {
+                        metadata.Homepage = homepage;
+                    }
+                    
                     // commit id
                     if (OssUtilities.GetJSONPropertyStringIfExists(versionElement, "gitHead") is string gitHead &&
                         !string.IsNullOrWhiteSpace(gitHead))

--- a/src/Shared/PackageManagers/NPMProjectManager.cs
+++ b/src/Shared/PackageManagers/NPMProjectManager.cs
@@ -170,11 +170,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             return new Uri($"{ENV_NPM_API_ENDPOINT}/package/{purl?.Name}");
         }
 
-        /// <summary>
-        /// Gets the structured metadata for the npm package
-        /// </summary>
-        /// <param name="purl">PackageURL to retrieve metadata for</param>
-        /// <returns></returns>
+        /// <inheritdoc />
         public override async Task<PackageMetadata> GetPackageMetadata(PackageURL purl)
         {
             PackageMetadata metadata = new();

--- a/src/Shared/PackageManagers/NuGetProjectManager.cs
+++ b/src/Shared/PackageManagers/NuGetProjectManager.cs
@@ -2,6 +2,7 @@
 
 namespace Microsoft.CST.OpenSource.PackageManagers
 {
+    using Helpers;
     using HtmlAgilityPack;
     using Model;
     using NuGet.Packaging;
@@ -417,7 +418,15 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                     // TODO: maintainers
 
                     // repository
-                    NuspecReader? nuspecReader = GetNuspec(purl);
+                    PackageURL nuspecPurl = purl;
+
+                    // If no version specified, get it for the latest version
+                    if (nuspecPurl.Version.IsBlank())
+                    {
+                        nuspecPurl = new PackageURL(purl.Type, purl.Namespace, purl.Name, metadata.PackageVersion,
+                            purl.Qualifiers, purl.Subpath);
+                    }
+                    NuspecReader? nuspecReader = GetNuspec(nuspecPurl);
                     RepositoryMetadata? repositoryMetadata = nuspecReader?.GetRepositoryMetadata();
                     if (repositoryMetadata != null)
                     {

--- a/src/Shared/PackageManagers/NuGetProjectManager.cs
+++ b/src/Shared/PackageManagers/NuGetProjectManager.cs
@@ -400,6 +400,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                         Algorithm = OssUtilities.GetJSONPropertyStringIfExists(versionContent, "packageHashAlgorithm"),
                         Signature = OssUtilities.GetJSONPropertyStringIfExists(versionContent, "packageHash"),
                     });
+                    
+                    // homepage
+                    metadata.Homepage = OssUtilities.GetJSONPropertyStringIfExists(versionContent, "projectUrl");
 
                     // author(s)
                     JsonElement? authorElement = OssUtilities.GetJSONPropertyIfExists(versionElement, "authors");

--- a/src/Shared/PackageManagers/NuGetProjectManager.cs
+++ b/src/Shared/PackageManagers/NuGetProjectManager.cs
@@ -22,6 +22,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
     {
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public static string ENV_NUGET_ENDPOINT_API = "https://api.nuget.org";
+        public static string ENV_NUGET_ENDPOINT = "https://www.nuget.org";
 
         private readonly string NUGET_DEFAULT_REGISTRATION_ENDPOINT = "https://api.nuget.org/v3/registration5-gz-semver2/";
 
@@ -354,11 +355,12 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             // Title is different than name or description for NuGet packages, not always used.
             // metadata.Title = GetLatestCatalogEntry(root).GetProperty("title").GetString();
 
-            metadata.PackageManagerUri = ENV_NUGET_ENDPOINT_API;
+            metadata.PackageManagerUri = ENV_NUGET_ENDPOINT;
             metadata.Platform = "NUGET";
             metadata.Language = "C#";
             // metadata.SpokenLanguage = GetLatestCatalogEntry(root).GetProperty("language").GetString();
-            metadata.Package_Uri = $"{metadata.PackageManagerUri}/{metadata.Name?.ToLower()}/index.json";
+            metadata.PackageUri = $"{metadata.PackageManagerUri}/packages/{metadata.Name?.ToLower()}";
+            metadata.ApiPackageUri = $"{RegistrationEndpoint}{metadata.Name?.ToLower()}/index.json";
 
             List<Version> versions = GetVersions(contentJSON);
             Version? latestVersion = GetLatestVersion(versions);
@@ -381,9 +383,10 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                 if (versionElement != null)
                 {
                     // redo the generic values to version specific values
-                    metadata.VersionUri = OssUtilities.GetJSONPropertyStringIfExists(versionElement, "@id");
+                    metadata.VersionUri = $"{metadata.PackageManagerUri}/packages/{metadata.Name?.ToLower()}/{versionToGet}";
+                    metadata.ApiVersionUri = OssUtilities.GetJSONPropertyStringIfExists(versionElement, "@id");
 
-                    JsonElement versionContent = await this.GetVersionUriMetadata(metadata.VersionUri!) ?? throw new InvalidOperationException();
+                    JsonElement versionContent = await this.GetVersionUriMetadata(metadata.ApiVersionUri!) ?? throw new InvalidOperationException();
                     
                     // Get the artifact contents url
                     JsonElement? packageContent = OssUtilities.GetJSONPropertyIfExists(versionElement, "packageContent");

--- a/src/Shared/PackageManagers/PyPIProjectManager.cs
+++ b/src/Shared/PackageManagers/PyPIProjectManager.cs
@@ -196,7 +196,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                 metadata.Description = summary;
             }
             metadata.PackageManagerUri = ENV_PYPI_ENDPOINT;
-            metadata.Package_Uri = OssUtilities.GetJSONPropertyStringIfExists(infoElement, "package_url");
+            metadata.PackageUri = OssUtilities.GetJSONPropertyStringIfExists(infoElement, "package_url");
             metadata.Keywords = OssUtilities.ConvertJSONToList(OssUtilities.GetJSONPropertyIfExists(infoElement, "keywords"));
 
             // author

--- a/src/Shared/Shared.Lib.csproj
+++ b/src/Shared/Shared.Lib.csproj
@@ -42,6 +42,7 @@
         <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.0" />
         <PackageReference Include="NLog" Version="4.7.12" />
         <PackageReference Include="NLog.Schema" Version="4.7.12" />
+        <PackageReference Include="NuGet.Packaging" Version="6.1.0" />
         <PackageReference Include="Octokit" Version="0.50.0" />
         <PackageReference Include="Sarif.Sdk" Version="2.4.12" />
         <PackageReference Include="SemanticVersioning" Version="2.0.0" />

--- a/src/Shared/Utilities/OssUtilities.cs
+++ b/src/Shared/Utilities/OssUtilities.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CST.OpenSource.Utilities
         {
             if (jsonElement is not null && jsonElement?.ToString() is string str && !string.IsNullOrEmpty(str))
             {
-                if (str.Contains("["))
+                if (str.StartsWith("["))
                 {
                     if (jsonElement?.EnumerateArray() is JsonElement.ArrayEnumerator enumerator)
                     {


### PR DESCRIPTION
This PR aims to add some new features to the metadata tool.
It adds support for NuGet packages.
It adds a homepage property.
Fixes some bugs with NPM package parsing.
Adds a unique value for the frontend package and package version urls and the api urls. ie https://www.nuget.org/packages/Newtonsoft.Json vs https://api.nuget.org/v3/registration5-gz-semver2/newtonsoft.json/index.json