### PR TITLE
Added a static OssGadgetJsonSerializer class

### DIFF
--- a/src/Shared/Extensions/PackageUrlExtension.cs
+++ b/src/Shared/Extensions/PackageUrlExtension.cs
@@ -2,9 +2,12 @@
 
 namespace Microsoft.CST.OpenSource.Extensions;
 
+using Helpers;
 using System.IO;
 using System.Text.RegularExpressions;
 using PackageUrl;
+using System.Net;
+using System.Web;
 
 public static class PackageUrlExtension
 {
@@ -12,5 +15,12 @@ public static class PackageUrlExtension
     {
         string invalidChars = new string(Path.GetInvalidFileNameChars()) + new string(Path.GetInvalidPathChars());
         return Regex.Replace(packageUrl.ToString(), "[" + Regex.Escape(invalidChars) + "]", "-");
+    }
+    
+    public static string GetNameWithScope(this PackageURL packageUrl)
+    {
+        return packageUrl.Namespace.IsNotBlank()
+            ? $"@{packageUrl.Namespace}/{packageUrl.Name}"
+            : packageUrl.Name;
     }
 }

--- a/src/Shared/Extensions/PackageUrlExtension.cs
+++ b/src/Shared/Extensions/PackageUrlExtension.cs
@@ -6,8 +6,6 @@ using Helpers;
 using System.IO;
 using System.Text.RegularExpressions;
 using PackageUrl;
-using System.Net;
-using System.Web;
 
 public static class PackageUrlExtension
 {
@@ -16,11 +14,24 @@ public static class PackageUrlExtension
         string invalidChars = new string(Path.GetInvalidFileNameChars()) + new string(Path.GetInvalidPathChars());
         return Regex.Replace(packageUrl.ToString(), "[" + Regex.Escape(invalidChars) + "]", "-");
     }
-    
-    public static string GetNameWithScope(this PackageURL packageUrl)
+
+    public static bool HasNamespace(this PackageURL packageUrl)
     {
-        return packageUrl.Namespace.IsNotBlank()
-            ? $"@{packageUrl.Namespace}/{packageUrl.Name}"
-            : packageUrl.Name;
+        return packageUrl.Namespace.IsNotBlank();
+    }
+    
+    /// <summary>
+    /// Gets the package's full name including namespace if applicable.
+    /// </summary>
+    /// <example>
+    /// lodash -> lodash
+    /// @angular/core -> angular/core
+    /// </example>
+    /// <remarks>Doesn't contain any prefix to the namespace, so no @ for scoped npm packages for example.</remarks>
+    /// <param name="packageUrl">The <see cref="PackageURL"/> to get the full name for.</param>
+    /// <returns>The full name.</returns>
+    public static string GetFullName(this PackageURL packageUrl)
+    {
+        return packageUrl.HasNamespace() ? $"{packageUrl.Namespace}/{packageUrl.Name}" : packageUrl.Name;
     }
 }

--- a/src/Shared/OssGadgetJsonSerializer.cs
+++ b/src/Shared/OssGadgetJsonSerializer.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+namespace Microsoft.CST.OpenSource;
+
+using Helpers;
+using System.Text.Json;
+
+public class OssGadgetJsonSerializer
+{
+    // Custom json serialization converter for PackageURLs
+    public static readonly JsonSerializerOptions Options = new()
+    {
+        Converters =
+        {
+            new PackageUrlJsonConverter()
+        }
+    };
+}

