### PR TITLE
Add GetPublishedAtAsync to BaseProjectManager

### DIFF
--- a/src/Shared/Model/PackageMetadata.cs
+++ b/src/Shared/Model/PackageMetadata.cs
@@ -3,6 +3,7 @@
 namespace Microsoft.CST.OpenSource.Model
 {
     using Newtonsoft.Json;
+    using System;
     using System.Collections.Generic;
 
     public class Downloads
@@ -111,7 +112,7 @@ namespace Microsoft.CST.OpenSource.Model
         public long? Size { get; set; }
 
         [JsonProperty(PropertyName = "upload_time", NullValueHandling = NullValueHandling.Ignore)]
-        public string? UploadTime { get; set; }
+        public DateTime? UploadTime { get; set; }
 
         [JsonProperty(PropertyName = "commit_id", NullValueHandling = NullValueHandling.Ignore)]
         public string? CommitId { get; set; }

--- a/src/Shared/PackageManagers/BaseProjectManager.cs
+++ b/src/Shared/PackageManagers/BaseProjectManager.cs
@@ -291,6 +291,17 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         {
             throw new NotImplementedException("BaseProjectManager does not implement EnumerateVersions.");
         }
+        
+        /// <summary>
+        /// Gets the <see cref="DateTime"/> a package version was published at.
+        /// </summary>
+        /// <param name="purl">Package URL specifying the package. Version is mandatory.</param>
+        /// <param name="useCache">If the cache should be used when looking for the published time.</param>
+        /// <returns>The <see cref="DateTime"/> when this version was published, or null if not found.</returns>
+        public virtual Task<DateTime?> GetPublishedAtAsync(PackageURL purl, bool useCache = true)
+        {
+            throw new NotImplementedException("BaseProjectManager does not implement GetPublishedAtAsync.");
+        }
 
         /// <summary>
         /// Gets the latest version from the package metadata.

--- a/src/Shared/PackageManagers/BaseProjectManager.cs
+++ b/src/Shared/PackageManagers/BaseProjectManager.cs
@@ -291,17 +291,6 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         {
             throw new NotImplementedException("BaseProjectManager does not implement EnumerateVersions.");
         }
-        
-        /// <summary>
-        /// Gets the <see cref="DateTime"/> a package version was published at.
-        /// </summary>
-        /// <param name="purl">Package URL specifying the package. Version is mandatory.</param>
-        /// <param name="useCache">If the cache should be used when looking for the published time.</param>
-        /// <returns>The <see cref="DateTime"/> when this version was published, or null if not found.</returns>
-        public virtual Task<DateTime?> GetPublishedAtAsync(PackageURL purl, bool useCache = true)
-        {
-            throw new NotImplementedException("BaseProjectManager does not implement GetPublishedAtAsync.");
-        }
 
         /// <summary>
         /// Gets the latest version from the package metadata.

--- a/src/Shared/PackageManagers/NPMProjectManager.cs
+++ b/src/Shared/PackageManagers/NPMProjectManager.cs
@@ -179,8 +179,8 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         public async Task<DateTime?> GetPublishedAtAsync(PackageURL purl, bool useCache = true)
         {
             Check.NotNull(nameof(purl.Version), purl.Version);
-            string? uploadTime = (await this.GetPackageMetadataAsync(purl, useCache))?.UploadTime;
-            return uploadTime == null ? null : DateTime.Parse(uploadTime);
+            DateTime? uploadTime = (await this.GetPackageMetadataAsync(purl, useCache))?.UploadTime;
+            return uploadTime;
         }
 
         /// <summary>
@@ -261,7 +261,10 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                 if (root.TryGetProperty("time", out JsonElement time))
                 {
                     string? uploadTime = OssUtilities.GetJSONPropertyStringIfExists(time, metadata.PackageVersion);
-                    metadata.UploadTime = uploadTime;
+                    if (uploadTime != null)
+                    {
+                        metadata.UploadTime = DateTime.Parse(uploadTime);
+                    }
                 }
 
                 if (versionElement != null)

--- a/src/Shared/PackageManagers/NPMProjectManager.cs
+++ b/src/Shared/PackageManagers/NPMProjectManager.cs
@@ -178,26 +178,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         /// <returns>The <see cref="DateTime"/> when this version was published, or null if not found.</returns>
         public async Task<DateTime?> GetPublishedAtAsync(PackageURL purl, bool useCache = true)
         {
-            string? content = await GetMetadataAsync(purl, useCache);
-            if (string.IsNullOrEmpty(content)) { return null; }
-
-            // convert NPM package data to normalized form
-            JsonDocument contentJSON = JsonDocument.Parse(content);
-            JsonElement root = contentJSON.RootElement;
-
-            if (!root.TryGetProperty("time", out JsonElement time))
-            {
-                return null;
-            }
-
-            string? publishedTime = OssUtilities.GetJSONPropertyStringIfExists(time, purl.Version);
-            if (publishedTime == null)
-            {
-                return null;
-            }
-
-            return DateTime.Parse(publishedTime);
-
+            Check.NotNull(nameof(purl.Version), purl.Version);
+            string? uploadTime = (await this.GetPackageMetadataAsync(purl, useCache))?.UploadTime;
+            return uploadTime == null ? null : DateTime.Parse(uploadTime);
         }
 
         /// <summary>

--- a/src/Shared/PackageManagers/NPMProjectManager.cs
+++ b/src/Shared/PackageManagers/NPMProjectManager.cs
@@ -170,6 +170,30 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             }
         }
 
