### PR TITLE
Refactor ExtractArchive into a helper class, and a few other changes.

### DIFF
--- a/src/Shared.CLI/Helpers/PackageDownloader.cs
+++ b/src/Shared.CLI/Helpers/PackageDownloader.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CST.OpenSource
             if (packageManager == null)
             {
                 // Cannot continue without a package manager.
-                throw new ArgumentException("Invalid Package URL type: {0}", purl.Type);
+                throw new ArgumentException($"Invalid Package URL type: {purl.Type}", nameof(purl.Type));
             }
             PackageVersions = new List<PackageURL>();
             if (purl.Version == null || purl.Version.Equals("*"))

--- a/src/Shared/Helpers/ArchiveHelper.cs
+++ b/src/Shared/Helpers/ArchiveHelper.cs
@@ -24,7 +24,10 @@ public static class ArchiveHelper
     /// <param name="content">stream of the contents to extract (should be an archive file)</param>
     /// <param name="cached">If the archive has been cached.</param>
     /// <returns>The path that the archive was extracted to.</returns>
-    public static async Task<string> ExtractArchiveAsync(string topLevelDirectory, string directoryName, Stream content,
+    public static async Task<string> ExtractArchiveAsync(
+        string topLevelDirectory,
+        string directoryName,
+        Stream content,
         bool cached = false)
     {
         Logger.Trace("ExtractArchive({0}, <stream> len={1})", directoryName, content.Length);

--- a/src/Shared/Helpers/ArchiveHelper.cs
+++ b/src/Shared/Helpers/ArchiveHelper.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+namespace Microsoft.CST.OpenSource.Helpers;
+
+using RecursiveExtractor;
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+public static class ArchiveHelper
+{
+    /// <summary>
+    /// Logger for each of the subclasses
+    /// </summary>
+    static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
+
+    /// <summary>
+    /// Extracts an archive (given by 'bytes') into a directory named 'directoryName',
+    /// recursively, using RecursiveExtractor.
+    /// </summary>
+    /// <param name="topLevelDirectory">The top level directory content should be extracted to.</param>
+    /// <param name="directoryName">directory to extract content into (within <paramref name="topLevelDirectory"/>)</param>
+    /// <param name="content">stream of the contents to extract (should be an archive file)</param>
+    /// <param name="cached">If the archive has been cached.</param>
+    /// <returns>The path that the archive was extracted to.</returns>
+    public static async Task<string> ExtractArchiveAsync(string topLevelDirectory, string directoryName, Stream content,
+        bool cached = false)
+    {
+        Logger.Trace("ExtractArchive({0}, <stream> len={1})", directoryName, content.Length);
+
+        Directory.CreateDirectory(topLevelDirectory);
+
+        StringBuilder dirBuilder = new(directoryName);
+
+        foreach (char c in Path.GetInvalidPathChars())
+        {
+            dirBuilder.Replace(c, '-'); // ignore: lgtm [cs/string-concatenation-in-loop]
+        }
+
+        string fullTargetPath = Path.Combine(topLevelDirectory, dirBuilder.ToString());
+
+        if (!cached)
+        {
+            while (Directory.Exists(fullTargetPath) || File.Exists(fullTargetPath))
+            {
+                dirBuilder.Append("-" + DateTime.Now.Ticks);
+                fullTargetPath = Path.Combine(topLevelDirectory, dirBuilder.ToString());
+            }
+        }
+
+        Extractor extractor = new();
+        ExtractorOptions extractorOptions = new()
+        {
+            ExtractSelfOnFail = true, Parallel = true
+            // MaxExtractedBytes = 1000 * 1000 * 10;  // 10 MB maximum package size
+        };
+        ExtractionStatusCode result = await extractor.ExtractToDirectoryAsync(topLevelDirectory, dirBuilder.ToString(),
+            content, extractorOptions);
+        if (result == ExtractionStatusCode.Ok)
+        {
+            Logger.Debug("Archive extracted to {0}", fullTargetPath);
+        }
+        else
+        {
+            Logger.Warn("Error extracting archive {0} ({1})", fullTargetPath, result);
+        }
+
+        return fullTargetPath;
+    }
+} 

--- a/src/Shared/Model/PackageMetadata.cs
+++ b/src/Shared/Model/PackageMetadata.cs
@@ -161,22 +161,22 @@ namespace Microsoft.CST.OpenSource.Model
         }
     }
 
-    public class User
+    public record User
     {
         [JsonProperty(PropertyName = "active_flag", NullValueHandling = NullValueHandling.Ignore)]
-        public bool? Active { get; set; }
+        public bool? Active { get; init; }
 
         [JsonProperty(PropertyName = "email", NullValueHandling = NullValueHandling.Ignore)]
-        public string? Email { get; set; }
+        public string? Email { get; init; }
 
         [JsonProperty(PropertyName = "Id", NullValueHandling = NullValueHandling.Ignore)]
-        public int? Id { get; set; }
+        public int? Id { get; init; }
 
         [JsonProperty(PropertyName = "name", NullValueHandling = NullValueHandling.Ignore)]
-        public string? Name { get; set; }
+        public string? Name { get; init; }
 
         [JsonProperty(PropertyName = "url", NullValueHandling = NullValueHandling.Ignore)]
-        public string? Url { get; set; }
+        public string? Url { get; init; }
     }
 
     public class Version

--- a/src/Shared/PackageManagers/BaseProjectManager.cs
+++ b/src/Shared/PackageManagers/BaseProjectManager.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         /// The type of the project manager from the package-url type specifications.
         /// </summary>
         /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
-        public const string Type = null!;
+        public const string Type = "undefined";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BaseProjectManager"/> class.

--- a/src/Shared/PackageManagers/BaseProjectManager.cs
+++ b/src/Shared/PackageManagers/BaseProjectManager.cs
@@ -18,19 +18,25 @@ namespace Microsoft.CST.OpenSource.PackageManagers
     using Version = SemanticVersioning.Version;
     using PackageUrl;
 
-    public class BaseProjectManager
+    public abstract class BaseProjectManager
     {
+        /// <summary>
+        /// The type of the project manager from the package-url type specifications.
+        /// </summary>
+        /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
+        public static readonly string Type = null!;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="BaseProjectManager"/> class.
         /// </summary>
-        public BaseProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory)
+        public BaseProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory = ".")
         {
             Options = new Dictionary<string, object>();
             TopLevelExtractionDirectory = destinationDirectory;
             HttpClientFactory = httpClientFactory;
         }
 
-        public BaseProjectManager(string destinationDirectory) : this(new DefaultHttpClientFactory(), destinationDirectory)
+        public BaseProjectManager(string destinationDirectory = ".") : this(new DefaultHttpClientFactory(), destinationDirectory)
         {
         }
 
@@ -279,8 +285,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         /// <remarks>The latest version is always first, then it is sorted by SemVer in descending order.</remarks>
         /// <param name="purl">Package URL specifying the package. Version is ignored.</param>
         /// <param name="useCache">If the cache should be used when looking for the versions.</param>
+        /// <param name="includePrerelease">If pre-release versions should be included.</param>
         /// <returns> A list of package version numbers.</returns>
-        public virtual Task<IEnumerable<string>> EnumerateVersions(PackageURL purl, bool useCache = true)
+        public virtual Task<IEnumerable<string>> EnumerateVersions(PackageURL purl, bool useCache = true, bool includePrerelease = true)
         {
             throw new NotImplementedException("BaseProjectManager does not implement EnumerateVersions.");
         }
@@ -332,9 +339,10 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         /// This method should return text reflecting metadata for the given package. There is no
         /// assumed format.
         /// </summary>
-        /// <param name="purl">PackageURL to search.</param>
+        /// <param name="purl">The <see cref="PackageURL"/> to get the metadata for.</param>
         /// <param name="useCache">If the metadata should be retrieved from the cache, if it is available.</param>