--- a/src/oss-find-squats-lib/FindPackageSquatResult.cs
+++ b/src/oss-find-squats-lib/FindPackageSquatResult.cs
@@ -3,7 +3,6 @@
 #pragma warning disable CS8618
 namespace Microsoft.CST.OpenSource.FindSquats
 {
-    using Microsoft.CST.OpenSource.Helpers;
     using Microsoft.CST.OpenSource.FindSquats.Mutators;
     using PackageUrl;
     using System;
@@ -17,15 +16,6 @@ namespace Microsoft.CST.OpenSource.FindSquats
     /// </summary>
     public class FindPackageSquatResult
     {
-        // Custom json serialization converter for PackageURLs
-        private static JsonSerializerOptions _serializeOptions = new()
-        {
-            Converters =
-            {
-                new PackageUrlJsonConverter()
-            }
-        };
-
         public FindPackageSquatResult(string packageName, PackageURL packageUrl, PackageURL squattedPackage, IEnumerable<Mutation> mutations)
         {
             PackageName = packageName;
@@ -65,7 +55,7 @@ namespace Microsoft.CST.OpenSource.FindSquats
         /// <returns>A json string representing this instance of <see cref="FindPackageSquatResult"/>.</returns>
         public string ToJson()
         {
-            return JsonSerializer.Serialize(this, _serializeOptions);
+            return JsonSerializer.Serialize(this, OssGadgetJsonSerializer.Options);
         }
 
         /// <summary>
@@ -76,7 +66,7 @@ namespace Microsoft.CST.OpenSource.FindSquats
         /// <exception cref="InvalidCastException">If the json string cannot be deserialized into a <see cref="FindPackageSquatResult"/>.</exception>
         public static FindPackageSquatResult FromJsonString(string json)
         {
-            return JsonSerializer.Deserialize<FindPackageSquatResult>(json, _serializeOptions) ?? throw new InvalidCastException();
+            return JsonSerializer.Deserialize<FindPackageSquatResult>(json, OssGadgetJsonSerializer.Options) ?? throw new InvalidCastException();
         }
     }
 }

--- a/src/oss-find-squats-lib/MutateExtension.cs
+++ b/src/oss-find-squats-lib/MutateExtension.cs
@@ -2,6 +2,7 @@
 
 namespace Microsoft.CST.OpenSource.FindSquats.ExtensionMethods
 {
+    using Extensions;
     using Helpers;
     using Microsoft.CST.OpenSource.FindSquats.Mutators;
     using Microsoft.CST.OpenSource.PackageManagers;
@@ -101,10 +102,10 @@ namespace Microsoft.CST.OpenSource.FindSquats.ExtensionMethods
                 return null;
             }
 
-            Dictionary<string, IList<Mutation>>? generatedMutations = new();
+            Dictionary<string, IList<Mutation>> generatedMutations = new();
 
             // Check to see if it is a scoped npm package to generate candidates for.
-            bool isScoped = purl.Namespace.IsNotBlank() && purl.Type.Equals("npm", StringComparison.OrdinalIgnoreCase);
+            bool isScoped = purl.HasNamespace();
             string nameToMutate = isScoped ? purl.Namespace : purl.Name;
 
             foreach (IMutator mutator in mutators)
@@ -114,17 +115,13 @@ namespace Microsoft.CST.OpenSource.FindSquats.ExtensionMethods
                     // Construct the mutated name if the package was scoped.
                     string mutated = isScoped ? $"{mutation.Mutated}/{purl.Name}" : mutation.Mutated;
                     string original = isScoped ? $"{purl.Namespace}/{purl.Name}" : purl.Name;
-
-                    Mutation calculatedMutation = new(mutated, original, mutation.Reason, mutation.Mutator);
                     
-                    if (generatedMutations.ContainsKey(mutated))
+                    if (!generatedMutations.ContainsKey(mutated))
                     {
-                        generatedMutations[mutated].Add(calculatedMutation);
+                        generatedMutations[mutated] = new List<Mutation>();
                     }
-                    else
-                    {
-                        generatedMutations[mutated] = new List<Mutation> { calculatedMutation };
-                    }
+
+                    generatedMutations[mutated].Add(new Mutation(mutated, original, mutation.Reason, mutation.Mutator));
                 }
             }
 

--- a/src/oss-find-squats-lib/MutateExtension.cs
+++ b/src/oss-find-squats-lib/MutateExtension.cs
@@ -105,22 +105,25 @@ namespace Microsoft.CST.OpenSource.FindSquats.ExtensionMethods
 
             // Check to see if it is a scoped npm package to generate candidates for.
             bool isScoped = purl.Namespace.IsNotBlank() && purl.Type.Equals("npm", StringComparison.OrdinalIgnoreCase);