+        public override async Task<DateTime?> GetPublishedAtAsync(PackageURL purl, bool useCache = true)
+        {
+            string? content = await GetMetadataAsync(purl, useCache);
+            if (string.IsNullOrEmpty(content)) { return null; }
+
+            // convert NPM package data to normalized form
+            JsonDocument contentJSON = JsonDocument.Parse(content);
+            JsonElement root = contentJSON.RootElement;
+
+            if (!root.TryGetProperty("time", out JsonElement time))
+            {
+                return null;
+            }
+
+            string? publishedTime = OssUtilities.GetJSONPropertyStringIfExists(time, purl.Version);
+            if (publishedTime == null)
+            {
+                return null;
+            }
+
+            return DateTime.Parse(publishedTime);
+
+        }
+
         /// <summary>
         /// Gets the latest version of the package
         /// </summary>

--- a/src/Shared/PackageManagers/NPMProjectManager.cs
+++ b/src/Shared/PackageManagers/NPMProjectManager.cs
@@ -170,7 +170,13 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             }
         }
 
-        public override async Task<DateTime?> GetPublishedAtAsync(PackageURL purl, bool useCache = true)
+        /// <summary>
+        /// Gets the <see cref="DateTime"/> a package version was published at.
+        /// </summary>
+        /// <param name="purl">Package URL specifying the package. Version is mandatory.</param>
+        /// <param name="useCache">If the cache should be used when looking for the published time.</param>
+        /// <returns>The <see cref="DateTime"/> when this version was published, or null if not found.</returns>
+        public async Task<DateTime?> GetPublishedAtAsync(PackageURL purl, bool useCache = true)
         {
             string? content = await GetMetadataAsync(purl, useCache);
             if (string.IsNullOrEmpty(content)) { return null; }

--- a/src/Shared/PackageManagers/NPMProjectManager.cs
+++ b/src/Shared/PackageManagers/NPMProjectManager.cs
@@ -263,11 +263,18 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                 metadata.PackageVersion = latestVersion is null ? purl.Version : latestVersion?.ToString();
             }
 
