### PR TITLE
Allows oss-health to access GITHUB_ACCESS_TOKEN

### DIFF
--- a/src/oss-health/BaseHealthAlgorithm.cs
+++ b/src/oss-health/BaseHealthAlgorithm.cs
@@ -12,6 +12,7 @@ namespace Microsoft.CST.OpenSource.Health
     {
         public BaseHealthAlgorithm()
         {
+            EnvironmentHelper.OverrideEnvironmentVariables(this);
         }
 
         public static double Clamp(double value, double min = 0, double max = 100)


### PR DESCRIPTION
oss-health was continually complaining about GITHUB_ACCESS_TOKEN being
unset.  This was because [this previous commit](https://github.com/microsoft/OSSGadget/commit/a25747d039cc532a2ffc3e652474545e8527d10b) removed the call which allowed oss-health to set it from the
environment.  This commit restores that ability.