-        /// <returns>a string containing metadata.</returns>
+        /// <remarks>If no version specified, defaults to latest version.</remarks>
+        /// <returns>A string representing the <see cref="PackageURL"/>'s metadata, or null if it wasn't found.</returns>
         public virtual Task<string?> GetMetadata(PackageURL purl, bool useCache = true)
         {
             throw new NotImplementedException($"{GetType().Name} does not implement GetMetadata.");
@@ -355,8 +363,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         /// </summary>
         /// <param name="purl">The <see cref="PackageURL"/> to get the normalized metadata for.</param>
         /// <param name="useCache">If the <see cref="PackageMetadata"/> should be retrieved from the cache, if it is available.</param>
-        /// <returns>A <see cref="GetPackageMetadata"/> object representing this <see cref="PackageURL"/>.</returns>
-        public virtual Task<PackageMetadata> GetPackageMetadata(PackageURL purl, bool useCache = true)
+        /// <remarks>If no version specified, defaults to latest version.</remarks>
+        /// <returns>A <see cref="PackageMetadata"/> object representing this <see cref="PackageURL"/>.</returns>
+        public virtual Task<PackageMetadata?> GetPackageMetadata(PackageURL purl, bool useCache = true)
         {
             string typeName = GetType().Name;
             throw new NotImplementedException($"{typeName} does not implement GetPackageMetadata.");

--- a/src/Shared/PackageManagers/BaseProjectManager.cs
+++ b/src/Shared/PackageManagers/BaseProjectManager.cs
@@ -2,15 +2,12 @@
 
 namespace Microsoft.CST.OpenSource.PackageManagers
 {
-    using Microsoft.CST.RecursiveExtractor;
     using Microsoft.Extensions.Caching.Memory;
     using Microsoft.CST.OpenSource.Model;
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using System.Linq;
     using System.Net.Http;
-    using System.Text;
     using System.Text.Json;
     using System.Text.RegularExpressions;
     using System.Threading.Tasks;
@@ -24,7 +21,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         /// The type of the project manager from the package-url type specifications.
         /// </summary>
         /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
-        public static readonly string Type = null!;
+        public const string Type = null!;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BaseProjectManager"/> class.

--- a/src/Shared/PackageManagers/BaseProjectManager.cs
+++ b/src/Shared/PackageManagers/BaseProjectManager.cs
@@ -18,6 +18,13 @@ namespace Microsoft.CST.OpenSource.PackageManagers
     public abstract class BaseProjectManager
     {
         /// <summary>
+        /// The type of the project manager from the package-url type specifications.
+        /// </summary>
+        /// <remarks>This differs from the Type property defined in other ProjectManagers as this one isn't static.</remarks>
+        /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
+        public abstract string ManagerType { get; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="BaseProjectManager"/> class.
         /// </summary>
         public BaseProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory = ".")

--- a/src/Shared/PackageManagers/BaseProjectManager.cs
+++ b/src/Shared/PackageManagers/BaseProjectManager.cs
@@ -18,12 +18,6 @@ namespace Microsoft.CST.OpenSource.PackageManagers
     public abstract class BaseProjectManager
     {
         /// <summary>
-        /// The type of the project manager from the package-url type specifications.
-        /// </summary>
-        /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
-        public const string Type = "undefined";
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="BaseProjectManager"/> class.
         /// </summary>
         public BaseProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory = ".")

--- a/src/Shared/PackageManagers/CPANProjectManager.cs
+++ b/src/Shared/PackageManagers/CPANProjectManager.cs
@@ -15,8 +15,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
     internal class CPANProjectManager : BaseProjectManager
     {
-        /// <inheritdoc cref="BaseProjectManager.Type"/>
-        public new const string Type = "cpan";
+        /// <summary>
+        /// The type of the project manager from the package-url type specifications.
+        /// </summary>
+        /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
+        public const string Type = "cpan";
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public static string ENV_CPAN_BINARY_ENDPOINT = "https://cpan.metacpan.org";

--- a/src/Shared/PackageManagers/CPANProjectManager.cs
+++ b/src/Shared/PackageManagers/CPANProjectManager.cs
@@ -15,6 +15,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
     internal class CPANProjectManager : BaseProjectManager
     {
+        /// <inheritdoc cref="BaseProjectManager.Type"/>
+        public new const string Type = "cpan";
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public static string ENV_CPAN_BINARY_ENDPOINT = "https://cpan.metacpan.org";
 
@@ -135,7 +138,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         }
         
         /// <inheritdoc />
-        public override async Task<IEnumerable<string>> EnumerateVersions(PackageURL purl, bool useCache = true)
+        public override async Task<IEnumerable<string>> EnumerateVersions(PackageURL purl, bool useCache = true, bool includePrerelease = true)
         {
             Logger.Trace("EnumerateVersions {0}", purl?.ToString());
             if (purl == null || purl.Name is null)

--- a/src/Shared/PackageManagers/CPANProjectManager.cs
+++ b/src/Shared/PackageManagers/CPANProjectManager.cs
@@ -3,6 +3,7 @@
 namespace Microsoft.CST.OpenSource.PackageManagers
 {
     using AngleSharp.Html.Parser;
+    using Helpers;
     using PackageUrl;
     using System;
     using System.Collections.Generic;
@@ -120,7 +121,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                 }
                 if (doExtract)
                 {
-                    downloadedPaths.Add(await ExtractArchive(targetName, await result.Content.ReadAsByteArrayAsync(), cached));
+                    downloadedPaths.Add(await ArchiveHelper.ExtractArchiveAsync(TopLevelExtractionDirectory, targetName, await result.Content.ReadAsStreamAsync(), cached));
                 }
                 else
                 {

--- a/src/Shared/PackageManagers/CPANProjectManager.cs
+++ b/src/Shared/PackageManagers/CPANProjectManager.cs
@@ -21,6 +21,8 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
         public const string Type = "cpan";
 
+        public override string ManagerType => Type;
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public static string ENV_CPAN_BINARY_ENDPOINT = "https://cpan.metacpan.org";
 

--- a/src/Shared/PackageManagers/CPANProjectManager.cs
+++ b/src/Shared/PackageManagers/CPANProjectManager.cs
@@ -128,9 +128,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                 }
                 else
                 {
-                    targetName += Path.GetExtension(binaryUrl) ?? "";
-                    await File.WriteAllBytesAsync(targetName, await result.Content.ReadAsByteArrayAsync());
-                    downloadedPaths.Add(targetName);
+                    extractionPath += Path.GetExtension(binaryUrl) ?? "";
+                    await File.WriteAllBytesAsync(extractionPath, await result.Content.ReadAsByteArrayAsync());
+                    downloadedPaths.Add(extractionPath);
                 }
                 break;
             }

--- a/src/Shared/PackageManagers/CRANProjectManager.cs
+++ b/src/Shared/PackageManagers/CRANProjectManager.cs
@@ -14,6 +14,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
     internal class CRANProjectManager : BaseProjectManager
     {
+        /// <inheritdoc cref="BaseProjectManager.Type"/>
+        public new const string Type = "cran";
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public static string ENV_CRAN_ENDPOINT = "https://cran.r-project.org";
 
@@ -109,7 +112,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         }
 
         /// <inheritdoc />
-        public override async Task<IEnumerable<string>> EnumerateVersions(PackageURL purl, bool useCache = true)
+        public override async Task<IEnumerable<string>> EnumerateVersions(PackageURL purl, bool useCache = true, bool includePrerelease = true)
         {
             Logger.Trace("EnumerateVersions {0}", purl?.ToString());
             if (purl == null || purl.Name is null)

--- a/src/Shared/PackageManagers/CRANProjectManager.cs
+++ b/src/Shared/PackageManagers/CRANProjectManager.cs
@@ -14,8 +14,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
     internal class CRANProjectManager : BaseProjectManager
     {
-        /// <inheritdoc cref="BaseProjectManager.Type"/>
-        public new const string Type = "cran";
+        /// <summary>
+        /// The type of the project manager from the package-url type specifications.
+        /// </summary>
+        /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
+        public const string Type = "cran";
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public static string ENV_CRAN_ENDPOINT = "https://cran.r-project.org";

--- a/src/Shared/PackageManagers/CRANProjectManager.cs
+++ b/src/Shared/PackageManagers/CRANProjectManager.cs
@@ -3,6 +3,7 @@
 namespace Microsoft.CST.OpenSource.PackageManagers
 {
     using AngleSharp.Html.Parser;
+    using Helpers;
     using PackageUrl;
     using System;
     using System.Collections.Generic;
@@ -62,7 +63,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                 }
                 if (doExtract)
                 {
-                    downloadedPaths.Add(await ExtractArchive(targetName, await result.Content.ReadAsByteArrayAsync(), cached));
+                    downloadedPaths.Add(await ArchiveHelper.ExtractArchiveAsync(TopLevelExtractionDirectory, targetName, await result.Content.ReadAsStreamAsync(), cached));
                 }
                 else
                 {
@@ -91,7 +92,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                 string targetName = $"cran-{packageName}@{packageVersion}";
                 if (doExtract)
                 {
-                    downloadedPaths.Add(await ExtractArchive(targetName, await result.Content.ReadAsByteArrayAsync(), cached));
+                    downloadedPaths.Add(await ArchiveHelper.ExtractArchiveAsync(TopLevelExtractionDirectory, targetName, await result.Content.ReadAsStreamAsync(), cached));
                 }
                 else
                 {

--- a/src/Shared/PackageManagers/CRANProjectManager.cs
+++ b/src/Shared/PackageManagers/CRANProjectManager.cs
@@ -70,9 +70,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                 }
                 else
                 {
-                    targetName += Path.GetExtension(url) ?? "";
-                    await File.WriteAllBytesAsync(targetName, await result.Content.ReadAsByteArrayAsync());
-                    downloadedPaths.Add(targetName);
+                    extractionPath += Path.GetExtension(url) ?? "";
+                    await File.WriteAllBytesAsync(extractionPath, await result.Content.ReadAsByteArrayAsync());
+                    downloadedPaths.Add(extractionPath);
                 }
             }
             catch (Exception ex)
@@ -93,15 +93,16 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                 Logger.Debug("Downloading {0}...", purl);
 
                 string targetName = $"cran-{packageName}@{packageVersion}";
+                string extractionPath = Path.Combine(TopLevelExtractionDirectory, targetName);
                 if (doExtract)
                 {
                     downloadedPaths.Add(await ArchiveHelper.ExtractArchiveAsync(TopLevelExtractionDirectory, targetName, await result.Content.ReadAsStreamAsync(), cached));
                 }
                 else
                 {
-                    targetName += Path.GetExtension(url) ?? "";
-                    await File.WriteAllBytesAsync(targetName, await result.Content.ReadAsByteArrayAsync());
-                    downloadedPaths.Add(targetName);
+                    extractionPath += Path.GetExtension(url) ?? "";
+                    await File.WriteAllBytesAsync(extractionPath, await result.Content.ReadAsByteArrayAsync());
+                    downloadedPaths.Add(extractionPath);
                 }
             }
             catch (Exception ex)

--- a/src/Shared/PackageManagers/CRANProjectManager.cs
+++ b/src/Shared/PackageManagers/CRANProjectManager.cs
@@ -20,6 +20,8 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
         public const string Type = "cran";
 
+        public override string ManagerType => Type;
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public static string ENV_CRAN_ENDPOINT = "https://cran.r-project.org";
 

--- a/src/Shared/PackageManagers/CargoProjectManager.cs
+++ b/src/Shared/PackageManagers/CargoProjectManager.cs
@@ -15,8 +15,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
     internal class CargoProjectManager : BaseProjectManager
     {
-        /// <inheritdoc cref="BaseProjectManager.Type"/>
-        public new const string Type = "cargo";
+        /// <summary>
+        /// The type of the project manager from the package-url type specifications.
+        /// </summary>
+        /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
+        public const string Type = "cargo";
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public static string ENV_CARGO_ENDPOINT = "https://crates.io";

--- a/src/Shared/PackageManagers/CargoProjectManager.cs
+++ b/src/Shared/PackageManagers/CargoProjectManager.cs
@@ -15,6 +15,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
     internal class CargoProjectManager : BaseProjectManager
     {
+        /// <inheritdoc cref="BaseProjectManager.Type"/>
+        public new const string Type = "cargo";
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public static string ENV_CARGO_ENDPOINT = "https://crates.io";
 
@@ -100,7 +103,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         }
 
         /// <inheritdoc />
-        public override async Task<IEnumerable<string>> EnumerateVersions(PackageURL purl, bool useCache = true)
+        public override async Task<IEnumerable<string>> EnumerateVersions(PackageURL purl, bool useCache = true, bool includePrerelease = true)
         {
             Logger.Trace("EnumerateVersions {0}", purl?.ToString());
             if (purl == null || purl.Name is null)

--- a/src/Shared/PackageManagers/CargoProjectManager.cs
+++ b/src/Shared/PackageManagers/CargoProjectManager.cs
@@ -3,6 +3,7 @@
 namespace Microsoft.CST.OpenSource.PackageManagers
 {
     using Extensions;
+    using Helpers;
     using PackageUrl;
     using System;
     using System.Collections.Generic;
@@ -68,7 +69,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
                 if (doExtract)
                 {
-                    downloadedPaths.Add(await ExtractArchive(targetName, await result.Content.ReadAsByteArrayAsync(), cached));
+                    downloadedPaths.Add(await ArchiveHelper.ExtractArchiveAsync(TopLevelExtractionDirectory, targetName, await result.Content.ReadAsStreamAsync(), cached));
                 }
                 else
                 {

--- a/src/Shared/PackageManagers/CargoProjectManager.cs
+++ b/src/Shared/PackageManagers/CargoProjectManager.cs
@@ -21,6 +21,8 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
         public const string Type = "cargo";
 
+        public override string ManagerType => Type;
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public static string ENV_CARGO_ENDPOINT = "https://crates.io";
 

--- a/src/Shared/PackageManagers/CocoapodsProjectManager.cs
+++ b/src/Shared/PackageManagers/CocoapodsProjectManager.cs
@@ -24,6 +24,8 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
         public const string Type = "cocoapods";
 
+        public override string ManagerType => Type;
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public static string ENV_COCOAPODS_SPECS_ENDPOINT = "https://github.com/CocoaPods/Specs/tree/master";
 

--- a/src/Shared/PackageManagers/CocoapodsProjectManager.cs
+++ b/src/Shared/PackageManagers/CocoapodsProjectManager.cs
@@ -106,9 +106,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                     }
                     else
                     {
-                        targetName += Path.GetExtension(url) ?? "";
-                        await File.WriteAllBytesAsync(targetName, await result.Content.ReadAsByteArrayAsync());
-                        downloadedPaths.Add(targetName);
+                        extractionPath += Path.GetExtension(url) ?? "";
+                        await File.WriteAllBytesAsync(extractionPath, await result.Content.ReadAsByteArrayAsync());
+                        downloadedPaths.Add(extractionPath);
                     }
                 }
                 else

--- a/src/Shared/PackageManagers/CocoapodsProjectManager.cs
+++ b/src/Shared/PackageManagers/CocoapodsProjectManager.cs
@@ -18,8 +18,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
     internal class CocoapodsProjectManager : BaseProjectManager
     {
-        /// <inheritdoc cref="BaseProjectManager.Type"/>
-        public new const string Type = "cocoapods";
+        /// <summary>
+        /// The type of the project manager from the package-url type specifications.
+        /// </summary>
+        /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
+        public const string Type = "cocoapods";
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public static string ENV_COCOAPODS_SPECS_ENDPOINT = "https://github.com/CocoaPods/Specs/tree/master";

--- a/src/Shared/PackageManagers/CocoapodsProjectManager.cs
+++ b/src/Shared/PackageManagers/CocoapodsProjectManager.cs
@@ -4,6 +4,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 {
     using AngleSharp.Html.Parser;
     using Extensions;
+    using Helpers;
     using PackageUrl;
     using System;
     using System.Collections.Generic;
@@ -98,7 +99,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                     }
                     if (doExtract)
                     {
-                        downloadedPaths.Add(await ExtractArchive(targetName, await result.Content.ReadAsByteArrayAsync(), cached));
+                        downloadedPaths.Add(await ArchiveHelper.ExtractArchiveAsync(TopLevelExtractionDirectory, targetName, await result.Content.ReadAsStreamAsync(), cached));
                     }
                     else
                     {

--- a/src/Shared/PackageManagers/CocoapodsProjectManager.cs
+++ b/src/Shared/PackageManagers/CocoapodsProjectManager.cs
@@ -18,6 +18,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
     internal class CocoapodsProjectManager : BaseProjectManager
     {
+        /// <inheritdoc cref="BaseProjectManager.Type"/>
+        public new const string Type = "cocoapods";
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public static string ENV_COCOAPODS_SPECS_ENDPOINT = "https://github.com/CocoaPods/Specs/tree/master";
 
@@ -133,7 +136,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         }
 
         /// <inheritdoc />
-        public override async Task<IEnumerable<string>> EnumerateVersions(PackageURL purl, bool useCache = true)
+        public override async Task<IEnumerable<string>> EnumerateVersions(PackageURL purl, bool useCache = true, bool includePrerelease = true)
         {
             Logger.Trace("EnumerateVersions {0}", purl?.ToString());
             if (purl == null)

--- a/src/Shared/PackageManagers/ComposerProjectManager.cs
+++ b/src/Shared/PackageManagers/ComposerProjectManager.cs
@@ -14,8 +14,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
     internal class ComposerProjectManager : BaseProjectManager
     {
-        /// <inheritdoc cref="BaseProjectManager.Type"/>
-        public new const string Type = "composer";
+        /// <summary>
+        /// The type of the project manager from the package-url type specifications.
+        /// </summary>
+        /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
+        public const string Type = "composer";
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public static string ENV_COMPOSER_ENDPOINT = "https://repo.packagist.org";

--- a/src/Shared/PackageManagers/ComposerProjectManager.cs
+++ b/src/Shared/PackageManagers/ComposerProjectManager.cs
@@ -14,6 +14,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
     internal class ComposerProjectManager : BaseProjectManager
     {
+        /// <inheritdoc cref="BaseProjectManager.Type"/>
+        public new const string Type = "composer";
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public static string ENV_COMPOSER_ENDPOINT = "https://repo.packagist.org";
 
@@ -114,7 +117,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         }
 
         /// <inheritdoc />
-        public override async Task<IEnumerable<string>> EnumerateVersions(PackageURL purl, bool useCache = true)
+        public override async Task<IEnumerable<string>> EnumerateVersions(PackageURL purl, bool useCache = true, bool includePrerelease = true)
         {
             Logger.Trace("EnumerateVersions {0}", purl?.ToString());
             if (purl == null)

--- a/src/Shared/PackageManagers/ComposerProjectManager.cs
+++ b/src/Shared/PackageManagers/ComposerProjectManager.cs
@@ -2,6 +2,7 @@
 
 namespace Microsoft.CST.OpenSource.PackageManagers
 {
+    using Helpers;
     using PackageUrl;
     using System;
     using System.Collections.Generic;
@@ -75,7 +76,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                         }
                         if (doExtract)
                         {
-                            downloadedPaths.Add(await ExtractArchive(targetName, await result.Content.ReadAsByteArrayAsync(), cached));
+                            downloadedPaths.Add(await ArchiveHelper.ExtractArchiveAsync(TopLevelExtractionDirectory, targetName, await result.Content.ReadAsStreamAsync(), cached));
                         }
                         else
                         {

--- a/src/Shared/PackageManagers/ComposerProjectManager.cs
+++ b/src/Shared/PackageManagers/ComposerProjectManager.cs
@@ -83,9 +83,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                         }
                         else
                         {
-                            targetName += ".zip";
-                            await File.WriteAllBytesAsync(targetName, await result.Content.ReadAsByteArrayAsync());
-                            downloadedPaths.Add(targetName);
+                            extractionPath += ".zip";
+                            await File.WriteAllBytesAsync(extractionPath, await result.Content.ReadAsByteArrayAsync());
+                            downloadedPaths.Add(extractionPath);
                         }
                     }
                 }

--- a/src/Shared/PackageManagers/ComposerProjectManager.cs
+++ b/src/Shared/PackageManagers/ComposerProjectManager.cs
@@ -20,6 +20,8 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
         public const string Type = "composer";
 
+        public override string ManagerType => Type;
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public static string ENV_COMPOSER_ENDPOINT = "https://repo.packagist.org";
 

--- a/src/Shared/PackageManagers/GemProjectManager.cs
+++ b/src/Shared/PackageManagers/GemProjectManager.cs
@@ -15,6 +15,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
     internal class GemProjectManager : BaseProjectManager
     {
+        /// <inheritdoc cref="BaseProjectManager.Type"/>
+        public new const string Type = "gem";
+
         public static string ENV_RUBYGEMS_ENDPOINT = "https://rubygems.org";
         public static string ENV_RUBYGEMS_ENDPOINT_API = "https://api.rubygems.org";
 
@@ -95,7 +98,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         }
 
         /// <inheritdoc />
-        public override async Task<IEnumerable<string>> EnumerateVersions(PackageURL purl, bool useCache = true)
+        public override async Task<IEnumerable<string>> EnumerateVersions(PackageURL purl, bool useCache = true, bool includePrerelease = true)
         {
             Logger.Trace("EnumerateVersions {0}", purl?.ToString());
             if (purl == null || purl.Name is null)

--- a/src/Shared/PackageManagers/GemProjectManager.cs
+++ b/src/Shared/PackageManagers/GemProjectManager.cs
@@ -15,8 +15,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
     internal class GemProjectManager : BaseProjectManager
     {
-        /// <inheritdoc cref="BaseProjectManager.Type"/>
-        public new const string Type = "gem";
+        /// <summary>
+        /// The type of the project manager from the package-url type specifications.
+        /// </summary>
+        /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
+        public const string Type = "gem";
 
         public static string ENV_RUBYGEMS_ENDPOINT = "https://rubygems.org";
         public static string ENV_RUBYGEMS_ENDPOINT_API = "https://api.rubygems.org";

--- a/src/Shared/PackageManagers/GemProjectManager.cs
+++ b/src/Shared/PackageManagers/GemProjectManager.cs
@@ -21,6 +21,8 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
         public const string Type = "gem";
 
+        public override string ManagerType => Type;
+
         public static string ENV_RUBYGEMS_ENDPOINT = "https://rubygems.org";
         public static string ENV_RUBYGEMS_ENDPOINT_API = "https://api.rubygems.org";
 

--- a/src/Shared/PackageManagers/GemProjectManager.cs
+++ b/src/Shared/PackageManagers/GemProjectManager.cs
@@ -2,6 +2,7 @@
 
 namespace Microsoft.CST.OpenSource.PackageManagers
 {
+    using Helpers;
     using PackageUrl;
     using System;
     using System.Collections.Generic;
@@ -62,7 +63,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                 }
                 if (doExtract)
                 {
-                    downloadedPaths.Add(await ExtractArchive(targetName, await result.Content.ReadAsByteArrayAsync(), cached));
+                    downloadedPaths.Add(await ArchiveHelper.ExtractArchiveAsync(TopLevelExtractionDirectory, targetName, await result.Content.ReadAsStreamAsync(), cached));
                 }
                 else
                 {

--- a/src/Shared/PackageManagers/GemProjectManager.cs
+++ b/src/Shared/PackageManagers/GemProjectManager.cs
@@ -70,9 +70,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                 }
                 else
                 {
-                    targetName += Path.GetExtension(url) ?? "";
-                    await File.WriteAllBytesAsync(targetName, await result.Content.ReadAsByteArrayAsync());
-                    downloadedPaths.Add(targetName);
+                    extractionPath += Path.GetExtension(url) ?? "";
+                    await File.WriteAllBytesAsync(extractionPath, await result.Content.ReadAsByteArrayAsync());
+                    downloadedPaths.Add(extractionPath);
                 }
             }
             catch (Exception ex)

--- a/src/Shared/PackageManagers/GitHubProjectManager.cs
+++ b/src/Shared/PackageManagers/GitHubProjectManager.cs
@@ -16,6 +16,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
     internal class GitHubProjectManager : BaseProjectManager
     {
+        /// <inheritdoc cref="BaseProjectManager.Type"/>
+        public new const string Type = "github";
+
         public static string ENV_GITHUB_ENDPOINT = "https://github.com";
 
         public GitHubProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory) : base(httpClientFactory, destinationDirectory)
@@ -172,7 +175,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         }
 
         /// <inheritdoc />
-        public override async Task<IEnumerable<string>> EnumerateVersions(PackageURL purl, bool useCache = true)
+        public override async Task<IEnumerable<string>> EnumerateVersions(PackageURL purl, bool useCache = true, bool includePrerelease = true)
         {
             try
             {

--- a/src/Shared/PackageManagers/GitHubProjectManager.cs
+++ b/src/Shared/PackageManagers/GitHubProjectManager.cs
@@ -22,6 +22,8 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
         public const string Type = "github";
 
+        public override string ManagerType => Type;
+
         public static string ENV_GITHUB_ENDPOINT = "https://github.com";
 
         public GitHubProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory) : base(httpClientFactory, destinationDirectory)

--- a/src/Shared/PackageManagers/GitHubProjectManager.cs
+++ b/src/Shared/PackageManagers/GitHubProjectManager.cs
@@ -16,8 +16,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
     internal class GitHubProjectManager : BaseProjectManager
     {
-        /// <inheritdoc cref="BaseProjectManager.Type"/>
-        public new const string Type = "github";
+        /// <summary>
+        /// The type of the project manager from the package-url type specifications.
+        /// </summary>
+        /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
+        public const string Type = "github";
 
         public static string ENV_GITHUB_ENDPOINT = "https://github.com";
 

--- a/src/Shared/PackageManagers/GitHubProjectManager.cs
+++ b/src/Shared/PackageManagers/GitHubProjectManager.cs
@@ -151,7 +151,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                         Logger.Debug("Download successful.");
                         if (doExtract)
                         {
-                            downloadedPaths.Add(await ExtractArchive(relativeWorkingDirectory, await result.Content.ReadAsByteArrayAsync(), cached));
+                            downloadedPaths.Add(await ArchiveHelper.ExtractArchiveAsync(TopLevelExtractionDirectory, relativeWorkingDirectory, await result.Content.ReadAsStreamAsync(), cached));
                         }
                         else
                         {

--- a/src/Shared/PackageManagers/GolangProjectManager.cs
+++ b/src/Shared/PackageManagers/GolangProjectManager.cs
@@ -2,6 +2,7 @@
 
 namespace Microsoft.CST.OpenSource.PackageManagers
 {
+    using Helpers;
     using PackageUrl;
     using System;
     using System.Collections.Generic;
@@ -64,7 +65,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                 }
                 if (doExtract)
                 {
-                    downloadedPaths.Add(await ExtractArchive(targetName, await result.Content.ReadAsByteArrayAsync(), cached));
+                    downloadedPaths.Add(await ArchiveHelper.ExtractArchiveAsync(TopLevelExtractionDirectory, targetName, await result.Content.ReadAsStreamAsync(), cached));
                 }
                 else
                 {

--- a/src/Shared/PackageManagers/GolangProjectManager.cs
+++ b/src/Shared/PackageManagers/GolangProjectManager.cs
@@ -13,8 +13,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
     internal class GolangProjectManager : BaseProjectManager
     {
-        /// <inheritdoc cref="BaseProjectManager.Type"/>
-        public new const string Type = "golang";
+        /// <summary>
+        /// The type of the project manager from the package-url type specifications.
+        /// </summary>
+        /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
+        public const string Type = "golang";
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public static string ENV_GO_PROXY_ENDPOINT = "https://proxy.golang.org";

--- a/src/Shared/PackageManagers/GolangProjectManager.cs
+++ b/src/Shared/PackageManagers/GolangProjectManager.cs
@@ -13,6 +13,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
     internal class GolangProjectManager : BaseProjectManager
     {
+        /// <inheritdoc cref="BaseProjectManager.Type"/>
+        public new const string Type = "golang";
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public static string ENV_GO_PROXY_ENDPOINT = "https://proxy.golang.org";
 
@@ -98,7 +101,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         }
 
         /// <inheritdoc />
-        public override async Task<IEnumerable<string>> EnumerateVersions(PackageURL purl, bool useCache = true)
+        public override async Task<IEnumerable<string>> EnumerateVersions(PackageURL purl, bool useCache = true, bool includePrerelease = true)
         {
             Logger.Trace("EnumerateVersions {0}", purl?.ToString());
             if (purl == null)

--- a/src/Shared/PackageManagers/GolangProjectManager.cs
+++ b/src/Shared/PackageManagers/GolangProjectManager.cs
@@ -19,6 +19,8 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
         public const string Type = "golang";
 
+        public override string ManagerType => Type;
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public static string ENV_GO_PROXY_ENDPOINT = "https://proxy.golang.org";
 

--- a/src/Shared/PackageManagers/GolangProjectManager.cs
+++ b/src/Shared/PackageManagers/GolangProjectManager.cs
@@ -72,9 +72,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                 }
                 else
                 {
-                    targetName += Path.GetExtension(url) ?? "";
-                    await File.WriteAllBytesAsync(targetName, await result.Content.ReadAsByteArrayAsync());
-                    downloadedPaths.Add(targetName);
+                    extractionPath += Path.GetExtension(url) ?? "";
+                    await File.WriteAllBytesAsync(extractionPath, await result.Content.ReadAsByteArrayAsync());
+                    downloadedPaths.Add(extractionPath);
                 }
             }
             catch (Exception ex)

--- a/src/Shared/PackageManagers/HackageProjectManager.cs
+++ b/src/Shared/PackageManagers/HackageProjectManager.cs
@@ -71,9 +71,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                 }
                 else
                 {
-                    targetName += Path.GetExtension(url) ?? "";
-                    await File.WriteAllBytesAsync(targetName, await result.Content.ReadAsByteArrayAsync());
-                    downloadedPaths.Add(targetName);
+                    extractionPath += Path.GetExtension(url) ?? "";
+                    await File.WriteAllBytesAsync(extractionPath, await result.Content.ReadAsByteArrayAsync());
+                    downloadedPaths.Add(extractionPath);
                 }
             }
             catch (Exception ex)

--- a/src/Shared/PackageManagers/HackageProjectManager.cs
+++ b/src/Shared/PackageManagers/HackageProjectManager.cs
@@ -3,6 +3,7 @@
 namespace Microsoft.CST.OpenSource.PackageManagers
 {
     using AngleSharp.Html.Parser;
+    using Helpers;
     using PackageUrl;
     using System;
     using System.Collections.Generic;
@@ -63,7 +64,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                 }
                 if (doExtract)
                 {
-                    downloadedPaths.Add(await ExtractArchive(targetName, await result.Content.ReadAsByteArrayAsync(), cached));
+                    downloadedPaths.Add(await ArchiveHelper.ExtractArchiveAsync(TopLevelExtractionDirectory, targetName, await result.Content.ReadAsStreamAsync(), cached));
                 }
                 else
                 {

--- a/src/Shared/PackageManagers/HackageProjectManager.cs
+++ b/src/Shared/PackageManagers/HackageProjectManager.cs
@@ -14,8 +14,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
     internal class HackageProjectManager : BaseProjectManager
     {
-        /// <inheritdoc cref="BaseProjectManager.Type"/>
-        public new const string Type = "hackage";
+        /// <summary>
+        /// The type of the project manager from the package-url type specifications.
+        /// </summary>
+        /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
+        public const string Type = "hackage";
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public static string ENV_HACKAGE_ENDPOINT = "https://hackage.haskell.org";

--- a/src/Shared/PackageManagers/HackageProjectManager.cs
+++ b/src/Shared/PackageManagers/HackageProjectManager.cs
@@ -14,6 +14,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
     internal class HackageProjectManager : BaseProjectManager
     {
+        /// <inheritdoc cref="BaseProjectManager.Type"/>
+        public new const string Type = "hackage";
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public static string ENV_HACKAGE_ENDPOINT = "https://hackage.haskell.org";
 
@@ -81,7 +84,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         }
 
         /// <inheritdoc />
-        public override async Task<IEnumerable<string>> EnumerateVersions(PackageURL purl, bool useCache = true)
+        public override async Task<IEnumerable<string>> EnumerateVersions(PackageURL purl, bool useCache = true, bool includePrerelease = true)
         {
             Logger.Trace("EnumerateVersions {0}", purl?.ToString());
             if (purl == null || purl.Name is null)

--- a/src/Shared/PackageManagers/HackageProjectManager.cs
+++ b/src/Shared/PackageManagers/HackageProjectManager.cs
@@ -20,6 +20,8 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
         public const string Type = "hackage";
 
+        public override string ManagerType => Type;
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public static string ENV_HACKAGE_ENDPOINT = "https://hackage.haskell.org";
 

--- a/src/Shared/PackageManagers/MavenProjectManager.cs
+++ b/src/Shared/PackageManagers/MavenProjectManager.cs
@@ -20,6 +20,8 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
         public const string Type = "maven";
 
+        public override string ManagerType => Type;
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public static string ENV_MAVEN_ENDPOINT = "https://repo1.maven.org/maven2";
 

--- a/src/Shared/PackageManagers/MavenProjectManager.cs
+++ b/src/Shared/PackageManagers/MavenProjectManager.cs
@@ -2,6 +2,7 @@
 
 namespace Microsoft.CST.OpenSource.PackageManagers
 {
+    using Helpers;
     using PackageUrl;
     using System;
     using System.Collections.Generic;
@@ -66,7 +67,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                     }
                     if (doExtract)
                     {
-                        downloadedPaths.Add(await ExtractArchive(targetName, await result.Content.ReadAsByteArrayAsync(), cached));
+                        downloadedPaths.Add(await ArchiveHelper.ExtractArchiveAsync(TopLevelExtractionDirectory, targetName, await result.Content.ReadAsStreamAsync(), cached));
                     }
                     else
                     {

--- a/src/Shared/PackageManagers/MavenProjectManager.cs
+++ b/src/Shared/PackageManagers/MavenProjectManager.cs
@@ -74,9 +74,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                     }
                     else
                     {
-                        targetName += Path.GetExtension(url) ?? "";
-                        await File.WriteAllBytesAsync(targetName, await result.Content.ReadAsByteArrayAsync());
-                        downloadedPaths.Add(targetName);
+                        extractionPath += Path.GetExtension(url) ?? "";
+                        await File.WriteAllBytesAsync(extractionPath, await result.Content.ReadAsByteArrayAsync());
+                        downloadedPaths.Add(extractionPath);
                     }
                 }
             }

--- a/src/Shared/PackageManagers/MavenProjectManager.cs
+++ b/src/Shared/PackageManagers/MavenProjectManager.cs
@@ -14,8 +14,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
     internal class MavenProjectManager : BaseProjectManager
     {
-        /// <inheritdoc cref="BaseProjectManager.Type"/>
-        public new const string Type = "maven";
+        /// <summary>
+        /// The type of the project manager from the package-url type specifications.
+        /// </summary>
+        /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
+        public const string Type = "maven";
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public static string ENV_MAVEN_ENDPOINT = "https://repo1.maven.org/maven2";

--- a/src/Shared/PackageManagers/MavenProjectManager.cs
+++ b/src/Shared/PackageManagers/MavenProjectManager.cs
@@ -14,6 +14,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
     internal class MavenProjectManager : BaseProjectManager
     {
+        /// <inheritdoc cref="BaseProjectManager.Type"/>
+        public new const string Type = "maven";
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public static string ENV_MAVEN_ENDPOINT = "https://repo1.maven.org/maven2";
 
@@ -101,7 +104,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         }
 
         /// <inheritdoc />
-        public override async Task<IEnumerable<string>> EnumerateVersions(PackageURL purl, bool useCache = true)
+        public override async Task<IEnumerable<string>> EnumerateVersions(PackageURL purl, bool useCache = true, bool includePrerelease = true)
         {
             Logger.Trace("EnumerateVersions {0}", purl?.ToString());
             if (purl is null || purl.Name is null || purl.Namespace is null)

--- a/src/Shared/PackageManagers/NPMProjectManager.cs
+++ b/src/Shared/PackageManagers/NPMProjectManager.cs
@@ -18,8 +18,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
     public class NPMProjectManager : BaseProjectManager
     {
-        /// <inheritdoc cref="BaseProjectManager.Type"/>
-        public new const string Type = "npm";
+        /// <summary>
+        /// The type of the project manager from the package-url type specifications.
+        /// </summary>
+        /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
+        public const string Type = "npm";
 
         public static string ENV_NPM_API_ENDPOINT { get; set; } = "https://registry.npmjs.org";
         public static string ENV_NPM_ENDPOINT { get; set; } = "https://www.npmjs.com";

--- a/src/Shared/PackageManagers/NPMProjectManager.cs
+++ b/src/Shared/PackageManagers/NPMProjectManager.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                 }
                 if (doExtract)
                 {
-                    downloadedPaths.Add(await ExtractArchive(targetName, await result.Content.ReadAsByteArrayAsync(), cached));
+                    downloadedPaths.Add(await ArchiveHelper.ExtractArchiveAsync(TopLevelExtractionDirectory, targetName, await result.Content.ReadAsStreamAsync(), cached));
                 }
                 else
                 {

--- a/src/Shared/PackageManagers/NPMProjectManager.cs
+++ b/src/Shared/PackageManagers/NPMProjectManager.cs
@@ -303,12 +303,14 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
                     // author(s)
                     JsonElement? authorElement = OssUtilities.GetJSONPropertyIfExists(versionElement, "_npmUser");
-                    User author = new();
                     if (authorElement is not null)
                     {
-                        author.Name = OssUtilities.GetJSONPropertyStringIfExists(authorElement, "name");
-                        author.Email = OssUtilities.GetJSONPropertyStringIfExists(authorElement, "email");
-                        author.Url = OssUtilities.GetJSONPropertyStringIfExists(authorElement, "url");
+                        User author = new()
+                        {
+                            Name = OssUtilities.GetJSONPropertyStringIfExists(authorElement, "name"),
+                            Email = OssUtilities.GetJSONPropertyStringIfExists(authorElement, "email"),
+                            Url = OssUtilities.GetJSONPropertyStringIfExists(authorElement, "url")
+                        };
 
                         metadata.Authors ??= new List<User>();
                         metadata.Authors.Add(author);

--- a/src/Shared/PackageManagers/NPMProjectManager.cs
+++ b/src/Shared/PackageManagers/NPMProjectManager.cs
@@ -18,6 +18,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
     public class NPMProjectManager : BaseProjectManager
     {
+        /// <inheritdoc cref="BaseProjectManager.Type"/>
+        public new const string Type = "npm";
+
         public static string ENV_NPM_API_ENDPOINT { get; set; } = "https://registry.npmjs.org";
         public static string ENV_NPM_ENDPOINT { get; set; } = "https://www.npmjs.com";
 
@@ -98,7 +101,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         }
 
         /// <inheritdoc />
-        public override async Task<IEnumerable<string>> EnumerateVersions(PackageURL purl, bool useCache = true)
+        public override async Task<IEnumerable<string>> EnumerateVersions(PackageURL purl, bool useCache = true, bool includePrerelease = true)
         {
             Logger.Trace("EnumerateVersions {0}", purl?.ToString());
             if (purl?.Name is null)
@@ -186,7 +189,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         }
 
         /// <inheritdoc />
-        public override async Task<PackageMetadata> GetPackageMetadata(PackageURL purl, bool useCache = true)
+        public override async Task<PackageMetadata?> GetPackageMetadata(PackageURL purl, bool useCache = true)
         {
             PackageMetadata metadata = new();
             string? content = await GetMetadata(purl, useCache);

--- a/src/Shared/PackageManagers/NPMProjectManager.cs
+++ b/src/Shared/PackageManagers/NPMProjectManager.cs
@@ -24,6 +24,8 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
         public const string Type = "npm";
 
+        public override string ManagerType => Type;
+
         public static string ENV_NPM_API_ENDPOINT { get; set; } = "https://registry.npmjs.org";
         public static string ENV_NPM_ENDPOINT { get; set; } = "https://www.npmjs.com";
 

--- a/src/Shared/PackageManagers/NPMProjectManager.cs
+++ b/src/Shared/PackageManagers/NPMProjectManager.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                 result.EnsureSuccessStatusCode();
                 Logger.Debug("Downloading {0}...", purl?.ToString());
                 string targetName = $"npm-{packageName}@{packageVersion}";
-                string extractionPath = Path.Combine(TopLevelExtractionDirectory ?? string.Empty, targetName);
+                string extractionPath = Path.Combine(TopLevelExtractionDirectory, targetName);
                 if (doExtract && Directory.Exists(extractionPath) && cached == true)
                 {
                     downloadedPaths.Add(extractionPath);
@@ -73,9 +73,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                 }
                 else
                 {
-                    targetName += Path.GetExtension(tarball) ?? "";
-                    await File.WriteAllBytesAsync(targetName, await result.Content.ReadAsByteArrayAsync());
-                    downloadedPaths.Add(targetName);
+                    extractionPath += Path.GetExtension(tarball) ?? "";
+                    await File.WriteAllBytesAsync(extractionPath, await result.Content.ReadAsByteArrayAsync());
+                    downloadedPaths.Add(extractionPath);
                 }
             }
             catch (Exception ex)

--- a/src/Shared/PackageManagers/NuGetProjectManager.cs
+++ b/src/Shared/PackageManagers/NuGetProjectManager.cs
@@ -20,8 +20,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
     public class NuGetProjectManager : BaseProjectManager
     {
-        /// <inheritdoc cref="BaseProjectManager.Type"/>
-        public new const string Type = "nuget";
+        /// <summary>
+        /// The type of the project manager from the package-url type specifications.
+        /// </summary>
+        /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
+        public const string Type = "nuget";
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public const string ENV_NUGET_ENDPOINT_API = "https://api.nuget.org";

--- a/src/Shared/PackageManagers/NuGetProjectManager.cs
+++ b/src/Shared/PackageManagers/NuGetProjectManager.cs
@@ -132,7 +132,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
                                 if (doExtract)
                                 {
-                                    downloadedPaths.Add(await ExtractArchive(targetName, await result.Content.ReadAsByteArrayAsync(), cached));
+                                    downloadedPaths.Add(await ArchiveHelper.ExtractArchiveAsync(TopLevelExtractionDirectory, targetName, await result.Content.ReadAsStreamAsync(), cached));
                                 }
                                 else
                                 {
@@ -172,7 +172,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
                                     if (doExtract)
                                     {
-                                        downloadedPaths.Add(await ExtractArchive(targetName, await result.Content.ReadAsByteArrayAsync(), cached));
+                                        downloadedPaths.Add(await ArchiveHelper.ExtractArchiveAsync(TopLevelExtractionDirectory, targetName, await result.Content.ReadAsStreamAsync(), cached));
                                     }
                                     else
                                     {

--- a/src/Shared/PackageManagers/NuGetProjectManager.cs
+++ b/src/Shared/PackageManagers/NuGetProjectManager.cs
@@ -138,9 +138,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                                 }
                                 else
                                 {
-                                    targetName += Path.GetExtension(archive) ?? "";
-                                    await File.WriteAllBytesAsync(targetName, await result.Content.ReadAsByteArrayAsync());
-                                    downloadedPaths.Add(targetName);
+                                    extractionPath += Path.GetExtension(archive) ?? "";
+                                    await File.WriteAllBytesAsync(extractionPath, await result.Content.ReadAsByteArrayAsync());
+                                    downloadedPaths.Add(extractionPath);
                                 }
                                 return downloadedPaths;
                             }
@@ -178,9 +178,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                                     }
                                     else
                                     {
-                                        targetName += Path.GetExtension(archive) ?? "";
-                                        await File.WriteAllBytesAsync(targetName, await result.Content.ReadAsByteArrayAsync());
-                                        downloadedPaths.Add(targetName);
+                                        extractionPath += Path.GetExtension(archive) ?? "";
+                                        await File.WriteAllBytesAsync(extractionPath, await result.Content.ReadAsByteArrayAsync());
+                                        downloadedPaths.Add(extractionPath);
                                     }
                                     return downloadedPaths;
                                 }

--- a/src/Shared/PackageManagers/NuGetProjectManager.cs
+++ b/src/Shared/PackageManagers/NuGetProjectManager.cs
@@ -18,9 +18,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
     using Utilities;
     using Version = SemanticVersioning.Version;
 
-
     public class NuGetProjectManager : BaseProjectManager
     {
+        /// <inheritdoc cref="BaseProjectManager.Type"/>
+        public new const string Type = "nuget";
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public const string ENV_NUGET_ENDPOINT_API = "https://api.nuget.org";
         public const string ENV_NUGET_ENDPOINT = "https://www.nuget.org";
@@ -215,7 +217,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         }
 
         /// <inheritdoc />
-        public override async Task<IEnumerable<string>> EnumerateVersions(PackageURL purl, bool useCache = true)
+        public override async Task<IEnumerable<string>> EnumerateVersions(PackageURL purl, bool useCache = true, bool includePrerelease = true)
         {
             Logger.Trace("EnumerateVersions {0}", purl?.ToString());
 
@@ -335,7 +337,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         }
         
         /// <inheritdoc />
-        public override async Task<PackageMetadata> GetPackageMetadata(PackageURL purl, bool useCache = true)
+        public override async Task<PackageMetadata?> GetPackageMetadata(PackageURL purl, bool useCache = true)
         {
             PackageMetadata metadata = new();
             string? content = await GetMetadata(purl, useCache);

--- a/src/Shared/PackageManagers/NuGetProjectManager.cs
+++ b/src/Shared/PackageManagers/NuGetProjectManager.cs
@@ -26,6 +26,8 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
         public const string Type = "nuget";
 
+        public override string ManagerType => Type;
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public const string ENV_NUGET_ENDPOINT_API = "https://api.nuget.org";
         public const string ENV_NUGET_ENDPOINT = "https://www.nuget.org";

--- a/src/Shared/PackageManagers/NuGetProjectManager.cs
+++ b/src/Shared/PackageManagers/NuGetProjectManager.cs
@@ -406,13 +406,13 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
                     // author(s)
                     JsonElement? authorElement = OssUtilities.GetJSONPropertyIfExists(versionElement, "authors");
-                    User author = new();
                     if (authorElement is not null)
                     {
-                        author.Name = authorElement?.GetString();
-                        // TODO: User email and url
-                        // author.Email = OssUtilities.GetJSONPropertyStringIfExists(authorElement, "email");
-                        // author.Url = OssUtilities.GetJSONPropertyStringIfExists(authorElement, "url");
+                        User author = new()
+                        {
+                            Name = authorElement?.GetString(),
+                            // TODO: User email and url
+                        };
 
                         metadata.Authors ??= new List<User>();
                         metadata.Authors.Add(author);

--- a/src/Shared/PackageManagers/ProjectManagerFactory.cs
+++ b/src/Shared/PackageManagers/ProjectManagerFactory.cs
@@ -11,27 +11,6 @@ namespace Microsoft.CST.OpenSource.PackageManagers
     public static class ProjectManagerFactory
     {
         /// <summary>
-        /// Create a BaseProjectManager.
-        /// </summary>
-        /// <param name="httpClientFactory">The Http cliend factory for making http clients to make requests with.</param>
-        /// <param name="destinationDirectory">The directory to use to store any downloaded packages.</param>
-        /// <returns></returns>
-        public static BaseProjectManager CreateBaseProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory)
-        {
-            return new BaseProjectManager(httpClientFactory, destinationDirectory);
-        }
-
-        /// <summary>
-        /// Create a BaseProjectManager.
-        /// </summary>
-        /// <param name="destinationDirectory">The directory to use to store any downloaded packages.</param>
-        /// <returns></returns>
-        public static BaseProjectManager CreateBaseProjectManager(string destinationDirectory)
-        {
-            return new BaseProjectManager(destinationDirectory);
-        }
-
-        /// <summary>
         /// Get an appropriate project manager for package given its PackageURL.
         /// </summary>
         /// <param name="purl">The <see cref="PackageURL"/> for the package to create the project manager for.</param>

--- a/src/Shared/PackageManagers/PyPIProjectManager.cs
+++ b/src/Shared/PackageManagers/PyPIProjectManager.cs
@@ -2,6 +2,7 @@
 
 namespace Microsoft.CST.OpenSource.PackageManagers
 {
+    using Helpers;
     using Model;
     using NLog.LayoutRenderers.Wrappers;
     using PackageUrl;
@@ -81,7 +82,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                         }
                         if (doExtract)
                         {
-                            downloadedPaths.Add(await ExtractArchive(targetName, await result.Content.ReadAsByteArrayAsync(), cached));
+                            downloadedPaths.Add(await ArchiveHelper.ExtractArchiveAsync(TopLevelExtractionDirectory, targetName, await result.Content.ReadAsStreamAsync(), cached));
                         }
                         else
                         {

--- a/src/Shared/PackageManagers/PyPIProjectManager.cs
+++ b/src/Shared/PackageManagers/PyPIProjectManager.cs
@@ -74,9 +74,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                             continue;   // Missing a package type
                         }
 
-                        string? url = release.GetProperty("url").GetString();
-
-                        System.Net.Http.HttpResponseMessage result = await httpClient.GetAsync(url);
+                        System.Net.Http.HttpResponseMessage result = await httpClient.GetAsync(release.GetProperty("url").GetString());
                         result.EnsureSuccessStatusCode();
                         string targetName = $"pypi-{packageType}-{packageName}@{packageVersion}";
                         string extension = ".tar.gz";

--- a/src/Shared/PackageManagers/PyPIProjectManager.cs
+++ b/src/Shared/PackageManagers/PyPIProjectManager.cs
@@ -18,8 +18,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
     public class PyPIProjectManager : BaseProjectManager
     {
-        /// <inheritdoc cref="BaseProjectManager.Type"/>
-        public new const string Type = "pypi";
+        /// <summary>
+        /// The type of the project manager from the package-url type specifications.
+        /// </summary>
+        /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
+        public const string Type = "pypi";
 
         public static string ENV_PYPI_ENDPOINT { get; set; } = "https://pypi.org";
 

--- a/src/Shared/PackageManagers/PyPIProjectManager.cs
+++ b/src/Shared/PackageManagers/PyPIProjectManager.cs
@@ -18,6 +18,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
     public class PyPIProjectManager : BaseProjectManager
     {
+        /// <inheritdoc cref="BaseProjectManager.Type"/>
+        public new const string Type = "pypi";
+
         public static string ENV_PYPI_ENDPOINT { get; set; } = "https://pypi.org";
 
         public PyPIProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory) : base(httpClientFactory, destinationDirectory)
@@ -115,7 +118,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         }
 
         /// <inheritdoc />
-        public override async Task<IEnumerable<string>> EnumerateVersions(PackageURL purl, bool useCache = true)
+        public override async Task<IEnumerable<string>> EnumerateVersions(PackageURL purl, bool useCache = true, bool includePrerelease = true)
         {
             Logger.Trace("EnumerateVersions {0}", purl?.ToString());
             if (purl == null || purl.Name is null)
@@ -175,7 +178,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         }
 
         /// <inheritdoc />
-        public override async Task<PackageMetadata> GetPackageMetadata(PackageURL purl, bool useCache = true)
+        public override async Task<PackageMetadata?> GetPackageMetadata(PackageURL purl, bool useCache = true)
         {
             PackageMetadata metadata = new();
             string? content = await GetMetadata(purl, useCache);

--- a/src/Shared/PackageManagers/PyPIProjectManager.cs
+++ b/src/Shared/PackageManagers/PyPIProjectManager.cs
@@ -74,9 +74,16 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                             continue;   // Missing a package type
                         }
 
-                        System.Net.Http.HttpResponseMessage result = await httpClient.GetAsync(release.GetProperty("url").GetString());
+                        string? url = release.GetProperty("url").GetString();
+
+                        System.Net.Http.HttpResponseMessage result = await httpClient.GetAsync(url);
                         result.EnsureSuccessStatusCode();
                         string targetName = $"pypi-{packageType}-{packageName}@{packageVersion}";
+                        string extension = ".tar.gz";
+                        if (packageType.ToString() == "bdist_wheel")
+                        {
+                            extension = ".whl";
+                        }
                         string extractionPath = Path.Combine(TopLevelExtractionDirectory, targetName);
                         if (doExtract && Directory.Exists(extractionPath) && cached == true)
                         {
@@ -89,8 +96,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                         }
                         else
                         {
-                            await File.WriteAllBytesAsync(targetName, await result.Content.ReadAsByteArrayAsync());
-                            downloadedPaths.Add(targetName);
+                            extractionPath += extension;
+                            await File.WriteAllBytesAsync(extractionPath, await result.Content.ReadAsByteArrayAsync());
+                            downloadedPaths.Add(extractionPath);
                         }
                     }
                 }

--- a/src/Shared/PackageManagers/PyPIProjectManager.cs
+++ b/src/Shared/PackageManagers/PyPIProjectManager.cs
@@ -24,6 +24,8 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
         public const string Type = "pypi";
 
+        public override string ManagerType => Type;
+
         public static string ENV_PYPI_ENDPOINT { get; set; } = "https://pypi.org";
 
         public PyPIProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory) : base(httpClientFactory, destinationDirectory)

--- a/src/Shared/PackageManagers/URLProjectManager.cs
+++ b/src/Shared/PackageManagers/URLProjectManager.cs
@@ -18,6 +18,8 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
         public const string Type = "url";
 
+        public override string ManagerType => Type;
+
         public URLProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory) : base(httpClientFactory, destinationDirectory)
         {
         }

--- a/src/Shared/PackageManagers/URLProjectManager.cs
+++ b/src/Shared/PackageManagers/URLProjectManager.cs
@@ -75,20 +75,17 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             }
         }
 
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
-        public override async Task<IEnumerable<string>> EnumerateVersions(PackageURL purl, bool useCache = true)
-#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
         public override async Task<IEnumerable<string>> EnumerateVersions(PackageURL purl, bool useCache = true, bool includePrerelease = true)
         {
             Logger.Trace("EnumerateVersions {0}", purl?.ToString());
             if (purl == null)
             {
-                return new List<string>();
+                return await Task.FromResult(Array.Empty<string>());
             }
 
-            return new List<string>() {
+            return await Task.FromResult(new List<string>() {
                 "1.0"
-            };
+            });
         }
 
         /// <inheritdoc />

--- a/src/Shared/PackageManagers/URLProjectManager.cs
+++ b/src/Shared/PackageManagers/URLProjectManager.cs
@@ -63,8 +63,8 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                 }
                 else
                 {
-                    await File.WriteAllBytesAsync(targetName, await result.Content.ReadAsByteArrayAsync());
-                    downloadedPaths.Add(targetName);
+                    await File.WriteAllBytesAsync(extractionPath, await result.Content.ReadAsByteArrayAsync());
+                    downloadedPaths.Add(extractionPath);
                 }
                 return downloadedPaths;
             }

--- a/src/Shared/PackageManagers/URLProjectManager.cs
+++ b/src/Shared/PackageManagers/URLProjectManager.cs
@@ -12,8 +12,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
     internal class URLProjectManager : BaseProjectManager
     {
-        /// <inheritdoc cref="BaseProjectManager.Type"/>
-        public new const string Type = "url";
+        /// <summary>
+        /// The type of the project manager from the package-url type specifications.
+        /// </summary>
+        /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
+        public const string Type = "url";
 
         public URLProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory) : base(httpClientFactory, destinationDirectory)
         {

--- a/src/Shared/PackageManagers/URLProjectManager.cs
+++ b/src/Shared/PackageManagers/URLProjectManager.cs
@@ -12,6 +12,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
     internal class URLProjectManager : BaseProjectManager
     {
+        /// <inheritdoc cref="BaseProjectManager.Type"/>
+        public new const string Type = "url";
+
         public URLProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory) : base(httpClientFactory, destinationDirectory)
         {
         }
@@ -75,6 +78,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
         public override async Task<IEnumerable<string>> EnumerateVersions(PackageURL purl, bool useCache = true)
 #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+        public override async Task<IEnumerable<string>> EnumerateVersions(PackageURL purl, bool useCache = true, bool includePrerelease = true)
         {
             Logger.Trace("EnumerateVersions {0}", purl?.ToString());
             if (purl == null)

--- a/src/Shared/PackageManagers/URLProjectManager.cs
+++ b/src/Shared/PackageManagers/URLProjectManager.cs
@@ -2,6 +2,7 @@
 
 namespace Microsoft.CST.OpenSource.PackageManagers
 {
+    using Helpers;
     using PackageUrl;
     using System;
     using System.Collections.Generic;
@@ -55,7 +56,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                 }
                 if (doExtract)
                 {
-                    downloadedPaths.Add(await ExtractArchive(targetName, await result.Content.ReadAsByteArrayAsync(), cached));
+                    downloadedPaths.Add(await ArchiveHelper.ExtractArchiveAsync(TopLevelExtractionDirectory, targetName, await result.Content.ReadAsStreamAsync(), cached));
                 }
                 else
                 {

--- a/src/Shared/PackageManagers/UbuntuProjectManager.cs
+++ b/src/Shared/PackageManagers/UbuntuProjectManager.cs
@@ -16,6 +16,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
     internal class UbuntuProjectManager : BaseProjectManager
     {
+        /// <inheritdoc cref="BaseProjectManager.Type"/>
+        public new const string Type = "ubuntu";
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public static string ENV_UBUNTU_ARCHIVE_MIRROR = "https://mirror.math.princeton.edu/pub";
 
@@ -179,7 +182,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         }
 
         /// <inheritdoc />
-        public override async Task<IEnumerable<string>> EnumerateVersions(PackageURL purl, bool useCache = true)
+        public override async Task<IEnumerable<string>> EnumerateVersions(PackageURL purl, bool useCache = true, bool includePrerelease = true)
         {
             Logger.Trace("EnumerateVersions {0}", purl?.ToString());
 

--- a/src/Shared/PackageManagers/UbuntuProjectManager.cs
+++ b/src/Shared/PackageManagers/UbuntuProjectManager.cs
@@ -111,9 +111,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                             }
                             else
                             {
-                                targetName += Path.GetExtension(anchorHref) ?? "";
-                                await File.WriteAllBytesAsync(targetName, await downloadResult.Content.ReadAsByteArrayAsync());
-                                downloadedPaths.Add(targetName);
+                                extractionPath += Path.GetExtension(anchorHref) ?? "";
+                                await File.WriteAllBytesAsync(extractionPath, await downloadResult.Content.ReadAsByteArrayAsync());
+                                downloadedPaths.Add(extractionPath);
                             }
                         }
 
@@ -156,6 +156,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
                                     // TODO: Add distro version id
                                     string targetName = $"ubuntu-{purl.Name}@{packageVersion}-{secondHref}";
+                                    string extractionPath = Path.Combine(TopLevelExtractionDirectory, targetName);
 
                                     if (doExtract)
                                     {
@@ -163,9 +164,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                                     }
                                     else
                                     {
-                                        targetName += Path.GetExtension(anchorHref) ?? "";
-                                        await File.WriteAllBytesAsync(targetName, await downloadResult.Content.ReadAsByteArrayAsync());
-                                        downloadedPaths.Add(targetName);
+                                        extractionPath += Path.GetExtension(anchorHref) ?? "";
+                                        await File.WriteAllBytesAsync(extractionPath, await downloadResult.Content.ReadAsByteArrayAsync());
+                                        downloadedPaths.Add(extractionPath);
                                     }
                                 }
                             }

--- a/src/Shared/PackageManagers/UbuntuProjectManager.cs
+++ b/src/Shared/PackageManagers/UbuntuProjectManager.cs
@@ -3,6 +3,7 @@
 namespace Microsoft.CST.OpenSource.PackageManagers
 {
     using AngleSharp.Html.Parser;
+    using Helpers;
     using PackageUrl;
     using System;
     using System.Collections.Generic;
@@ -103,7 +104,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
                             if (doExtract)
                             {
-                                downloadedPaths.Add(await ExtractArchive(targetName, await downloadResult.Content.ReadAsByteArrayAsync(), cached));
+                                downloadedPaths.Add(await ArchiveHelper.ExtractArchiveAsync(TopLevelExtractionDirectory, targetName, await downloadResult.Content.ReadAsStreamAsync(), cached));
                             }
                             else
                             {
@@ -155,7 +156,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
                                     if (doExtract)
                                     {
-                                        downloadedPaths.Add(await ExtractArchive(targetName, await downloadResult.Content.ReadAsByteArrayAsync(), cached));
+                                        downloadedPaths.Add(await ArchiveHelper.ExtractArchiveAsync(TopLevelExtractionDirectory, targetName, await downloadResult.Content.ReadAsStreamAsync(), cached));
                                     }
                                     else
                                     {

--- a/src/Shared/PackageManagers/UbuntuProjectManager.cs
+++ b/src/Shared/PackageManagers/UbuntuProjectManager.cs
@@ -16,8 +16,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
     internal class UbuntuProjectManager : BaseProjectManager
     {
-        /// <inheritdoc cref="BaseProjectManager.Type"/>
-        public new const string Type = "ubuntu";
+        /// <summary>
+        /// The type of the project manager from the package-url type specifications.
+        /// </summary>
+        /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
+        public const string Type = "ubuntu";
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public static string ENV_UBUNTU_ARCHIVE_MIRROR = "https://mirror.math.princeton.edu/pub";

--- a/src/Shared/PackageManagers/UbuntuProjectManager.cs
+++ b/src/Shared/PackageManagers/UbuntuProjectManager.cs
@@ -22,6 +22,8 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
         public const string Type = "ubuntu";
 
+        public override string ManagerType => Type;
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public static string ENV_UBUNTU_ARCHIVE_MIRROR = "https://mirror.math.princeton.edu/pub";
 

--- a/src/Shared/PackageManagers/VSMProjectManager.cs
+++ b/src/Shared/PackageManagers/VSMProjectManager.cs
@@ -16,6 +16,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
     internal class VSMProjectManager : BaseProjectManager
     {
+        /// <inheritdoc cref="BaseProjectManager.Type"/>
+        public new const string Type = "vsm";
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public static string ENV_VS_MARKETPLACE_ENDPOINT = "https://marketplace.visualstudio.com";
 
@@ -162,7 +165,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         }
 
         /// <inheritdoc />
-        public override async Task<IEnumerable<string>> EnumerateVersions(PackageURL purl, bool useCache = true)
+        public override async Task<IEnumerable<string>> EnumerateVersions(PackageURL purl, bool useCache = true, bool includePrerelease = true)
         {
             Logger.Trace("EnumerateVersions {0}", purl?.ToString());
 

--- a/src/Shared/PackageManagers/VSMProjectManager.cs
+++ b/src/Shared/PackageManagers/VSMProjectManager.cs
@@ -22,6 +22,8 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
         public const string Type = "vsm";
 
+        public override string ManagerType => Type;
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public static string ENV_VS_MARKETPLACE_ENDPOINT = "https://marketplace.visualstudio.com";
 

--- a/src/Shared/PackageManagers/VSMProjectManager.cs
+++ b/src/Shared/PackageManagers/VSMProjectManager.cs
@@ -16,8 +16,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
     internal class VSMProjectManager : BaseProjectManager
     {
-        /// <inheritdoc cref="BaseProjectManager.Type"/>
-        public new const string Type = "vsm";
+        /// <summary>
+        /// The type of the project manager from the package-url type specifications.
+        /// </summary>
+        /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
+        public const string Type = "vsm";
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public static string ENV_VS_MARKETPLACE_ENDPOINT = "https://marketplace.visualstudio.com";

--- a/src/Shared/PackageManagers/VSMProjectManager.cs
+++ b/src/Shared/PackageManagers/VSMProjectManager.cs
@@ -2,6 +2,7 @@
 
 namespace Microsoft.CST.OpenSource.PackageManagers
 {
+    using Helpers;
     using Microsoft.Extensions.Caching.Memory;
     using PackageUrl;
     using System;
@@ -135,7 +136,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                                     }
                                     if (doExtract)
                                     {
-                                        downloadedPaths.Add(await ExtractArchive(targetName, await downloadResult.Content.ReadAsByteArrayAsync(), cached));
+                                        downloadedPaths.Add(await ArchiveHelper.ExtractArchiveAsync(TopLevelExtractionDirectory, targetName, await downloadResult.Content.ReadAsStreamAsync(), cached));
                                     }
                                     else
                                     {

--- a/src/Shared/PackageManagers/VSMProjectManager.cs
+++ b/src/Shared/PackageManagers/VSMProjectManager.cs
@@ -143,9 +143,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                                     }
                                     else
                                     {
-                                        targetName += Path.GetExtension(source.GetString()) ?? "";
-                                        await File.WriteAllBytesAsync(targetName, await downloadResult.Content.ReadAsByteArrayAsync());
-                                        downloadedPaths.Add(targetName);
+                                        extractionPath += Path.GetExtension(source.GetString()) ?? "";
+                                        await File.WriteAllBytesAsync(extractionPath, await downloadResult.Content.ReadAsByteArrayAsync());
+                                        downloadedPaths.Add(extractionPath);
                                     }
                                 }
                                 catch (Exception ex)

--- a/src/oss-detect-cryptography/DetectCryptographyTool.cs
+++ b/src/oss-detect-cryptography/DetectCryptographyTool.cs
@@ -22,7 +22,7 @@ using Microsoft.CST.RecursiveExtractor;
 
 namespace Microsoft.CST.OpenSource
 {
-    using Microsoft.CST.OpenSource.PackageManagers;
+    using Helpers;
     using PackageUrl;
     using System.Net.Http;
 
@@ -92,9 +92,8 @@ namespace Microsoft.CST.OpenSource
                             {
                                 targetDirectoryName = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
                             }
-                            BaseProjectManager projectManager = ProjectManagerFactory.CreateBaseProjectManager(detectCryptographyTool.HttpClientFactory, targetDirectoryName);
 
-                            string? path = await projectManager.ExtractArchive("temp", File.ReadAllBytes(target));
+                            string? path = await ArchiveHelper.ExtractArchiveAsync(targetDirectoryName, "temp", File.OpenRead(target));
 
                             results = await detectCryptographyTool.AnalyzeDirectory(path);
 

--- a/src/oss-detect-cryptography/DetectCryptographyTool.cs
+++ b/src/oss-detect-cryptography/DetectCryptographyTool.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CST.OpenSource
                                 targetDirectoryName = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
                             }
 
-                            string? path = await ArchiveHelper.ExtractArchiveAsync(targetDirectoryName, "temp", File.OpenRead(target));
+                            string? path = await ArchiveHelper.ExtractArchiveAsync(targetDirectoryName, Path.GetFileName(target), File.OpenRead(target));
 
                             results = await detectCryptographyTool.AnalyzeDirectory(path);
 

--- a/src/oss-download/Properties/launchSettings.json
+++ b/src/oss-download/Properties/launchSettings.json
@@ -1,7 +1,0 @@
-{
-  "profiles": {
-    "oss-download": {
-      "commandName": "Project"
-    }
-  }
-}

--- a/src/oss-find-squats-lib/Mutators/IMutator.cs
+++ b/src/oss-find-squats-lib/Mutators/IMutator.cs
@@ -5,6 +5,7 @@ namespace Microsoft.CST.OpenSource.FindSquats.Mutators
     using Extensions;
     using PackageUrl;
     using System.Collections.Generic;
+    using System.Web;
 
     /// <summary>
     /// The mutator interface
@@ -37,14 +38,14 @@ namespace Microsoft.CST.OpenSource.FindSquats.Mutators
                 if (hasNamespace)
                 {
                     yield return new Mutation(
-                        mutated: arg.CreateWithNewNames(arg.Name, mutation.Mutated).ToString(),
+                        mutated: arg.CreateWithNewNames(arg.Name, HttpUtility.UrlEncode(mutation.Mutated)).ToString(),
                         original: mutation.Original,
                         reason: mutation.Reason,
                         mutator: mutation.Mutator);
                 }
 
                 yield return new Mutation(
-                    mutated: arg.CreateWithNewNames(mutation.Mutated, arg.Namespace).ToString(),
+                    mutated: arg.CreateWithNewNames(HttpUtility.UrlEncode(mutation.Mutated), arg.Namespace).ToString(),
                     original: mutation.Original,
                     reason: mutation.Reason,
                     mutator: mutation.Mutator);

--- a/src/oss-tests/ArchiveHelperTests.cs
+++ b/src/oss-tests/ArchiveHelperTests.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+namespace Microsoft.CST.OpenSource.Tests;
+
+using Helpers;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public class ArchiveHelperTests
+{
+    /// <summary>
+    /// Unit test that ExtractArchiveAsync works successfully.
+    /// </summary>
+    [TestMethod]
+    public async Task ExtractArchiveSucceeds()
+    {
+        // Get the Base64Zip.zip file from our TestData resources.
+        FileStream? zip = new(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? string.Empty, "TestData", "Base64Zip.zip"), FileMode.Open);
+        
+        // Create a list of the files we expect to be in the zip file. 
+        string[] expectedFiles = {"Base64", "Hex", "oss-defog.dll"};
+
+        // Create a new temporary directory
+        string? targetDirectoryName = null;
+        while (targetDirectoryName == null || Directory.Exists(targetDirectoryName))
+        {
+            targetDirectoryName = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        }
+
+        try
+        {
+            // Extract the zip file to the target directory.
+            string? path = await ArchiveHelper.ExtractArchiveAsync(
+                    targetDirectoryName,
+                    "Base64Zip",
+                    zip);
+            
+            // Assert that the directory we extracted the zip archive to exists.
+            Assert.IsTrue(Directory.Exists(path));
+
+            // Check that the extracted files from the zip archive match the ones we expected.
+            string?[] files = Directory.EnumerateFiles(Path.Combine(path, "Base64Zip")).Select(Path.GetFileName).ToArray();
+            CollectionAssert.AreEquivalent(expectedFiles, files);
+        }
+        finally
+        {
+            // Delete the temp directory that was created.
+            FileSystemHelper.RetryDeleteDirectory(targetDirectoryName);
+        }
+    }
+}

--- a/src/oss-tests/ArchiveHelperTests.cs
+++ b/src/oss-tests/ArchiveHelperTests.cs
@@ -50,6 +50,9 @@ public class ArchiveHelperTests
         {
             // Delete the temp directory that was created.
             FileSystemHelper.RetryDeleteDirectory(targetDirectoryName);
+            
+            // Close the stream that was used to read the zip file.
+            zip.Close();
         }
     }
 }

--- a/src/oss-tests/ArchiveHelperTests.cs
+++ b/src/oss-tests/ArchiveHelperTests.cs
@@ -3,7 +3,6 @@
 namespace Microsoft.CST.OpenSource.Tests;
 
 using Helpers;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;


### PR DESCRIPTION
A lot of this work comes from work I had done in #318 that I just wanted to separate out to make that PR easier to review.

This PR includes:

- Refactor `ExtractArchive` from `BaseProjectManager` into a separate `ArchiveHelper` static class.
- Rename `PackageManagerFactory` to `ProjectManagerFactory`, and remove the `BaseProjectManager` constructors as they were able to be removed thanks to the `ExtractArchive` change detailed above.
- Updated `PackageMetadata.User` to be a record instead of a class, will help with future json parsing.
- Made `BaseProjectManager` abstract.
- Add a `Type` readonly string to each implementation of `BaseProjectManager`. Isn't currently being used as of this PR, but #318 uses it, and I anticipate it being useful in other places in the future as well.
- Add `includePrerelease` to `BaseProjectManager.EnumerateVersions` to filter out pre-release/beta versions if they aren't wanted. Defaults to `true`, so there are no changes from what is currently in production.
- Make `BaseProjectManager.GetPackageMetadata` return a nullable `PackageMetadata` object.
- Fix any potential issues down the line in `IMutator` with mutated names including things that aren't HTTP encoded. 
   - I was running into an issue mutating `newtonsoft.json` as it was creating `newtonsoft/json` as a mutation because `.` is close to `/` and that was causing issues with `newtonsoft` becoming the namespace, and `json` becoming the name.