-            // if we found any version at all, get the deets
+            // if we found any version at all, get the information
             if (metadata.PackageVersion != null)
             {
                 Version versionToGet = new(metadata.PackageVersion);
                 JsonElement? versionElement = GetVersionElement(contentJSON, versionToGet);
+                
+                if (root.TryGetProperty("time", out JsonElement time))
+                {
+                    string? uploadTime = OssUtilities.GetJSONPropertyStringIfExists(time, metadata.PackageVersion);
+                    metadata.UploadTime = uploadTime;
+                }
+
                 if (versionElement != null)
                 {
                     // redo the generic values to version specific values

--- a/src/Shared/PackageManagers/NuGetProjectManager.cs
+++ b/src/Shared/PackageManagers/NuGetProjectManager.cs
@@ -102,7 +102,13 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             return RegistrationEndpoint;
         }
 
-        public override async Task<DateTime?> GetPublishedAtAsync(PackageURL purl, bool useCache = true)
+        /// <summary>
+        /// Gets the <see cref="DateTime"/> a package version was published at.
+        /// </summary>
+        /// <param name="purl">Package URL specifying the package. Version is mandatory.</param>
+        /// <param name="useCache">If the cache should be used when looking for the published time.</param>
+        /// <returns>The <see cref="DateTime"/> when this version was published, or null if not found.</returns>
+        public async Task<DateTime?> GetPublishedAtAsync(PackageURL purl, bool useCache = true)
         {
             Check.NotNull(nameof(purl.Version), purl.Version);
             NuGetPackageVersionMetadata? packageVersionMetadata =

--- a/src/Shared/PackageManagers/NuGetProjectManager.cs
+++ b/src/Shared/PackageManagers/NuGetProjectManager.cs
@@ -111,10 +111,8 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         public async Task<DateTime?> GetPublishedAtAsync(PackageURL purl, bool useCache = true)
         {
             Check.NotNull(nameof(purl.Version), purl.Version);
-            NuGetPackageVersionMetadata? packageVersionMetadata =
-                await Actions.GetMetadataAsync(purl, useCache: useCache);
-
-            return packageVersionMetadata?.Published?.DateTime;
+            string? uploadTime = (await this.GetPackageMetadataAsync(purl, useCache))?.UploadTime;
+            return uploadTime == null ? null : DateTime.Parse(uploadTime);
         }
 
         /// <inheritdoc />

--- a/src/Shared/PackageManagers/NuGetProjectManager.cs
+++ b/src/Shared/PackageManagers/NuGetProjectManager.cs
@@ -111,8 +111,8 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         public async Task<DateTime?> GetPublishedAtAsync(PackageURL purl, bool useCache = true)
         {
             Check.NotNull(nameof(purl.Version), purl.Version);
-            string? uploadTime = (await this.GetPackageMetadataAsync(purl, useCache))?.UploadTime;
-            return uploadTime == null ? null : DateTime.Parse(uploadTime);
+            DateTime? uploadTime = (await this.GetPackageMetadataAsync(purl, useCache))?.UploadTime;
+            return uploadTime;
         }
 
         /// <inheritdoc />
@@ -246,7 +246,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             }
 
             // publishing info
-            metadata.UploadTime = packageVersionPackageVersionMetadata.Published?.ToString("MM/dd/yy HH:mm:ss zz");
+            metadata.UploadTime = packageVersionPackageVersionMetadata.Published?.DateTime;
         }
 
         /// <summary>

--- a/src/Shared/PackageManagers/NuGetProjectManager.cs
+++ b/src/Shared/PackageManagers/NuGetProjectManager.cs
@@ -102,6 +102,15 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             return RegistrationEndpoint;
         }
 
+        public override async Task<DateTime?> GetPublishedAtAsync(PackageURL purl, bool useCache = true)
+        {
+            Check.NotNull(nameof(purl.Version), purl.Version);
+            NuGetPackageVersionMetadata? packageVersionMetadata =
+                await Actions.GetMetadataAsync(purl, useCache: useCache);
+
+            return packageVersionMetadata?.Published?.DateTime;
+        }
+
         /// <inheritdoc />
         public override async Task<string?> GetMetadataAsync(PackageURL purl, bool useCache = true)
         {

--- a/src/Shared/PackageManagers/PyPIProjectManager.cs
+++ b/src/Shared/PackageManagers/PyPIProjectManager.cs
@@ -187,7 +187,13 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             }
         }
 