-            string nameToMutate = isScoped ? (purl.Namespace!).Substring(1) : purl.Name;
+            string nameToMutate = isScoped ? purl.Namespace : purl.Name;
 
             foreach (IMutator mutator in mutators)
             {
                 foreach (Mutation mutation in mutator.Generate(nameToMutate))
                 {
                     // Construct the mutated name if the package was scoped.
-                    string mutated = isScoped ? $"@{mutation.Mutated}/{purl.Name}" : mutation.Mutated;
+                    string mutated = isScoped ? $"{mutation.Mutated}/{purl.Name}" : mutation.Mutated;
+                    string original = isScoped ? $"{purl.Namespace}/{purl.Name}" : purl.Name;
 
+                    Mutation calculatedMutation = new(mutated, original, mutation.Reason, mutation.Mutator);
+                    
                     if (generatedMutations.ContainsKey(mutated))
                     {
-                        generatedMutations[mutated].Add(mutation);
+                        generatedMutations[mutated].Add(calculatedMutation);
                     }
                     else
                     {
-                        generatedMutations[mutated] = new List<Mutation> { mutation };
+                        generatedMutations[mutated] = new List<Mutation> { calculatedMutation };
                     }
                 }
             }

--- a/src/oss-tests/FindSquatsTests.cs
+++ b/src/oss-tests/FindSquatsTests.cs
@@ -35,6 +35,7 @@ namespace Microsoft.CST.OpenSource.Tests
 
         [DataTestMethod]
         [DataRow("pkg:npm/angular/core", "engular/core", "angullar/core")]
+        [DataRow("pkg:npm/%40angular/core", "@engular/core", "@angullar/core")] // back compat check
         [DataRow("pkg:npm/lodash", "odash", "lodah")]
         [DataRow("pkg:npm/babel/runtime", "abel/runtime", "bable/runtime")]
         public void ScopedNpmPackageSquats(string packageUrl, params string[] expectedSquats)
