### PR TITLE
Refactor the ProjectManagerFactory

### DIFF
--- a/src/Shared.CLI/Helpers/OutputBuilder/SarifOutputBuilder.cs
+++ b/src/Shared.CLI/Helpers/OutputBuilder/SarifOutputBuilder.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CST.OpenSource.Shared
         /// <returns>Location list with single location object</returns>
         public static List<Location> BuildPurlLocation(PackageURL purl)
         {
-            BaseProjectManager? projectManager = ProjectManagerFactory.CreateProjectManager(purl, null);
+            BaseProjectManager? projectManager = ProjectManagerFactory.GetProjectManager(purl, null);
             if (projectManager == null)
             {
                 Logger.Debug("Cannot determine the package type");

--- a/src/Shared.CLI/Helpers/OutputBuilder/SarifOutputBuilder.cs
+++ b/src/Shared.CLI/Helpers/OutputBuilder/SarifOutputBuilder.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CST.OpenSource.Shared
         /// <returns>Location list with single location object</returns>
         public static List<Location> BuildPurlLocation(PackageURL purl)
         {
-            BaseProjectManager? projectManager = ProjectManagerFactory.CreateProjectManager(purl, null);
+            BaseProjectManager? projectManager = ProjectManagerFactory.ConstructPackageManager(purl, null);
             if (projectManager == null)
             {
                 Logger.Debug("Cannot determine the package type");

--- a/src/Shared.CLI/Helpers/OutputBuilder/SarifOutputBuilder.cs
+++ b/src/Shared.CLI/Helpers/OutputBuilder/SarifOutputBuilder.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CST.OpenSource.Shared
         /// <returns>Location list with single location object</returns>
         public static List<Location> BuildPurlLocation(PackageURL purl)
         {
-            BaseProjectManager? projectManager = ProjectManagerFactory.GetProjectManager(purl, null);
+            BaseProjectManager? projectManager = ProjectManagerFactory.CreateProjectManager(purl, null);
             if (projectManager == null)
             {
                 Logger.Debug("Cannot determine the package type");

--- a/src/Shared.CLI/Helpers/PackageDownloader.cs
+++ b/src/Shared.CLI/Helpers/PackageDownloader.cs
@@ -22,10 +22,10 @@ namespace Microsoft.CST.OpenSource
         /// Constructor - creates a class object for downloading packages.
         /// </summary>
         /// <param name="purl">The package to download.</param>
-        /// <param name="httpClientFactory">The <see cref="IHttpClientFactory"/> to use to make the client to use when downloading.</param>
+        /// <param name="projectManagerFactory">The <see cref="ProjectManagerFactory"/> to use to get the project managers.</param>
         /// <param name="destinationDir">The directory where the package needs to be downloaded to.</param>
         /// <param name="doCaching">Check and use the cache if it exists - create if not.</param>
-        public PackageDownloader(PackageURL purl, IHttpClientFactory? httpClientFactory, string? destinationDir = null, bool doCaching = false)
+        public PackageDownloader(PackageURL purl, ProjectManagerFactory projectManagerFactory, string? destinationDir = null, bool doCaching = false)
         {
             if (purl == null)
             {
@@ -47,7 +47,7 @@ namespace Microsoft.CST.OpenSource
                 destinationDirectory = destinationDir;
             }
 
-            packageManager = ProjectManagerFactory.CreateProjectManager(purl, httpClientFactory, destinationDirectory);
+            packageManager = projectManagerFactory.CreateProjectManager(purl, destinationDirectory);
             if (packageManager == null)
             {
                 // Cannot continue without a package manager.

--- a/src/Shared.CLI/Helpers/PackageDownloader.cs
+++ b/src/Shared.CLI/Helpers/PackageDownloader.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CST.OpenSource
         /// <param name="projectManagerFactory">The <see cref="ProjectManagerFactory"/> to use to get the project managers.</param>
         /// <param name="destinationDir">The directory where the package needs to be downloaded to.</param>
         /// <param name="doCaching">Check and use the cache if it exists - create if not.</param>
-        public PackageDownloader(PackageURL purl, ProjectManagerFactory projectManagerFactory, string? destinationDir = null, bool doCaching = false)
+        public PackageDownloader(PackageURL purl, ProjectManagerFactory? projectManagerFactory = null, string? destinationDir = null, bool doCaching = false)
         {
             if (purl == null)
             {
@@ -47,7 +47,7 @@ namespace Microsoft.CST.OpenSource
                 destinationDirectory = destinationDir;
             }
 
-            packageManager = projectManagerFactory.CreateProjectManager(purl, destinationDirectory);
+            packageManager = (projectManagerFactory ?? new ProjectManagerFactory()).CreateProjectManager(purl, destinationDirectory);
             if (packageManager == null)
             {
                 // Cannot continue without a package manager.

--- a/src/Shared.CLI/Helpers/PackageDownloader.cs
+++ b/src/Shared.CLI/Helpers/PackageDownloader.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CST.OpenSource
         /// <param name="projectManagerFactory">The <see cref="ProjectManagerFactory"/> to use to get the project managers.</param>
         /// <param name="destinationDir">The directory where the package needs to be downloaded to.</param>
         /// <param name="doCaching">Check and use the cache if it exists - create if not.</param>
-        public PackageDownloader(PackageURL purl, ProjectManagerFactory? projectManagerFactory = null, string? destinationDir = null, bool doCaching = false)
+        public PackageDownloader(PackageURL purl, ProjectManagerFactory projectManagerFactory, string? destinationDir = null, bool doCaching = false)
         {
             if (purl == null)
             {
@@ -47,7 +47,7 @@ namespace Microsoft.CST.OpenSource
                 destinationDirectory = destinationDir;
             }
 
-            packageManager = (projectManagerFactory ?? new ProjectManagerFactory()).CreateProjectManager(purl, destinationDirectory);
+            packageManager = projectManagerFactory.CreateProjectManager(purl, destinationDirectory);
             if (packageManager == null)
             {
                 // Cannot continue without a package manager.

--- a/src/Shared.CLI/Helpers/RepoSearch.cs
+++ b/src/Shared.CLI/Helpers/RepoSearch.cs
@@ -2,14 +2,11 @@
 
 namespace Microsoft.CST.OpenSource.Shared
 {
-    using Microsoft.CST.OpenSource.Helpers;
     using Microsoft.CST.OpenSource.PackageManagers;
-    using NLog;
     using PackageUrl;
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Net.Http;
     using System.Threading.Tasks;
 
     /// <summary>
@@ -28,16 +25,16 @@ namespace Microsoft.CST.OpenSource.Shared
     /// </summary>
     public class RepoSearch
     {
-        public RepoSearch(IHttpClientFactory httpClientFactory)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RepoSearch"/> class.
+        /// </summary>
+        /// <param name="projectManagerFactory">The <see cref="ProjectManagerFactory"/> to generate the project managers with.</param>
+        public RepoSearch(ProjectManagerFactory? projectManagerFactory = null)
         {
-            HttpClientFactory = httpClientFactory;
+            _projectManagerFactory = projectManagerFactory ?? new ProjectManagerFactory();
         }
 
-        public RepoSearch() : this(new DefaultHttpClientFactory())
-        {
-        }
-
-        private IHttpClientFactory HttpClientFactory { get; }
+        private ProjectManagerFactory _projectManagerFactory { get; }
 
         /// <summary>
         ///     try to resolve the source code for an npm package through different means
@@ -62,7 +59,7 @@ namespace Microsoft.CST.OpenSource.Shared
             Logger.Debug("Searching for source code for: {0}", purlNoVersion.ToString());
 
             // Use reflection to find the correct downloader class
-            BaseProjectManager? projectManager = ProjectManagerFactory.CreateProjectManager(purl, HttpClientFactory);
+            BaseProjectManager? projectManager = _projectManagerFactory.CreateProjectManager(purl);
 
             if (projectManager != null)
             {

--- a/src/Shared.CLI/Helpers/RepoSearch.cs
+++ b/src/Shared.CLI/Helpers/RepoSearch.cs
@@ -29,9 +29,9 @@ namespace Microsoft.CST.OpenSource.Shared
         /// Initializes a new instance of the <see cref="RepoSearch"/> class.
         /// </summary>
         /// <param name="projectManagerFactory">The <see cref="ProjectManagerFactory"/> to generate the project managers with.</param>
-        public RepoSearch(ProjectManagerFactory? projectManagerFactory = null)
+        public RepoSearch(ProjectManagerFactory projectManagerFactory)
         {
-            _projectManagerFactory = projectManagerFactory ?? new ProjectManagerFactory();
+            _projectManagerFactory = projectManagerFactory;
         }
 
         private ProjectManagerFactory _projectManagerFactory { get; }

--- a/src/Shared.CLI/Helpers/RepoSearch.cs
+++ b/src/Shared.CLI/Helpers/RepoSearch.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CST.OpenSource.Shared
                                    null, purl.Qualifiers, purl.Subpath);
             Logger.Debug("Searching for source code for: {0}", purlNoVersion.ToString());
 
-            // Use reflection to find the correct downloader class
+            // Get the correct project manager using the factory.
             BaseProjectManager? projectManager = _projectManagerFactory.CreateProjectManager(purl);
 
             if (projectManager != null)

--- a/src/Shared.CLI/OSSGadget.cs
+++ b/src/Shared.CLI/OSSGadget.cs
@@ -23,6 +23,9 @@ namespace Microsoft.CST.OpenSource
         public OSSGadget(ProjectManagerFactory projectManagerFactory) : base(projectManagerFactory)
         {
         }
+        
+        public OSSGadget() : base()
+        {}
 
         /// <summary>
         /// Logger for this class

--- a/src/Shared.CLI/OSSGadget.cs
+++ b/src/Shared.CLI/OSSGadget.cs
@@ -4,13 +4,12 @@ namespace Microsoft.CST.OpenSource
 {
     using CommandLine;
     using CommandLine.Text;
-    using Microsoft.CST.OpenSource.Helpers;
     using Microsoft.CST.OpenSource.Shared;
+    using PackageManagers;
     using System;
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
-    using System.Net.Http;
     using System.Reflection;
     using static Microsoft.CST.OpenSource.Shared.OutputBuilderFactory;
 
@@ -21,11 +20,7 @@ namespace Microsoft.CST.OpenSource
         public static string ToolName { get => GetToolName() ?? ""; }
         public static string ToolVersion { get => GetToolVersion() ?? ""; }
 
-        public OSSGadget(IHttpClientFactory httpClientFactory) : base(httpClientFactory)
-        {
-        }
-
-        public OSSGadget() : base()
+        public OSSGadget(ProjectManagerFactory projectManagerFactory) : base(projectManagerFactory)
         {
         }
 

--- a/src/Shared/OssGadgetLib.cs
+++ b/src/Shared/OssGadgetLib.cs
@@ -5,6 +5,7 @@ namespace Microsoft.CST.OpenSource
     using Helpers;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Http;
+    using PackageManagers;
     using System;
     using System.Net.Http;
 
@@ -14,9 +15,9 @@ namespace Microsoft.CST.OpenSource
         protected static string ENV_HTTPCLIENT_USER_AGENT = "OSSDL";
 
         /// <summary>
-        /// The <see cref="IHttpClientFactory"/> to be used by classes that implement <see cref="OssGadgetLib"/>.
+        /// The <see cref="ProjectManagerFactory"/> to be used by classes that implement <see cref="OssGadgetLib"/>.
         /// </summary>
-        protected IHttpClientFactory HttpClientFactory { get; }
+        protected ProjectManagerFactory ProjectManagerFactory { get; }
 
         /// <summary>
         /// The <see cref="NLog.ILogger"/> for this class.
@@ -29,13 +30,13 @@ namespace Microsoft.CST.OpenSource
         /// </summary>
         protected string Directory { get; }
 
-        protected OssGadgetLib(IHttpClientFactory httpClientFactory, string directory = ".")
+        protected OssGadgetLib(ProjectManagerFactory projectManagerFactory, string directory = ".")
         {
-            HttpClientFactory = Check.NotNull(nameof(httpClientFactory), httpClientFactory);
+            ProjectManagerFactory = Check.NotNull(nameof(projectManagerFactory), projectManagerFactory);
             Directory = directory;
         }
 
-        protected OssGadgetLib(string directory = ".") : this(new DefaultHttpClientFactory(), directory)
+        protected OssGadgetLib(string directory = ".") : this(new ProjectManagerFactory(), directory)
         {
         }
 

--- a/src/Shared/PackageManagers/ProjectManagerFactory.cs
+++ b/src/Shared/PackageManagers/ProjectManagerFactory.cs
@@ -8,55 +8,153 @@ namespace Microsoft.CST.OpenSource.PackageManagers
     using System.Linq;
     using System.Net.Http;
 
-    public static class ProjectManagerFactory
+    public class ProjectManagerFactory
     {
         /// <summary>
-        /// Get an appropriate project manager for package given its PackageURL.
+        /// The delegate to use when defining the function to create a project manager with.
+        /// The only runtime parameter we need is the destination directory. Everything else can be defined in the constructor.
         /// </summary>
-        /// <param name="purl">The <see cref="PackageURL"/> for the package to create the project manager for.</param>
-        /// <param name="httpClientFactory"> The <see cref="IHttpClientFactory"/> for the project manager to use for making Http Clients to make web requests.</param>
-        /// <param name="destinationDirectory">The directory to use to store any downloaded packages.</param>
-        /// <returns> BaseProjectManager object </returns>
-        public static BaseProjectManager? CreateProjectManager(PackageURL purl, IHttpClientFactory? httpClientFactory = null, string? destinationDirectory = null)
+        public delegate BaseProjectManager? ConstructProjectManager(string destinationDirectory = ".");
+
+        /// <summary>
+        /// The dictionary of project managers.
+        /// </summary>
+        private readonly Dictionary<string, ConstructProjectManager> _projectManagers;
+
+        /// <summary>
+        /// Initializes a new instance of a <see cref="ProjectManagerFactory"/>.
+        /// </summary>
+        /// <param name="overrideManagers">Use a custom set of managers to override the defaults with.</param>
+        /// <param name="httpClientFactory">The <see cref="IHttpClientFactory"/> to use in the project managers.</param>
+        public ProjectManagerFactory(Dictionary<string, ConstructProjectManager> overrideManagers, IHttpClientFactory? httpClientFactory = null) : this(httpClientFactory)
         {
-            if (projectManagers.Count == 0)
-            {
-                projectManagers.AddRange(typeof(BaseProjectManager).Assembly.GetTypes()
-               .Where(type => type.IsSubclassOf(typeof(BaseProjectManager))));
-            }
-            // Use reflection to find the correct package management class
-            Type? downloaderClass = projectManagers
-               .Where(type => type.Name.Equals($"{purl.Type}ProjectManager",
-                                               StringComparison.InvariantCultureIgnoreCase))
-               .FirstOrDefault();
-
-            if (downloaderClass != null)
-            {
-                if (httpClientFactory != null)
-                {
-                    System.Reflection.ConstructorInfo? ctor = downloaderClass.GetConstructor(new[] { typeof(IHttpClientFactory), typeof(string) });
-                    if (ctor != null)
-                    {
-                        BaseProjectManager? _downloader = (BaseProjectManager)ctor.Invoke(new object?[] { httpClientFactory, destinationDirectory });
-                        return _downloader;
-                    }
-                }
-                else
-                {
-                    System.Reflection.ConstructorInfo? ctor = downloaderClass.GetConstructor(new[] { typeof(string) });
-                    if (ctor != null)
-                    {
-                        BaseProjectManager? _downloader = (BaseProjectManager)ctor.Invoke(new object?[] { destinationDirectory });
-                        return _downloader;
-                    }
-                }
-
-            }
-
-            return null;
+            overrideManagers.ToList().ForEach(pair => SetManager(pair.Key, pair.Value));
         }
 
-        // do reflection only once
-        private static readonly List<Type> projectManagers = new();
+        /// <summary>
+        /// Initializes a new instance of a <see cref="ProjectManagerFactory"/>.
+        /// </summary>
+        /// <param name="httpClientFactory">The <see cref="IHttpClientFactory"/> to use in the project managers.</param>
+        public ProjectManagerFactory(IHttpClientFactory? httpClientFactory = null)
+        {
+            _projectManagers = CreateDefaultManagers(httpClientFactory);
+        }
+
+        public bool UnsetManager(string lookup)
+        {
+            return _projectManagers.Remove(lookup);
+        }
+
+        private void SetManager(string lookup, ConstructProjectManager generator)
+        {
+            _projectManagers[lookup] = generator;
+        }
+
+        public void ClearManagers()
+        {
+            _projectManagers.Clear();
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="httpClientFactoryParam">The <see cref="IHttpClientFactory"/> to use in the project managers.</param>
+        /// <returns>A dictionary of the default managers with associated constructors.</returns>
+        private static Dictionary<string, ConstructProjectManager> CreateDefaultManagers(IHttpClientFactory? httpClientFactoryParam = null)
+        {
+            // If the httpClientFactory parameter is null, set the factory to the DefaultHttpClientFactory.
+            IHttpClientFactory httpClientFactory = httpClientFactoryParam ?? new DefaultHttpClientFactory();
+            return new Dictionary<string, ConstructProjectManager>(StringComparer.InvariantCultureIgnoreCase)
+            {
+                {
+                    CargoProjectManager.Type, destinationDirectory =>
+                        new CargoProjectManager(httpClientFactory, destinationDirectory)
+                },
+                {
+                    CocoapodsProjectManager.Type, destinationDirectory =>
+                        new CocoapodsProjectManager(httpClientFactory, destinationDirectory)
+                },
+                {
+                    ComposerProjectManager.Type, destinationDirectory =>
+                        new ComposerProjectManager(httpClientFactory, destinationDirectory)
+                },
+                {
+                    CPANProjectManager.Type, destinationDirectory =>
+                        new CPANProjectManager(httpClientFactory, destinationDirectory)
+                },
+                {
+                    CRANProjectManager.Type, destinationDirectory =>
+                        new CRANProjectManager(httpClientFactory, destinationDirectory)
+                },
+                {
+                    GemProjectManager.Type, destinationDirectory =>
+                        new GemProjectManager(httpClientFactory, destinationDirectory)
+                },
+                {
+                    GitHubProjectManager.Type, destinationDirectory =>
+                        new GitHubProjectManager(httpClientFactory, destinationDirectory)
+                },
+                {
+                    GolangProjectManager.Type, destinationDirectory =>
+                        new GolangProjectManager(httpClientFactory, destinationDirectory)
+                },
+                {
+                    HackageProjectManager.Type, destinationDirectory =>
+                        new HackageProjectManager(httpClientFactory, destinationDirectory)
+                },
+                {
+                    MavenProjectManager.Type, destinationDirectory =>
+                        new MavenProjectManager(httpClientFactory, destinationDirectory)
+                },
+                {
+                    NPMProjectManager.Type, destinationDirectory =>
+                        new NPMProjectManager(httpClientFactory, destinationDirectory)
+                },
+                {
+                    NuGetProjectManager.Type, destinationDirectory =>
+                        new NuGetProjectManager(httpClientFactory, destinationDirectory)
+                },
+                {
+                    PyPIProjectManager.Type, destinationDirectory =>
+                        new PyPIProjectManager(httpClientFactory, destinationDirectory)
+                },
+                {
+                    UbuntuProjectManager.Type, destinationDirectory =>
+                        new UbuntuProjectManager(httpClientFactory, destinationDirectory)
+                },
+                {
+                    URLProjectManager.Type, destinationDirectory =>
+                        new URLProjectManager(httpClientFactory, destinationDirectory)
+                },
+                {
+                    VSMProjectManager.Type, destinationDirectory =>
+                        new VSMProjectManager(httpClientFactory, destinationDirectory)
+                },
+            };
+        }
+
+        /// <summary>
+        /// Creates an appropriate project manager for a package given its PackageURL.
+        /// </summary>
+        /// <param name="purl">The <see cref="PackageURL"/> for the package to create the project manager for.</param>
+        /// <param name="destinationDirectory">The new destination directory, if provided.</param>
+        /// <returns>The implementation of <see cref="BaseProjectManager"/> for this <paramref name="purl"/>'s type.</returns>
+        public BaseProjectManager? CreateProjectManager(PackageURL purl, string destinationDirectory = ".")
+        {
+            ConstructProjectManager? projectManager = _projectManagers.GetValueOrDefault(purl.Type);
+
+            return projectManager?.Invoke(destinationDirectory);
+        }
+
+        /// <summary>
+        /// Add static method to just get a <see cref="BaseProjectManager"/> implementation.
+        /// </summary>
+        /// <param name="packageUrl">The <see cref="PackageURL"/> to get a project manager for.</param>
+        /// <param name="httpClientFactory">The <see cref="IHttpClientFactory"/> to optionally add.</param>
+        /// <returns>A new <see cref="BaseProjectManager"/> implementation.</returns>
+        public static BaseProjectManager? GetProjectManager(PackageURL packageUrl, IHttpClientFactory? httpClientFactory = null)
+        {
+            return new ProjectManagerFactory(httpClientFactory).CreateProjectManager(packageUrl);
+        }
     }
 }

--- a/src/Shared/PackageManagers/ProjectManagerFactory.cs
+++ b/src/Shared/PackageManagers/ProjectManagerFactory.cs
@@ -2,6 +2,7 @@
 
 namespace Microsoft.CST.OpenSource.PackageManagers
 {
+    using Helpers;
     using PackageUrl;
     using System;
     using System.Collections.Generic;
@@ -40,6 +41,8 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         {
             foreach((string? type, ConstructProjectManager? ctor) in overrideManagers)
             {
+                Check.NotNull(nameof(type), type, "The type defined in overrideManagers is null.");
+                Check.NotNull(nameof(ctor), ctor, "The constructor defined in overrideManagers is null.");
                 SetManager(type, ctor);
             }
         }

--- a/src/Shared/PackageManagers/ProjectManagerFactory.cs
+++ b/src/Shared/PackageManagers/ProjectManagerFactory.cs
@@ -54,16 +54,6 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         }
 
         /// <summary>
-        /// Remove a manager from the dictionary of constructors.
-        /// </summary>
-        /// <param name="type">The purl type of the ProjectManager to remove.</param>
-        /// <returns>If it was successfully removed.</returns>
-        public bool UnsetManager(string type)
-        {
-            return _projectManagers.Remove(type);
-        }
-
-        /// <summary>
         /// Sets a manager's constructor in the dictionary of constructors.
         /// </summary>
         /// <param name="type">The purl type of the ProjectManager to set.</param>
@@ -71,14 +61,6 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         private void SetManager(string type, ConstructProjectManager ctor)
         {
             _projectManagers[type] = ctor;
-        }
-
-        /// <summary>
-        /// Clears all of the managers and constructors from the dictionary.
-        /// </summary>
-        public void ClearManagers()
-        {
-            _projectManagers.Clear();
         }
 
         /// <summary>

--- a/src/Shared/PackageManagers/ProjectManagerFactory.cs
+++ b/src/Shared/PackageManagers/ProjectManagerFactory.cs
@@ -5,6 +5,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
     using PackageUrl;
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
 
     public class ProjectManagerFactory
@@ -177,10 +178,19 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         /// </summary>
         /// <param name="packageUrl">The <see cref="PackageURL"/> to get a project manager for.</param>
         /// <param name="httpClientFactory">The <see cref="IHttpClientFactory"/> to optionally add.</param>
+        /// <param name="overrideManagers">
+        /// If provided, will override each matching ProjectManager constructor from the defaults,
+        /// or add it if it wasn't present in <see cref="CreateDefaultManagers"/>.
+        /// </param>
+        /// <param name="destinationDirectory">The new destination directory, if provided.</param>
         /// <returns>A new <see cref="BaseProjectManager"/> implementation.</returns>
-        public static BaseProjectManager? CreateProjectManager(PackageURL packageUrl, IHttpClientFactory? httpClientFactory = null)
+        public static BaseProjectManager? ConstructPackageManager(PackageURL packageUrl, IHttpClientFactory? httpClientFactory = null, Dictionary<string, ConstructProjectManager>? overrideManagers = null, string destinationDirectory = ".")
         {
-            return new ProjectManagerFactory(httpClientFactory).CreateProjectManager(packageUrl);
+            if (overrideManagers != null && overrideManagers.Any())
+            {
+                return new ProjectManagerFactory(overrideManagers, httpClientFactory).CreateProjectManager(packageUrl, destinationDirectory);
+            }
+            return new ProjectManagerFactory(httpClientFactory).CreateProjectManager(packageUrl, destinationDirectory);
         }
     }
 }

--- a/src/oss-characteristics/CharacteristicTool.cs
+++ b/src/oss-characteristics/CharacteristicTool.cs
@@ -16,8 +16,8 @@ using SarifResult = Microsoft.CodeAnalysis.Sarif.Result;
 
 namespace Microsoft.CST.OpenSource
 {
+    using PackageManagers;
     using PackageUrl;
-    using System.Net.Http;
 
     public class CharacteristicTool : OSSGadget
     {
@@ -73,11 +73,11 @@ namespace Microsoft.CST.OpenSource
             public FailureLevel SarifLevel { get; set; } = FailureLevel.Note;
         }
 
-        public CharacteristicTool(IHttpClientFactory httpClientFactory) : base(httpClientFactory)
+        public CharacteristicTool(ProjectManagerFactory projectManagerFactory) : base(projectManagerFactory)
         {
         }
 
-        public CharacteristicTool() : this(new DefaultHttpClientFactory()) 
+        public CharacteristicTool() : this(new ProjectManagerFactory()) 
         {
         }
 
@@ -140,7 +140,7 @@ namespace Microsoft.CST.OpenSource
 
             Dictionary<string, AnalyzeResult?>? analysisResults = new Dictionary<string, AnalyzeResult?>();
 
-            PackageDownloader? packageDownloader = new PackageDownloader(purl, HttpClientFactory, targetDirectoryName, doCaching);
+            PackageDownloader? packageDownloader = new PackageDownloader(purl, ProjectManagerFactory, targetDirectoryName, doCaching);
             // ensure that the cache directory has the required package, download it otherwise
             List<string>? directoryNames = await packageDownloader.DownloadPackageLocalCopy(purl,
                 false,

--- a/src/oss-defog/DefoggerTool.cs
+++ b/src/oss-defog/DefoggerTool.cs
@@ -12,8 +12,8 @@ using System.Threading.Tasks;
 
 namespace Microsoft.CST.OpenSource
 {
+    using PackageManagers;
     using PackageUrl;
-    using System.Net.Http;
 
     public class DefoggerTool : OSSGadget
     {
@@ -361,7 +361,7 @@ namespace Microsoft.CST.OpenSource
         /// <summary>
         /// Initializes a new DefoggerTool instance.
         /// </summary>
-        public DefoggerTool(IHttpClientFactory httpClientFactory) : base(httpClientFactory)
+        public DefoggerTool(ProjectManagerFactory projectManagerFactory) : base(projectManagerFactory)
         {
             Findings = new List<EncodedString>();
             BinaryFindings = new List<EncodedBinary>();
@@ -369,7 +369,7 @@ namespace Microsoft.CST.OpenSource
             NonTextFindings = new List<EncodedBlob>();
         }
 
-        public DefoggerTool() : this(new DefaultHttpClientFactory())
+        public DefoggerTool() : this(new ProjectManagerFactory())
         {
         }
 
@@ -382,7 +382,7 @@ namespace Microsoft.CST.OpenSource
         {
             Logger.Trace("AnalyzePackage({0})", purl.ToString());
 
-            PackageDownloader? packageDownloader = new PackageDownloader(purl, HttpClientFactory, destinationDirectory, doCaching);
+            PackageDownloader? packageDownloader = new PackageDownloader(purl, ProjectManagerFactory, destinationDirectory, doCaching);
             foreach (string? directory in await packageDownloader.DownloadPackageLocalCopy(purl, false, true))
             {
                 if (System.IO.Directory.Exists(directory))

--- a/src/oss-detect-backdoor/DetectBackdoorTool.cs
+++ b/src/oss-detect-backdoor/DetectBackdoorTool.cs
@@ -13,7 +13,7 @@ using static Crayon.Output;
 
 namespace Microsoft.CST.OpenSource
 {
-    using System.Net.Http;
+    using PackageManagers;
 
     public class DetectBackdoorTool : OSSGadget
     {
@@ -51,12 +51,12 @@ namespace Microsoft.CST.OpenSource
             public bool UseCache { get; set; }
         }
 
-        public DetectBackdoorTool(IHttpClientFactory httpClientFactory) : base(httpClientFactory)
+        public DetectBackdoorTool(ProjectManagerFactory projectManagerFactory) : base(projectManagerFactory)
         {
             RULE_DIRECTORY = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Resources", "BackdoorRules");
         }
 
-        public DetectBackdoorTool() : this(new DefaultHttpClientFactory())
+        public DetectBackdoorTool() : this(new ProjectManagerFactory())
         {
         }
 
@@ -140,7 +140,7 @@ namespace Microsoft.CST.OpenSource
         {
             if (options != null && options.Targets is IList<string> targetList && targetList.Count > 0)
             {
-                CharacteristicTool? characteristicTool = new CharacteristicTool(HttpClientFactory);
+                CharacteristicTool? characteristicTool = new CharacteristicTool(ProjectManagerFactory);
                 CharacteristicTool.Options cOptions = new CharacteristicTool.Options
                 {
                     Targets = options.Targets,

--- a/src/oss-detect-cryptography/DetectCryptographyTool.cs
+++ b/src/oss-detect-cryptography/DetectCryptographyTool.cs
@@ -23,8 +23,8 @@ using Microsoft.CST.RecursiveExtractor;
 namespace Microsoft.CST.OpenSource
 {
     using Helpers;
+    using Microsoft.CST.OpenSource.PackageManagers;
     using PackageUrl;
-    using System.Net.Http;
 
     public class DetectCryptographyTool : OSSGadget
     {
@@ -235,11 +235,11 @@ namespace Microsoft.CST.OpenSource
             }
         }
 
-        public DetectCryptographyTool(IHttpClientFactory httpClientFactory) : base(httpClientFactory)
+        public DetectCryptographyTool(ProjectManagerFactory projectManagerFactory) : base(projectManagerFactory)
         {
         }
 
-        public DetectCryptographyTool() : this(new DefaultHttpClientFactory())
+        public DetectCryptographyTool() : this(new ProjectManagerFactory())
         {
         }
 
@@ -252,7 +252,7 @@ namespace Microsoft.CST.OpenSource
         {
             Logger.Trace("AnalyzePackage({0})", purl.ToString());
 
-            PackageDownloader? packageDownloader = new(purl, HttpClientFactory, targetDirectoryName, doCaching);
+            PackageDownloader? packageDownloader = new(purl, ProjectManagerFactory, targetDirectoryName, doCaching);
             List<string>? directoryNames = await packageDownloader.DownloadPackageLocalCopy(purl, false, true);
             directoryNames = directoryNames.Distinct().ToList<string>();
 

--- a/src/oss-diff/DiffTool.cs
+++ b/src/oss-diff/DiffTool.cs
@@ -23,7 +23,6 @@ namespace Microsoft.CST.OpenSource.DiffTool
     using Microsoft.CST.OpenSource.Helpers;
     using Microsoft.CST.OpenSource.PackageManagers;
     using PackageUrl;
-    using System.Net.Http;
 
     class DiffTool : OSSGadget
     {
@@ -85,11 +84,11 @@ namespace Microsoft.CST.OpenSource.DiffTool
             public IEnumerable<string> Targets { get; set; } = Array.Empty<string>();
         }
 
-        public DiffTool(IHttpClientFactory httpClientFactory) : base(httpClientFactory)
+        public DiffTool(ProjectManagerFactory projectManagerFactory) : base(projectManagerFactory)
         {
         }
 
-        public DiffTool() : this (new DefaultHttpClientFactory()) { }
+        public DiffTool() : this (new ProjectManagerFactory()) { }
 
         static async Task Main(string[] args)
         {
@@ -121,7 +120,7 @@ namespace Microsoft.CST.OpenSource.DiffTool
             try
             {
                 PackageURL purl1 = new PackageURL(options.Targets.First());
-                BaseProjectManager? manager = ProjectManagerFactory.CreateProjectManager(purl1, HttpClientFactory, options.DownloadDirectory ?? Path.GetTempPath());
+                BaseProjectManager? manager = ProjectManagerFactory.CreateProjectManager(purl1, options.DownloadDirectory ?? Path.GetTempPath());
 
                 if (manager is not null)
                 {
@@ -155,7 +154,7 @@ namespace Microsoft.CST.OpenSource.DiffTool
             try
             {
                 PackageURL purl2 = new PackageURL(options.Targets.Last());
-                BaseProjectManager? manager2 = ProjectManagerFactory.CreateProjectManager(purl2, HttpClientFactory, options.DownloadDirectory ?? Path.GetTempPath());
+                BaseProjectManager? manager2 = ProjectManagerFactory.CreateProjectManager(purl2, options.DownloadDirectory ?? Path.GetTempPath());
 
                 if (manager2 is not null)
                 {

--- a/src/oss-download/DownloadTool.cs
+++ b/src/oss-download/DownloadTool.cs
@@ -9,8 +9,9 @@ using System.Threading.Tasks;
 
 namespace Microsoft.CST.OpenSource
 {
+    using PackageManagers;
     using PackageUrl;
-    using System.Net.Http;
+
     public class DownloadTool : OSSGadget
     {
         public enum ErrorCode
@@ -55,11 +56,11 @@ namespace Microsoft.CST.OpenSource
             public bool UseCache { get; set; }
         }
 
-        public DownloadTool(IHttpClientFactory httpClientFactory) : base(httpClientFactory)
+        public DownloadTool(ProjectManagerFactory projectManagerFactory) : base(projectManagerFactory)
         {
         }
 
-        public DownloadTool() : this(new DefaultHttpClientFactory()) { }
+        public DownloadTool() : this(new ProjectManagerFactory()) { }
 
         /// <summary>
         ///     Main entrypoint for the download program.
@@ -99,7 +100,7 @@ namespace Microsoft.CST.OpenSource
                         PackageURL? purl = new PackageURL(target);
                         string downloadDirectory = options.DownloadDirectory == "." ? System.IO.Directory.GetCurrentDirectory() : options.DownloadDirectory;
                         bool useCache = options.UseCache;
-                        PackageDownloader? packageDownloader = new PackageDownloader(purl, HttpClientFactory, downloadDirectory, useCache);
+                        PackageDownloader? packageDownloader = new PackageDownloader(purl, ProjectManagerFactory, downloadDirectory, useCache);
 
                         List<string>? downloadResults = await packageDownloader.DownloadPackageLocalCopy(purl, options.DownloadMetadataOnly, options.Extract);
                         foreach (string? downloadPath in downloadResults)

--- a/src/oss-find-domain-squats/FindDomainSquatsTool.cs
+++ b/src/oss-find-domain-squats/FindDomainSquatsTool.cs
@@ -16,6 +16,7 @@ namespace Microsoft.CST.OpenSource.DomainSquats
     using Whois;
     using System.Text.RegularExpressions;
     using Microsoft.CST.OpenSource.FindSquats.Mutators;
+    using PackageManagers;
     using System.Net.Http;
 
     public class FindDomainSquatsTool : OSSGadget
@@ -77,7 +78,7 @@ namespace Microsoft.CST.OpenSource.DomainSquats
             public IEnumerable<string>? Targets { get; set; }
         }
 
-        public FindDomainSquatsTool(IHttpClientFactory httpClientFactory) : base(httpClientFactory)
+        public FindDomainSquatsTool(IHttpClientFactory httpClientFactory) : base(new ProjectManagerFactory(httpClientFactory))
         {
         }
 

--- a/src/oss-find-source/FindSourceTool.cs
+++ b/src/oss-find-source/FindSourceTool.cs
@@ -13,8 +13,8 @@ using static Microsoft.CST.OpenSource.Shared.OutputBuilderFactory;
 
 namespace Microsoft.CST.OpenSource
 {
+    using PackageManagers;
     using PackageUrl;
-    using System.Net.Http;
 
     public class FindSourceTool : OSSGadget
     {
@@ -23,11 +23,11 @@ namespace Microsoft.CST.OpenSource
             "pkg:github/metacpan/metacpan-web"
         };
 
-        public FindSourceTool(IHttpClientFactory httpClientFactory) : base(httpClientFactory)
+        public FindSourceTool(ProjectManagerFactory projectManagerFactory) : base(projectManagerFactory)
         {
         }
 
-        public FindSourceTool() : this(new DefaultHttpClientFactory())
+        public FindSourceTool() : this(new ProjectManagerFactory())
         {
         }
 
@@ -49,7 +49,7 @@ namespace Microsoft.CST.OpenSource
 
             try
             {
-                RepoSearch repoSearcher = new RepoSearch(HttpClientFactory);
+                RepoSearch repoSearcher = new RepoSearch(ProjectManagerFactory);
                 Dictionary<PackageURL, double>? repos = await (repoSearcher.ResolvePackageLibraryAsync(purl) ??
                     Task.FromResult(new Dictionary<PackageURL, double>()));
 

--- a/src/oss-find-squats-lib/FindPackageSquats.cs
+++ b/src/oss-find-squats-lib/FindPackageSquats.cs
@@ -11,11 +11,9 @@ namespace Microsoft.CST.OpenSource.FindSquats
     using PackageUrl;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Net.Http;
 
     public class FindPackageSquats : OssGadgetLib
     {
-
         /// <summary>
         /// The <see cref="PackageURL"/> to find squats for.
         /// </summary>
@@ -23,11 +21,11 @@ namespace Microsoft.CST.OpenSource.FindSquats
 
         public BaseProjectManager? ProjectManager { get;  }
 
-        public FindPackageSquats(IHttpClientFactory httpClientFactory, PackageURL packageUrl, string directory = ".")
-            : base(httpClientFactory, directory)
+        public FindPackageSquats(ProjectManagerFactory projectManagerFactory, PackageURL packageUrl)
+            : base(projectManagerFactory)
         {
             PackageUrl = packageUrl;
-            ProjectManager = ProjectManagerFactory.CreateProjectManager(packageUrl, httpClientFactory);
+            ProjectManager = projectManagerFactory.CreateProjectManager(packageUrl);
             if (ProjectManager is null)
             {
                 Logger.Trace($"Could not generate valid ProjectManager from { packageUrl }.");

--- a/src/oss-find-squats/FindSquatsTool.cs
+++ b/src/oss-find-squats/FindSquatsTool.cs
@@ -8,11 +8,11 @@ namespace Microsoft.CST.OpenSource.FindSquats
     using Microsoft.CST.OpenSource.Shared;
     using Mutators;
     using Newtonsoft.Json;
+    using PackageManagers;
     using PackageUrl;
     using System;
     using System.Collections.Generic;
     using System.IO;
-    using System.Net.Http;
     using System.Threading.Tasks;
     using SarifResult = Microsoft.CodeAnalysis.Sarif.Result;
 
@@ -52,11 +52,11 @@ namespace Microsoft.CST.OpenSource.FindSquats
 
         }
 
-        public FindSquatsTool(IHttpClientFactory httpClientFactory) : base(httpClientFactory)
+        public FindSquatsTool(ProjectManagerFactory projectManagerFactory) : base(projectManagerFactory)
         {
         }
 
-        public FindSquatsTool() : this(new DefaultHttpClientFactory())
+        public FindSquatsTool() : this(new ProjectManagerFactory())
         {
         }
 
@@ -106,7 +106,7 @@ namespace Microsoft.CST.OpenSource.FindSquats
                     continue;
                 }
 
-                FindPackageSquats findPackageSquats = new FindPackageSquats(HttpClientFactory, purl);
+                FindPackageSquats findPackageSquats = new FindPackageSquats(ProjectManagerFactory, purl);
 
                 IDictionary<string, IList<Mutation>>? potentialSquats = findPackageSquats.GenerateSquatCandidates(options: checkerOptions);
 

--- a/src/oss-health/HealthMetrics.cs
+++ b/src/oss-health/HealthMetrics.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CST.OpenSource.Health
 
         public List<Result> toSarif()
         {
-            BaseProjectManager? projectManager = ProjectManagerFactory.CreateProjectManager(purl, null);
+            BaseProjectManager? projectManager = ProjectManagerFactory.GetProjectManager(purl, null);
 
             if (projectManager == null)
             {

--- a/src/oss-health/HealthMetrics.cs
+++ b/src/oss-health/HealthMetrics.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CST.OpenSource.Health
 
         public List<Result> toSarif()
         {
-            BaseProjectManager? projectManager = ProjectManagerFactory.GetProjectManager(purl, null);
+            BaseProjectManager? projectManager = ProjectManagerFactory.CreateProjectManager(purl, null);
 
             if (projectManager == null)
             {

--- a/src/oss-health/HealthMetrics.cs
+++ b/src/oss-health/HealthMetrics.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CST.OpenSource.Health
 
         public List<Result> toSarif()
         {
-            BaseProjectManager? projectManager = ProjectManagerFactory.CreateProjectManager(purl, null);
+            BaseProjectManager? projectManager = ProjectManagerFactory.ConstructPackageManager(purl, null);
 
             if (projectManager == null)
             {

--- a/src/oss-health/HealthTool.cs
+++ b/src/oss-health/HealthTool.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CST.OpenSource
         }
         public async Task<HealthMetrics?> CheckHealth(PackageURL purl)
         {
-            BaseProjectManager? packageManager = ProjectManagerFactory.GetProjectManager(purl);
+            BaseProjectManager? packageManager = PackageManagers.ProjectManagerFactory.CreateProjectManager(purl);
 
             if (packageManager != null)
             {

--- a/src/oss-health/HealthTool.cs
+++ b/src/oss-health/HealthTool.cs
@@ -13,26 +13,27 @@ namespace Microsoft.CST.OpenSource
 {
     using Microsoft.CST.OpenSource.PackageManagers;
     using PackageUrl;
-    using System.Net.Http;
 
     public class HealthTool : OSSGadget
     {
-        public HealthTool(IHttpClientFactory httpClientFactory) : base(httpClientFactory)
+        
+        public HealthTool(ProjectManagerFactory projectManagerFactory) : base(projectManagerFactory)
         {
         }
-        public HealthTool() : this(new DefaultHttpClientFactory())
+
+        public HealthTool() : this(new ProjectManagerFactory())
         {
         }
         public async Task<HealthMetrics?> CheckHealth(PackageURL purl)
         {
-            BaseProjectManager? packageManager = ProjectManagerFactory.CreateProjectManager(purl, HttpClientFactory);
+            BaseProjectManager? packageManager = ProjectManagerFactory.GetProjectManager(purl);
 
             if (packageManager != null)
             {
                 string? content = await packageManager.GetMetadata(purl);
                 if (!string.IsNullOrWhiteSpace(content))
                 {
-                    RepoSearch repoSearcher = new RepoSearch(HttpClientFactory);
+                    RepoSearch repoSearcher = new RepoSearch(ProjectManagerFactory);
                     foreach ((PackageURL githubPurl, double _) in await repoSearcher.ResolvePackageLibraryAsync(purl))
                     {
                         try

--- a/src/oss-health/HealthTool.cs
+++ b/src/oss-health/HealthTool.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CST.OpenSource
         }
         public async Task<HealthMetrics?> CheckHealth(PackageURL purl)
         {
-            BaseProjectManager? packageManager = ProjectManagerFactory.ConstructPackageManager(purl);
+            BaseProjectManager? packageManager = ProjectManagerFactory.CreateProjectManager(purl);
 
             if (packageManager != null)
             {

--- a/src/oss-health/HealthTool.cs
+++ b/src/oss-health/HealthTool.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CST.OpenSource
         }
         public async Task<HealthMetrics?> CheckHealth(PackageURL purl)
         {
-            BaseProjectManager? packageManager = PackageManagers.ProjectManagerFactory.CreateProjectManager(purl);
+            BaseProjectManager? packageManager = ProjectManagerFactory.ConstructPackageManager(purl);
 
             if (packageManager != null)
             {

--- a/src/oss-metadata/MetadataTool.cs
+++ b/src/oss-metadata/MetadataTool.cs
@@ -11,7 +11,6 @@ namespace Microsoft.CST.OpenSource
     using Microsoft.CST.OpenSource.Model;
     using Microsoft.CST.OpenSource.PackageManagers;
     using PackageUrl;
-    using System.Net.Http;
 
     public class MetadataTool : OSSGadget
     {
@@ -43,19 +42,19 @@ namespace Microsoft.CST.OpenSource
             private IEnumerable<string> targets = Array.Empty<string>();
         }
 
-        public MetadataTool(IHttpClientFactory httpClientFactory) : base(httpClientFactory)
+        public MetadataTool(ProjectManagerFactory projectManagerFactory) : base(projectManagerFactory)
         {
         }
 
-        public MetadataTool(): this(new DefaultHttpClientFactory()) { }
+        public MetadataTool(): this(new ProjectManagerFactory()) { }
 
-        private static async Task<PackageMetadata?> GetPackageMetadata(PackageURL purl, IHttpClientFactory httpClientFactory, bool useCache = true)
+        private static async Task<PackageMetadata?> GetPackageMetadata(PackageURL purl, ProjectManagerFactory projectManagerFactory, bool useCache = true)
         {
             PackageMetadata? metadata = null;
             try
             {
                 // Use reflection to find the correct downloader class
-                BaseProjectManager? projectManager = ProjectManagerFactory.CreateProjectManager(purl, httpClientFactory);
+                BaseProjectManager? projectManager = projectManagerFactory.CreateProjectManager(purl);
                 if (projectManager != null)
                 {
                     metadata = await projectManager.GetPackageMetadata(purl, useCache);
@@ -92,7 +91,7 @@ namespace Microsoft.CST.OpenSource
                     {
                         PackageURL purl = new(target);
                         Logger.Info($"Collecting metadata for {purl}");
-                        PackageMetadata? metadata = await GetPackageMetadata(purl, HttpClientFactory, options.UseCache);
+                        PackageMetadata? metadata = await GetPackageMetadata(purl, ProjectManagerFactory, options.UseCache);
                         Logger.Info(metadata?.ToString());
                     }
                     catch (Exception ex)

--- a/src/oss-reproducible/ReproducibleTool.cs
+++ b/src/oss-reproducible/ReproducibleTool.cs
@@ -14,9 +14,8 @@ using static Crayon.Output;
 
 namespace Microsoft.CST.OpenSource
 {
-    using System.Net.Http;
-    using Microsoft.CST.OpenSource;
     using Microsoft.CST.OpenSource.Helpers;
+    using PackageManagers;
     using PackageUrl;
 
     public enum DiffTechnique
@@ -75,12 +74,14 @@ namespace Microsoft.CST.OpenSource
             public bool LeaveIntermediateFiles { get; set; }
         }
 
-        public ReproducibleTool(IHttpClientFactory httpClientFactory) : base(httpClientFactory)
+        public ReproducibleTool(ProjectManagerFactory projectManagerFactory) : base(projectManagerFactory)
         {
         }
-        public ReproducibleTool() : this(new DefaultHttpClientFactory())
+
+        public ReproducibleTool() : this(new ProjectManagerFactory())
         {
         }
+
         /// <summary>
         /// Main entrypoint for the download program.
         /// </summary>
@@ -233,7 +234,7 @@ namespace Microsoft.CST.OpenSource
             foreach (string? target in options.Targets ?? Array.Empty<string>())
             {
                 PackageURL? purl = new PackageURL(target);
-                PackageDownloader? downloader = new PackageDownloader(purl, HttpClientFactory, "temp");
+                PackageDownloader? downloader = new PackageDownloader(purl, ProjectManagerFactory, "temp");
                 foreach (PackageURL? version in downloader.PackageVersions)
                 {
                     targets.Add(version.ToString());
@@ -259,7 +260,7 @@ namespace Microsoft.CST.OpenSource
                     FileSystemHelper.RetryDeleteDirectory(tempDirectoryName);
                     // Download the package
                     Console.WriteLine("Downloading package...");
-                    PackageDownloader? packageDownloader = new PackageDownloader(purl, HttpClientFactory, Path.Join(tempDirectoryName, "package"));
+                    PackageDownloader? packageDownloader = new PackageDownloader(purl, ProjectManagerFactory, Path.Join(tempDirectoryName, "package"));
                     List<string>? downloadResults = await packageDownloader.DownloadPackageLocalCopy(purl, false, true);
 
                     if (!downloadResults.Any())
@@ -269,7 +270,7 @@ namespace Microsoft.CST.OpenSource
 
                     // Locate the source
                     Console.WriteLine("Locating source...");
-                    FindSourceTool? findSourceTool = new FindSourceTool(HttpClientFactory);
+                    FindSourceTool? findSourceTool = new FindSourceTool(ProjectManagerFactory);
                     Dictionary<PackageURL, double>? sourceMap = await findSourceTool.FindSourceAsync(purl);
                     if (sourceMap.Any())
                     {
@@ -294,7 +295,7 @@ namespace Microsoft.CST.OpenSource
                             }
                             Logger.Debug("Trying to download package, version/reference [{0}].", reference);
                             PackageURL? purlRef = new PackageURL(bestSourcePurl.Type, bestSourcePurl.Namespace, bestSourcePurl.Name, reference, bestSourcePurl.Qualifiers, bestSourcePurl.Subpath);
-                            packageDownloader = new PackageDownloader(purlRef, HttpClientFactory, Path.Join(tempDirectoryName, "src"));
+                            packageDownloader = new PackageDownloader(purlRef, ProjectManagerFactory, Path.Join(tempDirectoryName, "src"));
                             downloadResults = await packageDownloader.DownloadPackageLocalCopy(purlRef, false, true);
                             if (downloadResults.Any())
                             {

--- a/src/oss-risk-calculator/RiskCalculatorTool.cs
+++ b/src/oss-risk-calculator/RiskCalculatorTool.cs
@@ -17,8 +17,8 @@ using Microsoft.ApplicationInspector.RulesEngine;
 
 namespace Microsoft.CST.OpenSource
 {
+    using PackageManagers;
     using PackageUrl;
-    using System.Net.Http;
 
     public class RiskCalculatorTool : OSSGadget
     {
@@ -67,14 +67,13 @@ namespace Microsoft.CST.OpenSource
             public bool UseCache { get; set; }
         }
 
-        public RiskCalculatorTool(IHttpClientFactory httpClientFactory) : base(httpClientFactory)
+        public RiskCalculatorTool(ProjectManagerFactory projectManagerFactory) : base(projectManagerFactory)
         {
         }
 
-        public RiskCalculatorTool() : this(new DefaultHttpClientFactory())
+        public RiskCalculatorTool() : this(new ProjectManagerFactory())
         {
         }
-
 
         /// <summary>
         /// Calculates project risk based on health and characteristics.
@@ -87,14 +86,14 @@ namespace Microsoft.CST.OpenSource
         {
             Logger.Trace("CalculateRisk({0})", purl.ToString());
 
-            CharacteristicTool? characteristicTool = new CharacteristicTool(HttpClientFactory);
+            CharacteristicTool? characteristicTool = new CharacteristicTool(ProjectManagerFactory);
             CharacteristicTool.Options? cOptions = new CharacteristicTool.Options();
             Dictionary<string, AnalyzeResult?>? characteristics = characteristicTool.AnalyzePackage(cOptions, purl, targetDirectory, doCaching).Result;
             double aggregateRisk = 0.0;
 
             if (checkHealth)
             {
-                HealthTool? healthTool = new HealthTool(HttpClientFactory);
+                HealthTool? healthTool = new HealthTool(ProjectManagerFactory);
                 HealthMetrics? healthMetrics = await healthTool.CheckHealth(purl);
                 if (healthMetrics == null)
                 {

--- a/src/oss-tests/DownloadTests.cs
+++ b/src/oss-tests/DownloadTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 
 using Microsoft.CST.OpenSource.Helpers;
-using Microsoft.CST.OpenSource.Shared;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.IO;
@@ -11,6 +10,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.CST.OpenSource.Tests
 {
+    using PackageManagers;
     using PackageUrl;
 
     [TestClass]
@@ -244,7 +244,7 @@ namespace Microsoft.CST.OpenSource.Tests
             {
                 try
                 {
-                    packageDownloader = new PackageDownloader(packageUrl, null, tempDirectoryName, doCache);
+                    packageDownloader = new PackageDownloader(packageUrl, new ProjectManagerFactory(), tempDirectoryName, doCache);
                     packageDownloader.DownloadPackageLocalCopy(packageUrl, false, true).Wait();
                     break;
                 }

--- a/src/oss-tests/FindSourceTests.cs
+++ b/src/oss-tests/FindSourceTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.CST.OpenSource.Tests
 {
+    using PackageManagers;
     using PackageUrl;
     using System;
 
@@ -23,7 +24,7 @@ namespace Microsoft.CST.OpenSource.Tests
             // for initialization
             FindSourceTool tool = new();
 
-            RepoSearch searchTool = new();
+            RepoSearch searchTool = new(new ProjectManagerFactory());
             Dictionary<PackageURL, double>? results = await searchTool.ResolvePackageLibraryAsync(new PackageURL(purl));
 
             List<Result> sarifResults = new();
@@ -79,7 +80,7 @@ namespace Microsoft.CST.OpenSource.Tests
             // for initialization
             FindSourceTool tool = new();
 
-            RepoSearch searchTool = new();
+            RepoSearch searchTool = new(new ProjectManagerFactory());
             Dictionary<PackageURL, double>? results = await searchTool.ResolvePackageLibraryAsync(new PackageURL(purl));
             Assert.IsTrue(results.Count() == 0, $"Result {results} obtained from non-existent {purl}");
         }
@@ -94,7 +95,7 @@ namespace Microsoft.CST.OpenSource.Tests
             // for initialization
             FindSourceTool tool = new();
 
-            RepoSearch searchTool = new();
+            RepoSearch searchTool = new(new ProjectManagerFactory());
             Dictionary<PackageURL, double>? results = await searchTool.ResolvePackageLibraryAsync(new PackageURL(purl));
             PackageURL? targetPurl = new(targetResult);
             bool success = false;

--- a/src/oss-tests/FindSquatsTests.cs
+++ b/src/oss-tests/FindSquatsTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CST.OpenSource.Tests
         public void ScopedNpmPackageSquats(string packageUrl, params string[] expectedSquats)
         {
             FindPackageSquats findPackageSquats =
-                new(new DefaultHttpClientFactory(), new PackageURL(packageUrl));
+                new(new ProjectManagerFactory(), new PackageURL(packageUrl));
 
             IDictionary<string, IList<Mutation>>? squatsCandidates = findPackageSquats.GenerateSquatCandidates();
 
@@ -71,7 +71,7 @@ namespace Microsoft.CST.OpenSource.Tests
             PackageURL purl = new(packageUrl);
             if (purl.Name is not null && purl.Type is not null)
             {
-                BaseProjectManager? manager = ProjectManagerFactory.CreateProjectManager(purl, null);
+                BaseProjectManager? manager = ProjectManagerFactory.GetProjectManager(purl, null);
                 if (manager is not null)
                 {
                     foreach ((string _, IList<Mutation> mutations) in manager.EnumerateSquatCandidates(purl)!)
@@ -98,7 +98,7 @@ namespace Microsoft.CST.OpenSource.Tests
             PackageURL purl = new(packageUrl);
             if (purl.Name is not null && purl.Type is not null)
             {
-                BaseProjectManager? manager = ProjectManagerFactory.CreateProjectManager(purl, null);
+                BaseProjectManager? manager = ProjectManagerFactory.GetProjectManager(purl, null);
                 if (manager is not null)
                 {
                     foreach ((string mutationPurlString, IList<Mutation> mutations) in manager.EnumerateSquatCandidates(purl)!)
@@ -131,7 +131,7 @@ namespace Microsoft.CST.OpenSource.Tests
             PackageURL purl = new(packageUrl);
             if (purl.Name is not null && purl.Type is not null)
             {
-                BaseProjectManager? manager = ProjectManagerFactory.CreateProjectManager(purl, null);
+                BaseProjectManager? manager = ProjectManagerFactory.GetProjectManager(purl, null);
                 if (manager is not null)
                 {
                     foreach (IMutator mutator in manager.GetDefaultMutators())
@@ -156,7 +156,7 @@ namespace Microsoft.CST.OpenSource.Tests
             PackageURL purl = new(packageUrl);
             if (purl.Name is not null && purl.Type is not null)
             {
-                BaseProjectManager? manager = ProjectManagerFactory.CreateProjectManager(purl, null);
+                BaseProjectManager? manager = ProjectManagerFactory.GetProjectManager(purl, null);
                 if (manager is not null)
                 {
                     foreach ((string mutationPurlString, _) in manager.EnumerateSquatCandidates(purl)!)
@@ -199,7 +199,7 @@ namespace Microsoft.CST.OpenSource.Tests
 
             mockFactory.Setup(_ => _.CreateClient(It.IsAny<string>())).Returns(httpMock.ToHttpClient());
 
-            FindPackageSquats findPackageSquats = new(mockFactory.Object, lodash);
+            FindPackageSquats findPackageSquats = new(new ProjectManagerFactory(mockFactory.Object), lodash);
 
             // act
             IDictionary<string, IList<Mutation>>? squatCandidates = findPackageSquats.GenerateSquatCandidates();
@@ -236,7 +236,7 @@ namespace Microsoft.CST.OpenSource.Tests
 
             mockFactory.Setup(_ => _.CreateClient(It.IsAny<string>())).Returns(httpMock.ToHttpClient());
 
-            FindPackageSquats findPackageSquats = new(mockFactory.Object, lodash);
+            FindPackageSquats findPackageSquats = new(new ProjectManagerFactory(mockFactory.Object), lodash);
 
             // act
             IDictionary<string, IList<Mutation>>? squatCandidates = findPackageSquats.GenerateSquatCandidates();
@@ -271,7 +271,7 @@ namespace Microsoft.CST.OpenSource.Tests
 
             mockFactory.Setup(_ => _.CreateClient(It.IsAny<string>())).Returns(httpMock.ToHttpClient());
 
-            FindPackageSquats findPackageSquats = new(mockFactory.Object, foo);
+            FindPackageSquats findPackageSquats = new(new ProjectManagerFactory(mockFactory.Object), foo);
 
             // act
             IDictionary<string, IList<Mutation>>? squatCandidates = findPackageSquats.GenerateSquatCandidates();
@@ -308,7 +308,7 @@ namespace Microsoft.CST.OpenSource.Tests
 
             mockFactory.Setup(_ => _.CreateClient(It.IsAny<string>())).Returns(httpMock.ToHttpClient());
 
-            FindPackageSquats findPackageSquats = new(mockFactory.Object, newtonsoft);
+            FindPackageSquats findPackageSquats = new(new ProjectManagerFactory(mockFactory.Object), newtonsoft);
 
             // act
             IDictionary<string, IList<Mutation>>? squatCandidates = findPackageSquats.GenerateSquatCandidates();
@@ -346,7 +346,7 @@ namespace Microsoft.CST.OpenSource.Tests
 
             mockFactory.Setup(_ => _.CreateClient(It.IsAny<string>())).Returns(httpMock.ToHttpClient());
 
-            FindPackageSquats findPackageSquats = new(mockFactory.Object, angularCore);
+            FindPackageSquats findPackageSquats = new(new ProjectManagerFactory(mockFactory.Object), angularCore);
 
             // act
             IDictionary<string, IList<Mutation>>? squatCandidates = findPackageSquats.GenerateSquatCandidates();

--- a/src/oss-tests/FindSquatsTests.cs
+++ b/src/oss-tests/FindSquatsTests.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CST.OpenSource.Tests
             PackageURL purl = new(packageUrl);
             if (purl.Name is not null && purl.Type is not null)
             {
-                BaseProjectManager? manager = ProjectManagerFactory.CreateProjectManager(purl, null);
+                BaseProjectManager? manager = ProjectManagerFactory.ConstructPackageManager(purl, null);
                 if (manager is not null)
                 {
                     foreach ((string _, IList<Mutation> mutations) in manager.EnumerateSquatCandidates(purl)!)
@@ -98,7 +98,7 @@ namespace Microsoft.CST.OpenSource.Tests
             PackageURL purl = new(packageUrl);
             if (purl.Name is not null && purl.Type is not null)
             {
-                BaseProjectManager? manager = ProjectManagerFactory.CreateProjectManager(purl, null);
+                BaseProjectManager? manager = ProjectManagerFactory.ConstructPackageManager(purl, null);
                 if (manager is not null)
                 {
                     foreach ((string mutationPurlString, IList<Mutation> mutations) in manager.EnumerateSquatCandidates(purl)!)
@@ -131,7 +131,7 @@ namespace Microsoft.CST.OpenSource.Tests
             PackageURL purl = new(packageUrl);
             if (purl.Name is not null && purl.Type is not null)
             {
-                BaseProjectManager? manager = ProjectManagerFactory.CreateProjectManager(purl, null);
+                BaseProjectManager? manager = ProjectManagerFactory.ConstructPackageManager(purl, null);
                 if (manager is not null)
                 {
                     foreach (IMutator mutator in manager.GetDefaultMutators())
@@ -156,7 +156,7 @@ namespace Microsoft.CST.OpenSource.Tests
             PackageURL purl = new(packageUrl);
             if (purl.Name is not null && purl.Type is not null)
             {
-                BaseProjectManager? manager = ProjectManagerFactory.CreateProjectManager(purl, null);
+                BaseProjectManager? manager = ProjectManagerFactory.ConstructPackageManager(purl, null);
                 if (manager is not null)
                 {
                     foreach ((string mutationPurlString, _) in manager.EnumerateSquatCandidates(purl)!)

--- a/src/oss-tests/FindSquatsTests.cs
+++ b/src/oss-tests/FindSquatsTests.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CST.OpenSource.Tests
             PackageURL purl = new(packageUrl);
             if (purl.Name is not null && purl.Type is not null)
             {
-                BaseProjectManager? manager = ProjectManagerFactory.GetProjectManager(purl, null);
+                BaseProjectManager? manager = ProjectManagerFactory.CreateProjectManager(purl, null);
                 if (manager is not null)
                 {
                     foreach ((string _, IList<Mutation> mutations) in manager.EnumerateSquatCandidates(purl)!)
@@ -98,7 +98,7 @@ namespace Microsoft.CST.OpenSource.Tests
             PackageURL purl = new(packageUrl);
             if (purl.Name is not null && purl.Type is not null)
             {
-                BaseProjectManager? manager = ProjectManagerFactory.GetProjectManager(purl, null);
+                BaseProjectManager? manager = ProjectManagerFactory.CreateProjectManager(purl, null);
                 if (manager is not null)
                 {
                     foreach ((string mutationPurlString, IList<Mutation> mutations) in manager.EnumerateSquatCandidates(purl)!)
@@ -131,7 +131,7 @@ namespace Microsoft.CST.OpenSource.Tests
             PackageURL purl = new(packageUrl);
             if (purl.Name is not null && purl.Type is not null)
             {
-                BaseProjectManager? manager = ProjectManagerFactory.GetProjectManager(purl, null);
+                BaseProjectManager? manager = ProjectManagerFactory.CreateProjectManager(purl, null);
                 if (manager is not null)
                 {
                     foreach (IMutator mutator in manager.GetDefaultMutators())
@@ -156,7 +156,7 @@ namespace Microsoft.CST.OpenSource.Tests
             PackageURL purl = new(packageUrl);
             if (purl.Name is not null && purl.Type is not null)
             {
-                BaseProjectManager? manager = ProjectManagerFactory.GetProjectManager(purl, null);
+                BaseProjectManager? manager = ProjectManagerFactory.CreateProjectManager(purl, null);
                 if (manager is not null)
                 {
                     foreach ((string mutationPurlString, _) in manager.EnumerateSquatCandidates(purl)!)

--- a/src/oss-tests/ProjectManagerTests/ProjectManagerFactoryTests.cs
+++ b/src/oss-tests/ProjectManagerTests/ProjectManagerFactoryTests.cs
@@ -17,42 +17,24 @@ public class ProjectManagerFactoryTests
 {
     private readonly Mock<IHttpClientFactory> _mockFactory = new();
 
-    private readonly List<Dictionary<string, ProjectManagerFactory.ConstructProjectManager>> _overrideConstructors;
-    
     public ProjectManagerFactoryTests()
     {
         MockHttpMessageHandler mockHttp = new();
 
         _mockFactory.Setup(_ => _.CreateClient(It.IsAny<string>())).Returns(mockHttp.ToHttpClient());
-        
-        _overrideConstructors = new List<Dictionary<string, ProjectManagerFactory.ConstructProjectManager>>
-        {
-            new()
-            {
-                {"test", directory => new NuGetProjectManager(_mockFactory.Object, directory) } // Create a test type with the NuGetProjectManager.
-            },
-            new()
-            {
-                {"nuget", directory => new NuGetProjectManager(_mockFactory.Object, directory) } // Create a new nuget type and override the NuGetProjectManager.
-            },
-            new()
-            {
-                {"nuget", directory => new NPMProjectManager(_mockFactory.Object, directory) } // Create a new nuget type, but use an NPMProjectManager instead.
-            },
-            new()
-            {
-                {"nuget", directory => new NuGetProjectManager(_mockFactory.Object, directory) }, // Create a new nuget type and override the NuGetProjectManager.
-                {"npm", directory => new NPMProjectManager(_mockFactory.Object, directory) }, // Create a new npm type and override the NPMProjectManager.
-                {"pypi", directory => new PyPIProjectManager(_mockFactory.Object, directory) } // Create a new pypi type and override the PyPIProjectManager.
-            },
-        };
     }
 
+    /// <summary>
+    /// Test that the <see cref="ProjectManagerFactory"/> creates the correct ProjectManager for the <paramref name="purlString"/>.
+    /// </summary>
+    /// <param name="purlString">The <see cref="PackageURL"/> as a string to create a manager for from the factory</param>
+    /// <param name="expectedManager">The <see cref="Type"/> of the <see cref="BaseProjectManager"/> implementation we expect the factory to return.</param>
     [DataTestMethod]
     [DataRow("pkg:nuget/newtonsoft.json", typeof(NuGetProjectManager))]
     [DataRow("pkg:npm/foo", typeof(NPMProjectManager))]
     [DataRow("pkg:pypi/plotly", typeof(PyPIProjectManager))]
-    public void FactorySucceeds(string purlString, Type expectedManager)
+    [DataRow("pkg:foo/bar", null)]
+    public void FactorySucceeds(string purlString, Type? expectedManager)
     {
         ProjectManagerFactory projectManagerFactory = new(_mockFactory.Object);
 
@@ -60,54 +42,175 @@ public class ProjectManagerFactoryTests
 
         Assert.AreEqual(expectedManager, projectManagerFactory.CreateProjectManager(packageUrl)?.GetType());
     }
-    
-    [DataTestMethod]
-    [DataRow(null)] // Add nothing, remove nothing.
-    [DataRow(0)] // Add a "test" type with the NuGetProjectManager, remove nothing.
-    [DataRow(1)] // Add a "nuget" type with the NuGetProjectManager, overriding the default, remove nothing.
-    [DataRow(2)] // Add a "nuget" type but use an NPMProjectManager, overriding the default, remove nothing.
-    [DataRow(3)] // Add "nuget", "npm" and "pypi" types, overriding the defaults, remove nothing.
-    [DataRow(null, "nuget")] // Add nothing, remove "nuget".
-    [DataRow(null, "nuget", "npm")] // Add nothing, remove "nuget" & "npm".
-    public void FactoryOverrideDefaultsSucceeds(int? overrideSelect = null, params string[] removeTypes)
-    {
-        Dictionary<string, ProjectManagerFactory.ConstructProjectManager> addOverrides = new();
-        if (overrideSelect is not null)
-        {
-            addOverrides = _overrideConstructors[(int) overrideSelect];
-        }
 
-        Dictionary<string, ProjectManagerFactory.ConstructProjectManager> managerOverrides = ProjectManagerFactory.GetDefaultManagers(_mockFactory.Object)
-            .Where(kvp => !removeTypes.Contains(kvp.Key) && !addOverrides.ContainsKey(kvp.Key))
-            .Concat(addOverrides).ToDictionary(x => x.Key, x => x.Value);
-        
+    /// <summary>
+    /// Test if the default dictionary works, similar to <see cref="FactorySucceeds"/>, but uses the override constructor.
+    /// </summary>
+    [TestMethod]
+    public void DefaultSucceeds()
+    {
+        Dictionary<string, ProjectManagerFactory.ConstructProjectManager> managerOverrides =
+            ManagerOverridesConstructor(_mockFactory.Object, null, null);
         ProjectManagerFactory projectManagerFactory = new(managerOverrides);
 
-        foreach ((string purlType, ProjectManagerFactory.ConstructProjectManager ctor) in addOverrides)
+        AssertFactoryCreatesCorrect(projectManagerFactory, managerOverrides);
+    }
+    
+    /// <summary>
+    /// Test adding a new manager to the dictionary, not overriding an existing one.
+    /// </summary>
+    [TestMethod]
+    public void AddTestManagerSucceeds()
+    {
+        Dictionary<string, ProjectManagerFactory.ConstructProjectManager> addManagers = new()
         {
-            PackageURL packageUrl = new($"pkg:{purlType}/foo");
-            BaseProjectManager? expectedManager = ctor.Invoke();
-            BaseProjectManager? manager = projectManagerFactory.CreateProjectManager(packageUrl);
-            Assert.AreEqual(expectedManager?.ManagerType, manager?.ManagerType);
-            Assert.AreEqual(expectedManager?.GetType(), manager?.GetType());
-        }
-        
-        foreach ((string purlType, ProjectManagerFactory.ConstructProjectManager ctor) in managerOverrides)
-        {
-            PackageURL packageUrl = new($"pkg:{purlType}/foo");
-            BaseProjectManager? expectedManager = ctor.Invoke();
-            BaseProjectManager? manager = projectManagerFactory.CreateProjectManager(packageUrl);
-            Assert.AreEqual(expectedManager?.ManagerType, manager?.ManagerType);
-            Assert.AreEqual(expectedManager?.GetType(), manager?.GetType());
-        }
-
-        if (removeTypes.Any())
-        {
-            foreach (string purlType in removeTypes)
             {
-                PackageURL packageUrl = new($"pkg:{purlType}/foo");
-                Assert.IsNull(projectManagerFactory.CreateProjectManager(packageUrl));
+                "test", directory => new NuGetProjectManager(_mockFactory.Object, directory) // Create a test type with the NuGetProjectManager.
             }
+        };
+
+        Dictionary<string, ProjectManagerFactory.ConstructProjectManager> managerOverrides =
+            ManagerOverridesConstructor(_mockFactory.Object, addManagers, null);
+        ProjectManagerFactory projectManagerFactory = new(managerOverrides);
+        
+        AssertFactoryCreatesCorrect(projectManagerFactory, addManagers);
+
+        AssertFactoryCreatesCorrect(projectManagerFactory, managerOverrides);
+    }
+    
+    /// <summary>
+    /// Test overriding the nuget and npm entries as well as their destination directories in the dictionary.
+    /// </summary>
+    [TestMethod]
+    public void OverrideManagerSucceeds()
+    {
+        Dictionary<string, ProjectManagerFactory.ConstructProjectManager> addManagers = new()
+        {
+            {
+                "nuget", _ => new NuGetProjectManager(_mockFactory.Object, "nugetTestDirectory") // Override the default entry for nuget, and override the destinationDirectory.
+            },
+            {
+                "npm", _ => new NPMProjectManager(_mockFactory.Object, "npmTestDirectory") // Override the default entry for npm, and override the destinationDirectory.
+            }
+        };
+
+        Dictionary<string, ProjectManagerFactory.ConstructProjectManager> managerOverrides =
+            ManagerOverridesConstructor(_mockFactory.Object, addManagers, null);
+        ProjectManagerFactory projectManagerFactory = new(managerOverrides);
+        
+        AssertFactoryCreatesCorrect(projectManagerFactory, addManagers);
+
+        AssertFactoryCreatesCorrect(projectManagerFactory, managerOverrides);
+
+        // Assert that the overrides worked by checking the TopLevelExtractionDirectory was changed.
+        BaseProjectManager? nuGetProjectManager = projectManagerFactory.CreateProjectManager(new PackageURL("pkg:nuget/foo"));
+        Assert.AreEqual("nugetTestDirectory", nuGetProjectManager?.TopLevelExtractionDirectory);
+        
+        BaseProjectManager? npmProjectManager = projectManagerFactory.CreateProjectManager(new PackageURL("pkg:npm/foo"));
+        Assert.AreEqual("npmTestDirectory", npmProjectManager?.TopLevelExtractionDirectory);
+    }
+    
+    /// <summary>
+    /// Test changing an entry in the dictionary of constructors to construct a manager of a different type.
+    /// </summary>
+    [TestMethod]
+    public void ChangeProjectManagerSucceeds()
+    {
+        Dictionary<string, ProjectManagerFactory.ConstructProjectManager> addManagers = new()
+        {
+            {
+                "nuget", directory => new NPMProjectManager(_mockFactory.Object, directory) // Override the default entry for nuget and set it as another NPMProjectManager.
+            }
+        };
+
+        Dictionary<string, ProjectManagerFactory.ConstructProjectManager> managerOverrides =
+            ManagerOverridesConstructor(_mockFactory.Object, addManagers, null);
+        ProjectManagerFactory projectManagerFactory = new(managerOverrides);
+        
+        AssertFactoryCreatesCorrect(projectManagerFactory, addManagers);
+
+        AssertFactoryCreatesCorrect(projectManagerFactory, managerOverrides);
+    }
+    
+    /// <summary>
+    /// Test removing an entry from the default dictionary of project manager constructors.
+    /// </summary>
+    [TestMethod]
+    public void RemoveProjectManagerSucceeds()
+    {
+        string[] removeTypes = { "nuget" };
+
+        Dictionary<string, ProjectManagerFactory.ConstructProjectManager> managerOverrides =
+            ManagerOverridesConstructor(_mockFactory.Object, null, removeTypes);
+        ProjectManagerFactory projectManagerFactory = new(managerOverrides);
+        
+        AssertFactoryCreatesCorrect(projectManagerFactory, managerOverrides);
+        
+        foreach (string purlType in removeTypes)
+        {
+            PackageURL packageUrl = new($"pkg:{purlType}/foo");
+            Assert.IsNull(projectManagerFactory.CreateProjectManager(packageUrl));
+        }
+    }
+    
+    /// <summary>
+    /// Test removing all project managers from the dictionary of project manager constructors.
+    /// </summary>
+    /// <remarks>The <see cref="ProjectManagerFactory"/> should only ever return null in this case.</remarks>
+    [TestMethod]
+    public void RemoveAllProjectManagersSucceeds()
+    {
+        string[] removeTypes = ProjectManagerFactory.GetDefaultManagers(_mockFactory.Object).Select(kvp => kvp.Key).ToArray();
+
+        Dictionary<string, ProjectManagerFactory.ConstructProjectManager> managerOverrides =
+            ManagerOverridesConstructor(_mockFactory.Object, null, removeTypes);
+        ProjectManagerFactory projectManagerFactory = new(managerOverrides);
+        
+        AssertFactoryCreatesCorrect(projectManagerFactory, managerOverrides);
+        
+        foreach (string purlType in removeTypes)
+        {
+            PackageURL packageUrl = new($"pkg:{purlType}/foo");
+            Assert.IsNull(projectManagerFactory.CreateProjectManager(packageUrl));
+        }
+    }
+
+    /// <summary>
+    /// Helper method to create the modified dictionary of constructors.
+    /// </summary>
+    /// <param name="httpClientFactory">The <see cref="IHttpClientFactory"/> to use in the constructors.</param>
+    /// <param name="addManagers">The <see cref="Dictionary{String,ConstructProjectManager}"/> of managers to override the constructors for in the factory.</param>
+    /// <param name="removeTypes">The <see cref="PackageURL.Type"/>s to remove from being able to be constructed by the factory.</param>
+    /// <returns>The new <see cref="Dictionary{String,ConstructProjectManager}"/> that the <see cref="ProjectManagerFactory"/> should use.</returns>
+    private static Dictionary<string, ProjectManagerFactory.ConstructProjectManager> ManagerOverridesConstructor(
+        IHttpClientFactory httpClientFactory,
+        Dictionary<string, ProjectManagerFactory.ConstructProjectManager>? addManagers = null,
+        string[]? removeTypes = null)
+    {
+        Dictionary<string, ProjectManagerFactory.ConstructProjectManager> addOverrides =
+            addManagers ?? new Dictionary<string, ProjectManagerFactory.ConstructProjectManager>();
+
+        Dictionary<string, ProjectManagerFactory.ConstructProjectManager> managerOverrides = ProjectManagerFactory.GetDefaultManagers(httpClientFactory)
+            .Where(kvp => (removeTypes != null && !removeTypes.Contains(kvp.Key)) && !addOverrides.ContainsKey(kvp.Key))
+            .Concat(addOverrides).ToDictionary(x => x.Key, x => x.Value);
+
+        return managerOverrides;
+    }
+
+    /// <summary>
+    /// Helper method to assert that the <paramref name="projectManagerFactory"/> creates the expected implementation of <see cref="BaseProjectManager"/>.
+    /// </summary>
+    /// <param name="projectManagerFactory">The <see cref="ProjectManagerFactory"/> to use.</param>
+    /// <param name="dict">The <see cref="Dictionary{String,ConstructProjectManager}"/> to loop through to test on the <paramref name="projectManagerFactory"/>.</param>
+    private static void AssertFactoryCreatesCorrect(ProjectManagerFactory projectManagerFactory, Dictionary<string, ProjectManagerFactory.ConstructProjectManager> dict)
+    {
+        foreach ((string purlType, ProjectManagerFactory.ConstructProjectManager ctor) in dict)
+        {
+            PackageURL packageUrl = new($"pkg:{purlType}/foo");
+            BaseProjectManager? expectedManager = ctor.Invoke();
+            BaseProjectManager? manager = projectManagerFactory.CreateProjectManager(packageUrl);
+            Assert.AreEqual(expectedManager?.ManagerType, manager?.ManagerType);
+            Assert.AreEqual(expectedManager?.GetType(), manager?.GetType());
         }
     }
 }

--- a/src/oss-tests/ProjectManagerTests/ProjectManagerFactoryTests.cs
+++ b/src/oss-tests/ProjectManagerTests/ProjectManagerFactoryTests.cs
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+namespace Microsoft.CST.OpenSource.Tests.ProjectManagerTests;
+
+using Moq;
+using PackageManagers;
+using PackageUrl;
+using RichardSzalay.MockHttp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public class ProjectManagerFactoryTests
+{
+    private readonly Mock<IHttpClientFactory> _mockFactory = new();
+
+    private readonly List<Dictionary<string, ProjectManagerFactory.ConstructProjectManager>> _overrideConstructors;
+    
+    public ProjectManagerFactoryTests()
+    {
+        MockHttpMessageHandler mockHttp = new();
+
+        _mockFactory.Setup(_ => _.CreateClient(It.IsAny<string>())).Returns(mockHttp.ToHttpClient());
+        
+        _overrideConstructors = new List<Dictionary<string, ProjectManagerFactory.ConstructProjectManager>>
+        {
+            new()
+            {
+                {"test", directory => new NuGetProjectManager(_mockFactory.Object, directory) } // Create a test type with the NuGetProjectManager.
+            },
+            new()
+            {
+                {"nuget", directory => new NuGetProjectManager(_mockFactory.Object, directory) } // Create a new nuget type and override the NuGetProjectManager.
+            },
+            new()
+            {
+                {"nuget", directory => new NPMProjectManager(_mockFactory.Object, directory) } // Create a new nuget type, but use an NPMProjectManager instead.
+            },
+            new()
+            {
+                {"nuget", directory => new NuGetProjectManager(_mockFactory.Object, directory) }, // Create a new nuget type and override the NuGetProjectManager.
+                {"npm", directory => new NPMProjectManager(_mockFactory.Object, directory) }, // Create a new npm type and override the NPMProjectManager.
+                {"pypi", directory => new PyPIProjectManager(_mockFactory.Object, directory) } // Create a new pypi type and override the PyPIProjectManager.
+            },
+        };
+    }
+
+    [DataTestMethod]
+    [DataRow("pkg:nuget/newtonsoft.json", typeof(NuGetProjectManager))]
+    [DataRow("pkg:npm/foo", typeof(NPMProjectManager))]
+    [DataRow("pkg:pypi/plotly", typeof(PyPIProjectManager))]
+    public void FactorySucceeds(string purlString, Type expectedManager)
+    {
+        ProjectManagerFactory projectManagerFactory = new(_mockFactory.Object);
+
+        PackageURL packageUrl = new(purlString);
+
+        Assert.AreEqual(expectedManager, projectManagerFactory.CreateProjectManager(packageUrl)?.GetType());
+    }
+    
+    [DataTestMethod]
+    [DataRow(null)] // Add nothing, remove nothing.
+    [DataRow(0)] // Add a "test" type with the NuGetProjectManager, remove nothing.
+    [DataRow(1)] // Add a "nuget" type with the NuGetProjectManager, overriding the default, remove nothing.
+    [DataRow(2)] // Add a "nuget" type but use an NPMProjectManager, overriding the default, remove nothing.
+    [DataRow(3)] // Add "nuget", "npm" and "pypi" types, overriding the defaults, remove nothing.
+    [DataRow(null, "nuget")] // Add nothing, remove "nuget".
+    [DataRow(null, "nuget", "npm")] // Add nothing, remove "nuget" & "npm".
+    public void FactoryOverrideDefaultsSucceeds(int? overrideSelect = null, params string[] removeTypes)
+    {
+        Dictionary<string, ProjectManagerFactory.ConstructProjectManager> addOverrides = new();
+        if (overrideSelect is not null)
+        {
+            addOverrides = _overrideConstructors[(int) overrideSelect];
+        }
+
+        Dictionary<string, ProjectManagerFactory.ConstructProjectManager> managerOverrides = ProjectManagerFactory.GetDefaultManagers(_mockFactory.Object)
+            .Where(kvp => !removeTypes.Contains(kvp.Key) && !addOverrides.ContainsKey(kvp.Key))
+            .Concat(addOverrides).ToDictionary(x => x.Key, x => x.Value);
+        
+        ProjectManagerFactory projectManagerFactory = new(managerOverrides);
+
+        foreach ((string purlType, ProjectManagerFactory.ConstructProjectManager ctor) in addOverrides)
+        {
+            PackageURL packageUrl = new($"pkg:{purlType}/foo");
+            BaseProjectManager? expectedManager = ctor.Invoke();
+            BaseProjectManager? manager = projectManagerFactory.CreateProjectManager(packageUrl);
+            Assert.AreEqual(expectedManager?.ManagerType, manager?.ManagerType);
+            Assert.AreEqual(expectedManager?.GetType(), manager?.GetType());
+        }
+        
+        foreach ((string purlType, ProjectManagerFactory.ConstructProjectManager ctor) in managerOverrides)
+        {
+            PackageURL packageUrl = new($"pkg:{purlType}/foo");
+            BaseProjectManager? expectedManager = ctor.Invoke();
+            BaseProjectManager? manager = projectManagerFactory.CreateProjectManager(packageUrl);
+            Assert.AreEqual(expectedManager?.ManagerType, manager?.ManagerType);
+            Assert.AreEqual(expectedManager?.GetType(), manager?.GetType());
+        }
+
+        if (removeTypes.Any())
+        {
+            foreach (string purlType in removeTypes)
+            {
+                PackageURL packageUrl = new($"pkg:{purlType}/foo");
+                Assert.IsNull(projectManagerFactory.CreateProjectManager(packageUrl));
+            }
+        }
+    }
+}

--- a/src/oss-tests/SharedTests.cs
+++ b/src/oss-tests/SharedTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CST.OpenSource.Tests
         public async Task MetadataToFromJsonSucceeds(string packageUrlString)
         {
             PackageURL packageUrl = new(packageUrlString);
-            BaseProjectManager? projectManager = ProjectManagerFactory.CreateProjectManager(packageUrl);
+            BaseProjectManager? projectManager = ProjectManagerFactory.GetProjectManager(packageUrl);
 
             if (projectManager == null)
             {

--- a/src/oss-tests/SharedTests.cs
+++ b/src/oss-tests/SharedTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CST.OpenSource.Tests
         public async Task MetadataToFromJsonSucceeds(string packageUrlString)
         {
             PackageURL packageUrl = new(packageUrlString);
-            BaseProjectManager? projectManager = ProjectManagerFactory.CreateProjectManager(packageUrl);
+            BaseProjectManager? projectManager = ProjectManagerFactory.ConstructPackageManager(packageUrl);
 
             if (projectManager == null)
             {

--- a/src/oss-tests/SharedTests.cs
+++ b/src/oss-tests/SharedTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CST.OpenSource.Tests
         public async Task MetadataToFromJsonSucceeds(string packageUrlString)
         {
             PackageURL packageUrl = new(packageUrlString);
-            BaseProjectManager? projectManager = ProjectManagerFactory.GetProjectManager(packageUrl);
+            BaseProjectManager? projectManager = ProjectManagerFactory.CreateProjectManager(packageUrl);
 
             if (projectManager == null)
             {


### PR DESCRIPTION
Refactor the ProjectManagerFactory to no longer use reflection for the construction of ProjectManagers.
Switch OSSGadgetLib to use a ProjectManagerFactory instead of an IHttpClientFactory, and make the change in OSSGadget as well.