-        public override async Task<DateTime?> GetPublishedAtAsync(PackageURL purl, bool useCache = true)
+        /// <summary>
+        /// Gets the <see cref="DateTime"/> a package version was published at.
+        /// </summary>
+        /// <param name="purl">Package URL specifying the package. Version is mandatory.</param>
+        /// <param name="useCache">If the cache should be used when looking for the published time.</param>
+        /// <returns>The <see cref="DateTime"/> when this version was published, or null if not found.</returns>
+        public async Task<DateTime?> GetPublishedAtAsync(PackageURL purl, bool useCache = true)
         {
             Check.NotNull(nameof(purl.Version), purl.Version);
             PackageMetadata? metadata = await this.GetPackageMetadataAsync(purl, useCache);

--- a/src/Shared/PackageManagers/PyPIProjectManager.cs
+++ b/src/Shared/PackageManagers/PyPIProjectManager.cs
@@ -196,9 +196,28 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         public async Task<DateTime?> GetPublishedAtAsync(PackageURL purl, bool useCache = true)
         {
             Check.NotNull(nameof(purl.Version), purl.Version);
-            PackageMetadata? metadata = await this.GetPackageMetadataAsync(purl, useCache);
+            string? content = await GetMetadataAsync(purl, useCache);
+            if (string.IsNullOrEmpty(content)) { return null; }
 
-            string? uploadTime = metadata?.UploadTime;
+            JsonDocument contentJSON = JsonDocument.Parse(content);
+            string? uploadTime = null;
+            try
+            {
+                JsonElement versionElement = contentJSON.RootElement.GetProperty("releases").GetProperty(purl.Version);
+
+                // Only get the upload time for the tarball.
+                foreach (JsonElement releaseFile in versionElement.EnumerateArray()
+                             .Where(releaseFile => 
+                                 OssUtilities.GetJSONPropertyStringIfExists(releaseFile, "packagetype") == "sdist"))
+                {
+                    uploadTime = OssUtilities.GetJSONPropertyStringIfExists(releaseFile, "upload_time");
+                }
+            }
+            catch (KeyNotFoundException)
+            {
+                return null;
+            }
+
             if (uploadTime == null)
             {
                 return null;
@@ -229,7 +248,6 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             string? content = await GetMetadataAsync(purl, useCache);
             if (string.IsNullOrEmpty(content)) { return null; }
 
-            // convert NPM package data to normalized form
             JsonDocument contentJSON = JsonDocument.Parse(content);
             JsonElement root = contentJSON.RootElement;
 

--- a/src/Shared/PackageManagers/PyPIProjectManager.cs
+++ b/src/Shared/PackageManagers/PyPIProjectManager.cs
@@ -187,6 +187,20 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             }
         }
 
+        public override async Task<DateTime?> GetPublishedAtAsync(PackageURL purl, bool useCache = true)
+        {
+            Check.NotNull(nameof(purl.Version), purl.Version);
+            PackageMetadata? metadata = await this.GetPackageMetadataAsync(purl, useCache);
+
+            string? uploadTime = metadata?.UploadTime;
+            if (uploadTime == null)
+            {
+                return null;
+            }
+
+            return DateTime.Parse(uploadTime);
+        }
+
         public override async Task<string?> GetMetadataAsync(PackageURL purl, bool useCache = true)
         {
             try

--- a/src/Shared/PackageManagers/PyPIProjectManager.cs
+++ b/src/Shared/PackageManagers/PyPIProjectManager.cs
@@ -238,6 +238,8 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             metadata.Name = OssUtilities.GetJSONPropertyStringIfExists(infoElement, "name");
             metadata.Description = OssUtilities.GetJSONPropertyStringIfExists(infoElement, "summary"); // Summary is the short description. Description is usually the readme.
 
+            metadata.LatestPackageVersion = OssUtilities.GetJSONPropertyStringIfExists(infoElement, "version"); // Ran in the root, always points to latest version.
+
             metadata.PackageManagerUri = ENV_PYPI_ENDPOINT;
             metadata.PackageUri = OssUtilities.GetJSONPropertyStringIfExists(infoElement, "package_url");
             metadata.Keywords = OssUtilities.ConvertJSONToList(OssUtilities.GetJSONPropertyIfExists(infoElement, "keywords"));
@@ -286,19 +288,8 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                 });
             }
 