@@ -96,13 +97,13 @@ namespace Microsoft.CST.OpenSource.Tests
                     {
                         foreach (Mutation mutation in mutations)
                         {
-                            FindPackageSquatResult result = new(purl.GetNameWithScope(), purl,
+                            FindPackageSquatResult result = new(purl.GetFullName(), purl,
                                 new PackageURL(purl.Type, mutation.Mutated), new[] { mutation });
                             string jsonResult = result.ToJson();
                             if (jsonResult.Contains(expectedToFind, StringComparison.OrdinalIgnoreCase))
                             {
                                 FindPackageSquatResult fromJson = FindPackageSquatResult.FromJsonString(jsonResult);
-                                if (fromJson.PackageName.Equals(purl.GetNameWithScope(), StringComparison.OrdinalIgnoreCase))
+                                if (fromJson.PackageName.Equals(purl.GetFullName(), StringComparison.OrdinalIgnoreCase))
                                 {
                                     return;
                                 }

--- a/src/oss-tests/FindSquatsTests.cs
+++ b/src/oss-tests/FindSquatsTests.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.CST.OpenSource.Tests
 {
+    using Extensions;
     using PackageUrl;
 
     [TestClass]
@@ -33,9 +34,9 @@ namespace Microsoft.CST.OpenSource.Tests
         }
 
         [DataTestMethod]
-        [DataRow("pkg:npm/%40angular/core", "@engular/core", "@angullar/core")]
+        [DataRow("pkg:npm/angular/core", "engular/core", "angullar/core")]
         [DataRow("pkg:npm/lodash", "odash", "lodah")]
-        [DataRow("pkg:npm/%40babel/runtime", "@abel/runtime", "@bable/runtime")]
+        [DataRow("pkg:npm/babel/runtime", "abel/runtime", "bable/runtime")]
         public void ScopedNpmPackageSquats(string packageUrl, params string[] expectedSquats)
         {
             FindPackageSquats findPackageSquats =
@@ -54,7 +55,8 @@ namespace Microsoft.CST.OpenSource.Tests
         [DataTestMethod]
         [DataRow("pkg:npm/foo", "foojs")] // SuffixAdded, js
         [DataRow("pkg:npm/lodash", "odash")] // RemovedCharacter, first character
-        [DataRow("pkg:nuget/Microsoft.CST.OAT", "microsoft.cst.oat.net")]
+        [DataRow("pkg:npm/angular/core", "anguular/core")] // DoubleHit, third character
+        [DataRow("pkg:nuget/Microsoft.CST.OAT", "microsoft.cst.oat.net")] // SuffixAdded, .net
         public void GenerateManagerSpecific(string packageUrl, string expectedToFind)
         {
             PackageURL purl = new(packageUrl);
@@ -63,9 +65,9 @@ namespace Microsoft.CST.OpenSource.Tests
                 BaseProjectManager? manager = ProjectManagerFactory.CreateProjectManager(purl, null);
                 if (manager is not null)
                 {
-                    foreach (IMutator mutator in manager.GetDefaultMutators())
+                    foreach ((string _, IList<Mutation> mutations) in manager.EnumerateSquatCandidates(purl)!)
                     {
-                        foreach (Mutation mutation in mutator.Generate(purl.Name))
+                        foreach (Mutation mutation in mutations)
                         {
                             if (mutation.Mutated.Equals(expectedToFind, StringComparison.OrdinalIgnoreCase))
                             {
@@ -80,6 +82,7 @@ namespace Microsoft.CST.OpenSource.Tests
 
         [DataTestMethod]
         [DataRow("pkg:npm/foo", "pkg:npm/too")]
+        [DataRow("pkg:npm/angular/core", "pkg:npm/anngular/core")]
         [DataRow("pkg:nuget/Microsoft.CST.OAT", "pkg:nuget/microsoft.cst.oat.net")]
         public void ConvertToAndFromJson(string packageUrl, string expectedToFind)
         {
@@ -89,17 +92,17 @@ namespace Microsoft.CST.OpenSource.Tests
                 BaseProjectManager? manager = ProjectManagerFactory.CreateProjectManager(purl, null);
                 if (manager is not null)
                 {
-                    foreach (IMutator mutator in manager.GetDefaultMutators())
+                    foreach ((string _, IList<Mutation> mutations) in manager.EnumerateSquatCandidates(purl)!)
                     {
-                        foreach (Mutation mutation in mutator.Generate(purl.Name))
+                        foreach (Mutation mutation in mutations)
                         {
-                            FindPackageSquatResult result = new(purl.Name, purl,
+                            FindPackageSquatResult result = new(purl.GetNameWithScope(), purl,
                                 new PackageURL(purl.Type, mutation.Mutated), new[] { mutation });
                             string jsonResult = result.ToJson();
                             if (jsonResult.Contains(expectedToFind, StringComparison.OrdinalIgnoreCase))
                             {
                                 FindPackageSquatResult fromJson = FindPackageSquatResult.FromJsonString(jsonResult);
-                                if (fromJson.PackageName.Equals(purl.Name, StringComparison.OrdinalIgnoreCase))
+                                if (fromJson.PackageName.Equals(purl.GetNameWithScope(), StringComparison.OrdinalIgnoreCase))
                                 {
                                     return;
                                 }
@@ -113,6 +116,7 @@ namespace Microsoft.CST.OpenSource.Tests
 
         [DataTestMethod]
         [DataRow("pkg:npm/foo", typeof(UnicodeHomoglyphMutator))]
+        [DataRow("pkg:npm/foo/bar", typeof(UnicodeHomoglyphMutator))]
         [DataRow("pkg:nuget/Microsoft.CST.OAT", typeof(UnicodeHomoglyphMutator))]
         public void DontGenerateManagerSpecific(string packageUrl, Type notExpectedToFind)
         {


### PR DESCRIPTION
The new OssGadgetJsonSerializer contains the serialzer options needed for serializing and deserializing PackageURL objects.

Also fixed some issues with scoped npm packages and find squat mutations.