-            // get the version
-            List<Version> versions = GetVersions(contentJSON);
-            Version? latestVersion = GetLatestVersion(versions);
-
-            if (purl.Version != null)
-            {
-                // find the version object from the collection
-                metadata.PackageVersion = purl.Version;
-            }
-            else
-            {
-                metadata.PackageVersion = latestVersion is null ? purl.Version : latestVersion?.ToString();
-            }
+            // get the version, either use the provided one, or if null then use the LatestPackageVersion.
+            metadata.PackageVersion = purl.Version ?? metadata.LatestPackageVersion;
 
             // if we found any version at all, get the information.
             if (metadata.PackageVersion is not null)

--- a/src/Shared/PackageManagers/PyPIProjectManager.cs
+++ b/src/Shared/PackageManagers/PyPIProjectManager.cs
@@ -196,8 +196,8 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         public async Task<DateTime?> GetPublishedAtAsync(PackageURL purl, bool useCache = true)
         {
             Check.NotNull(nameof(purl.Version), purl.Version);
-            string? uploadTime = (await this.GetPackageMetadataAsync(purl, useCache))?.UploadTime;
-            return uploadTime == null ? null : DateTime.Parse(uploadTime);
+            DateTime? uploadTime = (await this.GetPackageMetadataAsync(purl, useCache))?.UploadTime;
+            return uploadTime;
         }
 
         public override async Task<string?> GetMetadataAsync(PackageURL purl, bool useCache = true)
@@ -325,10 +325,15 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                                 }
 
                                 metadata.Size = OssUtilities.GetJSONPropertyIfExists(releaseFile, "size")?.GetInt64();
-                                metadata.UploadTime = OssUtilities.GetJSONPropertyStringIfExists(releaseFile, "upload_time");
                                 metadata.Active = !OssUtilities.GetJSONPropertyIfExists(releaseFile, "yanked")?.GetBoolean();
                                 metadata.VersionUri = $"{ENV_PYPI_ENDPOINT}/project/{purl.Name}/{purl.Version}";
                                 metadata.VersionDownloadUri = OssUtilities.GetJSONPropertyStringIfExists(releaseFile, "url");
+                                
+                                string? uploadTime = OssUtilities.GetJSONPropertyStringIfExists(releaseFile, "upload_time");
+                                if (uploadTime != null)
+                                {
+                                    metadata.UploadTime = DateTime.Parse(uploadTime);
+                                }
                             }
                         }
                     }

--- a/src/Shared/PackageManagers/PyPIProjectManager.cs
+++ b/src/Shared/PackageManagers/PyPIProjectManager.cs
@@ -196,34 +196,8 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         public async Task<DateTime?> GetPublishedAtAsync(PackageURL purl, bool useCache = true)
         {
             Check.NotNull(nameof(purl.Version), purl.Version);
-            string? content = await GetMetadataAsync(purl, useCache);
-            if (string.IsNullOrEmpty(content)) { return null; }
-
-            JsonDocument contentJSON = JsonDocument.Parse(content);
-            string? uploadTime = null;
-            try
-            {
-                JsonElement versionElement = contentJSON.RootElement.GetProperty("releases").GetProperty(purl.Version);
-
-                // Only get the upload time for the tarball.
-                foreach (JsonElement releaseFile in versionElement.EnumerateArray()
-                             .Where(releaseFile => 
-                                 OssUtilities.GetJSONPropertyStringIfExists(releaseFile, "packagetype") == "sdist"))
-                {
-                    uploadTime = OssUtilities.GetJSONPropertyStringIfExists(releaseFile, "upload_time");
-                }
-            }
-            catch (KeyNotFoundException)
-            {
-                return null;
-            }
-
-            if (uploadTime == null)
-            {
-                return null;
-            }
-
-            return DateTime.Parse(uploadTime);
+            string? uploadTime = (await this.GetPackageMetadataAsync(purl, useCache))?.UploadTime;
+            return uploadTime == null ? null : DateTime.Parse(uploadTime);
         }
 
         public override async Task<string?> GetMetadataAsync(PackageURL purl, bool useCache = true)

--- a/src/oss-tests/ProjectManagerTests/NPMProjectManagerTests.cs
+++ b/src/oss-tests/ProjectManagerTests/NPMProjectManagerTests.cs
@@ -11,6 +11,7 @@ namespace Microsoft.CST.OpenSource.Tests.ProjectManagerTests
     using PackageManagers;
     using PackageUrl;
     using RichardSzalay.MockHttp;
+    using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Linq;
@@ -84,6 +85,28 @@ namespace Microsoft.CST.OpenSource.Tests.ProjectManagerTests
 
             Assert.AreEqual(count, versions.Count);
             Assert.AreEqual(latestVersion, versions.First());
+        }
+        
+        [DataTestMethod]
+        [DataRow("pkg:npm/lodash@4.17.15", "2019-07-19T02:28:46.584Z")]
+        [DataRow("pkg:npm/%40angular/core@13.2.5", "2022-03-02T18:25:31.169Z")]
+        [DataRow("pkg:npm/ds-modal@0.0.2", "2018-08-09T07:24:06.206Z")]
+        [DataRow("pkg:npm/monorepolint@0.4.0", "2019-08-07T16:20:53.525Z")]
+        [DataRow("pkg:npm/rly-cli@0.0.2", "2022-03-08T17:26:27.219Z")]
+        [DataRow("pkg:npm/example@0.0.0")] // No time property in the json.
+        public async Task GetPublishedAtSucceeds(string purlString, string? expectedTime = null)
+        {
+            PackageURL purl = new(purlString);
+            DateTime? time = await _projectManager.GetPublishedAtAsync(purl, useCache: false);
+
+            if (expectedTime == null)
+            {
+                Assert.IsNull(time);
+            }
+            else
+            {
+                Assert.AreEqual(DateTime.Parse(expectedTime), time);
+            }
         }
         
         [DataTestMethod]

--- a/src/oss-tests/ProjectManagerTests/NuGetProjectManagerTests.cs
+++ b/src/oss-tests/ProjectManagerTests/NuGetProjectManagerTests.cs
@@ -13,6 +13,7 @@ namespace Microsoft.CST.OpenSource.Tests.ProjectManagerTests
     using PackageManagers;
     using PackageUrl;
     using RichardSzalay.MockHttp;
+    using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Linq;
@@ -122,6 +123,23 @@ namespace Microsoft.CST.OpenSource.Tests.ProjectManagerTests
             Assert.AreEqual(latestVersion, versions.First());
         }
 
+        [DataTestMethod]
+        [DataRow("pkg:nuget/razorengine@4.2.3-beta1", "2015-10-06T17:53:46.37+00:00")]
+        [DataRow("pkg:nuget/razorengine@4.5.1-alpha001", "2017-09-02T05:17:55.973-04:00")]
+        public async Task GetPublishedAtSucceeds(string purlString, string? expectedTime = null)
+        {
+            PackageURL purl = new(purlString);
+            DateTime? time = await _projectManager.GetPublishedAtAsync(purl, useCache: false);
+
+            if (expectedTime == null)
+            {
+                Assert.IsNull(time);
+            }
+            else
+            {
+                Assert.AreEqual(DateTime.Parse(expectedTime), time);
+            }
+        }
                 
         [DataTestMethod]
         [DataRow("pkg:nuget/newtonsoft.json@13.0.1", "https://api.nuget.org/v3-flatcontainer/newtonsoft.json/13.0.1/newtonsoft.json")]

--- a/src/oss-tests/ProjectManagerTests/PyPIProjectManagerTests.cs
+++ b/src/oss-tests/ProjectManagerTests/PyPIProjectManagerTests.cs
@@ -64,6 +64,26 @@ namespace Microsoft.CST.OpenSource.Tests.ProjectManagerTests
             Assert.AreEqual(description, metadata.Description);
         }
         
+        [Ignore(message: "Ignored until https://github.com/microsoft/OSSGadget/issues/328 is addressed.")]
+        [DataTestMethod]
+        [DataRow("pkg:pypi/pandas@1.4.2", "")]
+        [DataRow("pkg:pypi/plotly@5.7.0", "")]
+        [DataRow("pkg:pypi/requests@2.27.1", "")]
+        public async Task GetPublishedAtSucceeds(string purlString, string? expectedTime = null)
+        {
+            PackageURL purl = new(purlString);
+            DateTime? time = await _projectManager.GetPublishedAtAsync(purl, useCache: false);
+
+            if (expectedTime == null)
+            {
+                Assert.IsNull(time);
+            }
+            else
+            {
+                Assert.AreEqual(DateTime.Parse(expectedTime), time);
+            }
+        }
+        
         [DataTestMethod]
         [DataRow("pkg:pypi/pandas@1.4.2", 86, "1.4.2")]
         [DataRow("pkg:pypi/plotly@3.7.1", 276, "5.7.0")]

--- a/src/oss-tests/ProjectManagerTests/PyPIProjectManagerTests.cs
+++ b/src/oss-tests/ProjectManagerTests/PyPIProjectManagerTests.cs
@@ -49,7 +49,6 @@ namespace Microsoft.CST.OpenSource.Tests.ProjectManagerTests
             _projectManager = new PyPIProjectManager(".", new NoOpPackageActions(), _httpFactory);
         }
 
-        [Ignore(message: "Ignored until https://github.com/microsoft/OSSGadget/issues/328 is addressed.")]
         [DataTestMethod]
         [DataRow("pkg:pypi/pandas@1.4.2", "Powerful data structures for data analysis, time series, and statistics")]
         [DataRow("pkg:pypi/plotly@5.7.0", "An open-source, interactive data visualization library for Python")]
@@ -64,11 +63,10 @@ namespace Microsoft.CST.OpenSource.Tests.ProjectManagerTests
             Assert.AreEqual(description, metadata.Description);
         }
         
-        [Ignore(message: "Ignored until https://github.com/microsoft/OSSGadget/issues/328 is addressed.")]
         [DataTestMethod]
-        [DataRow("pkg:pypi/pandas@1.4.2", "")]
-        [DataRow("pkg:pypi/plotly@5.7.0", "")]
-        [DataRow("pkg:pypi/requests@2.27.1", "")]
+        [DataRow("pkg:pypi/pandas@1.4.2", "2022-04-02T10:37:04")]
+        [DataRow("pkg:pypi/plotly@5.7.0", "2022-04-05T16:26:12")]
+        [DataRow("pkg:pypi/requests@2.27.1", "2022-01-05T15:40:51")]
         public async Task GetPublishedAtSucceeds(string purlString, string? expectedTime = null)
         {
             PackageURL purl = new(purlString);


### PR DESCRIPTION
It returns the DateTime of a given purl (with a specified version) for when it was published. Or returns null if it couldn't be found.
For CFS we are using this data, so having a direct method to get it vs calling GetPackageMetadata and only keeping the time would help. If you disagree no worries and we can just do that, this was just a fairly easy thing to whip up.

Also, `NPMProjectManager` wasn't setting `UploadTime` in the `GetPackageMetadata` call.