### PR TITLE
Refactor metadata tool to use deps.dev and libraries.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -351,3 +351,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Rider
+src/.idea

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -9,12 +9,11 @@ https://go.microsoft.com/fwlink/?LinkID=824704.
 
 However, OSS Gadget does make outbound network connections to various locations,
 including NPM (registry.npmjs.org), NuGet (api.nuget.org), and RubyGems (rubygems.org).
-These connections are unauthenticated and made directly to that service. As such,
+These connections are generally unauthenticated and made directly to that service. As such,
 their privacy policy would apply.
 
-In addition, the health calculator (oss-health.exe) tool queries GitHub using the
-public API. In order to do so, it needs an API key, which you would need to
-include. This connection is therefore authenticated, between the tool and GitHub, and
-as such, the [GitHub privacy policy](https://help.github.com/en/github/site-policy/github-privacy-statement)
-would apply.
+In addition, the health calculator (oss-health.exe) and metadata (oss-metadata) tools use API keys
+to query GitHub and libraries.io. Since this connection is authenticated, the
+[GitHub privacy policy](https://help.github.com/en/github/site-policy/github-privacy-statement) and
+[Libraries.io privacy policy](https://libraries.io/privacy) would apply.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A list of tools included is below.  Click on the name of a tool to go to the wik
 * [oss-find-source](https://github.com/microsoft/OSSGadget/wiki/OSS-Find-Source): Attempts to locate the source code (on GitHub, currently) of a given package.
 * [oss-find-squats](https://github.com/microsoft/OSSGadget/wiki/OSS-Find-Squats): Identifies potential typo-squatting for a given package.
 * [oss-health](https://github.com/microsoft/OSSGadget/wiki/OSS-Health): Calculates health metrics for a given package.
-* [oss-metadata](https://github.com/microsoft/OSSGadget/wiki/OSS-Metadata): Normalizes metadata about a package into a common schema.
+* [oss-metadata](https://github.com/microsoft/OSSGadget/wiki/OSS-Metadata): Retrieves metadata from deps.dev or libraries.io for a given package.
 * [oss-risk-calculator](https://github.com/microsoft/OSSGadget/wiki/OSS-Risk-Calculator): Calculates a metric for risk of using a package.
 
 All OSS Gadget tools accept one or more [Package URLs](https://github.com/package-url/purl-spec) as a way to uniquely identify a package. Package URLs look like `pkg:npm/express` or `pkg:gem/azure@0.7.10`. If you leave the version number off, it implicitly means, "attempt to find the latest version". Using an asterisk (`pkg:npm/express@*`) means "perform the action on all available versions".
@@ -60,7 +60,7 @@ This will download left-pad into a newly-created directory named `npm-left-pad@1
 Each of the programs self-documents information on command line options (`--help`).
 
 ### Building from Source
-OSS Gadget builds with standard `dotnet build` commands.
+OSS Gadget builds with standard `dotnet build` commands and includes tests via `dotnet test`.
 
 See [Building from Source](https://github.com/microsoft/OSSGadget/wiki/Building-from-Source) in the wiki for information on building from source.
 

--- a/src/Shared.CLI/OSSGadget.cs
+++ b/src/Shared.CLI/OSSGadget.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CST.OpenSource
                 h.AddPostOptionsLines(GetCommonSupportedHelpTextLines());
                 return HelpText.DefaultParsingErrorsHandler(result, h);
             });
-            Console.Write(helpText);
+            Console.Error.Write(helpText);
         }
 
         /// <summary>
@@ -128,10 +128,10 @@ namespace Microsoft.CST.OpenSource
 
         public static void ShowToolBanner()
         {
-            Console.WriteLine(OSSGadget.GetBanner());
+            Console.Error.WriteLine(OSSGadget.GetBanner());
             string? toolName = GetToolName();
             string? toolVersion = GetToolVersion();
-            Console.WriteLine($"OSS Gadget - {toolName} {toolVersion} - github.com/Microsoft/OSSGadget");
+            Console.Error.WriteLine($"OSS Gadget - {toolName} {toolVersion} - github.com/Microsoft/OSSGadget");
         }
 
         /// <summary>
@@ -178,24 +178,23 @@ namespace Microsoft.CST.OpenSource
         protected static string GetCommonSupportedHelpText()
         {
             string supportedHelpText = @"
-                The package-url specifier is described at https://github.com/package-url/purl-spec:
-                  pkg:cargo/rand                The latest version of Rand (via crates.io)
-                  pkg:cocoapods/AFNetworking    The latest version of AFNetworking (via cocoapods.org)
-                  pkg:composer/Smarty/Smarty    The latest version of Smarty (via Composer/ Packagist)
-                  pkg:cpan/Apache-ACEProxy      The latest version of Apache::ACEProxy (via cpan.org)
-                  pkg:cran/ACNE@0.8.0           Version 0.8.0 of ACNE (via cran.r-project.org)
-                  pkg:gem/rubytree@*            All versions of RubyTree (via rubygems.org)
-                  pkg:golang/sigs.k8s.io/yaml   The latest version of sigs.k8s.io/yaml (via proxy.golang.org)
-                  pkg:github/Microsoft/DevSkim  The latest release of DevSkim (via GitHub)
-                  pkg:hackage/a50@*             All versions of a50 (via hackage.haskell.org)
-                  pkg:maven/org.apdplat/deep-qa The latest version of org.apdplat.deep-qa (via repo1.maven.org)
-                  pkg:npm/express               The latest version of Express (via npm.org)
-                  pkg:nuget/Newtonsoft.JSON     The latest version of Newtonsoft.JSON (via nuget.org)
-                  pkg:pypi/django@1.11.1        Version 1.11.1 of Django (via pypi.org)
-                  pkg:ubuntu/zerofree           The latest version of zerofree from Ubuntu (via packages.ubuntu.com)
-                  pkg:vsm/MLNET/07              The latest version of MLNET.07 (from marketplace.visualstudio.com)
-                  pkg:url/foo@1.0?url=<URL>     The direct URL <URL>
-                ";
+The package-url specifier is described at https://github.com/package-url/purl-spec:
+    pkg:cargo/rand                The latest version of Rand (via crates.io)
+    pkg:cocoapods/AFNetworking    The latest version of AFNetworking (via cocoapods.org)
+    pkg:composer/Smarty/Smarty    The latest version of Smarty (via Composer/ Packagist)
+    pkg:cpan/Apache-ACEProxy      The latest version of Apache::ACEProxy (via cpan.org)
+    pkg:cran/ACNE@0.8.0           Version 0.8.0 of ACNE (via cran.r-project.org)
+    pkg:gem/rubytree@*            All versions of RubyTree (via rubygems.org)
+    pkg:golang/sigs.k8s.io/yaml   The latest version of sigs.k8s.io/yaml (via proxy.golang.org)
+    pkg:github/Microsoft/DevSkim  The latest release of DevSkim (via GitHub)
+    pkg:hackage/a50@*             All versions of a50 (via hackage.haskell.org)
+    pkg:maven/org.apdplat/deep-qa The latest version of org.apdplat.deep-qa (via repo1.maven.org)
+    pkg:npm/express               The latest version of Express (via npm.org)
+    pkg:nuget/Newtonsoft.JSON     The latest version of Newtonsoft.JSON (via nuget.org)
+    pkg:pypi/django@1.11.1        Version 1.11.1 of Django (via pypi.org)
+    pkg:ubuntu/zerofree           The latest version of zerofree from Ubuntu (via packages.ubuntu.com)
+    pkg:vsm/MLNET/07              The latest version of MLNET.07 (from marketplace.visualstudio.com)
+    pkg:url/foo@1.0?url=<URL>     The direct URL <URL>\n";
             return supportedHelpText;
         }
 

--- a/src/Shared/Metadata/BaseMetadataSource.cs
+++ b/src/Shared/Metadata/BaseMetadataSource.cs
@@ -5,14 +5,12 @@ namespace Microsoft.CST.OpenSource;
 using System.Threading.Tasks;
 using System.Text.Json;
 using PackageUrl;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.DependencyInjection;
 using System.Net.Http;
 using System;
 using Polly;
 using System.Net;
 using Polly.Retry;
-using System.Collections.Generic;
 using Polly.Contrib.WaitAndRetry;
 
 public abstract class BaseMetadataSource

--- a/src/Shared/Metadata/BaseMetadataSource.cs
+++ b/src/Shared/Metadata/BaseMetadataSource.cs
@@ -47,7 +47,7 @@ public abstract class BaseMetadataSource
     {
         policy ??= Policy
             .Handle<HttpRequestException>()
-            .OrResult<HttpResponseMessage>(r => r.StatusCode != HttpStatusCode.OK)
+            .OrResult<HttpResponseMessage>(r => (int)r.StatusCode >= 500 || r.StatusCode == HttpStatusCode.TooManyRequests)
             .WaitAndRetryAsync(Backoff.DecorrelatedJitterBackoffV2(TimeSpan.FromSeconds(15), retryCount: 5));
 
         var result = await policy.ExecuteAsync(() => HttpClient.GetAsync(uri, HttpCompletionOption.ResponseContentRead));

--- a/src/Shared/Metadata/BaseMetadataSource.cs
+++ b/src/Shared/Metadata/BaseMetadataSource.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+namespace Microsoft.CST.OpenSource;
+
+using System.Threading.Tasks;
+using System.Text.Json;
+using PackageUrl;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.DependencyInjection;
+using System.Net.Http;
+using System;
+
+public abstract class BaseMetadataSource
+{
+    protected static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
+
+    protected HttpClient HttpClient;
+    
+    public BaseMetadataSource()
+    {
+        ServiceProvider serviceProvider = new ServiceCollection()
+            .AddHttpClient()
+            .BuildServiceProvider();
+
+        var clientFactor = serviceProvider.GetService<IHttpClientFactory>() ?? throw new InvalidOperationException();
+        HttpClient = clientFactor.CreateClient();
+    }
+
+    public async Task<JsonDocument?> GetMetadataForPackageUrlAsync(PackageURL packageUrl, bool useCache = false)
+    {
+        return await GetMetadataAsync(packageUrl.Type, packageUrl.Namespace, packageUrl.Name, packageUrl.Version, useCache);
+    }
+    public abstract Task<JsonDocument?> GetMetadataAsync(string packageType, string packageNamespace, string packageName, string packageVersion, bool useCache = false);
+}

--- a/src/Shared/Metadata/DepsDevMetadataSource.cs
+++ b/src/Shared/Metadata/DepsDevMetadataSource.cs
@@ -35,12 +35,15 @@ public class DepsDevMetadataSource : BaseMetadataSource
         {
             Logger.Warn("Unable to get metadata for [{} {}]. Package type [{}] is not supported. Try another data provider.", packageNamespace, packageName, packageType);
         }
-
-        var packageNamespaceEnc = ("/" + packageNamespace?.Replace("@", "%40").Replace("/", "%2F")) ?? "";
+        var packageNamespaceEnc = packageNamespace?.Replace("@", "%40").Replace("/", "%2F");
         var packageNameEnc = packageName.Replace("@", "%40").Replace("/", "%2F");
-        
+
+        var fullPackageName = string.IsNullOrWhiteSpace(packageNamespaceEnc) ?
+            $"{packageNameEnc}" :
+            $"{packageNamespaceEnc}%2F{packageNameEnc}";
+
         // The missing slash in the next line is not a bug.
-        var url = $"{ENV_DEPS_DEV_ENDPOINT}/s/{packageTypeEnc}/p{packageNamespaceEnc}/{packageNameEnc}/v/{packageVersion}";
+        var url = $"{ENV_DEPS_DEV_ENDPOINT}/s/{packageTypeEnc}/p/{fullPackageName}/v/{packageVersion}";
         try
         {
             return await BaseProjectManager.GetJsonCache(HttpClient, url, useCache);

--- a/src/Shared/Metadata/DepsDevMetadataSource.cs
+++ b/src/Shared/Metadata/DepsDevMetadataSource.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+namespace Microsoft.CST.OpenSource;
+
+using RecursiveExtractor;
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using System.Text.Json;
+using PackageUrl;
+using System.Linq;
+using System.Collections.Generic;
+using Microsoft.CST.OpenSource.PackageManagers;
+using Microsoft.Extensions.DependencyInjection;
+using System.Net.Http;
+
+public class DepsDevMetadataSource : BaseMetadataSource
+{
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
+    public static string ENV_DEPS_DEV_ENDPOINT = "https://deps.dev/_";
+
+    public static readonly List<string> VALID_TYPES = new List<string>() {
+        "npm",
+        "go",
+        "maven",
+        "pypi",
+        "cargo"
+    };
+
+    public override async Task<JsonDocument?> GetMetadataAsync(string packageType, string packageNamespace, string packageName, string packageVersion, bool useCache = false)
+    {
+        var packageTypeEnc = string.Equals(packageType, "golang") ? "go" : packageType;
+        if (!VALID_TYPES.Contains(packageTypeEnc, StringComparer.InvariantCultureIgnoreCase))
+        {
+            Logger.Warn("Unable to get metadata for [{} {}]. Package type [{}] is not supported. Try another data provider.", packageNamespace, packageName, packageType);
+        }
+
+        var packageNamespaceEnc = ("/" + packageNamespace?.Replace("@", "%40").Replace("/", "%2F")) ?? "";
+        var packageNameEnc = packageName.Replace("@", "%40").Replace("/", "%2F");
+        
+        // The missing slash in the next line is not a bug.
+        var url = $"{ENV_DEPS_DEV_ENDPOINT}/s/{packageTypeEnc}/p{packageNamespaceEnc}/{packageNameEnc}/v/{packageVersion}";
+        try
+        {
+            return await BaseProjectManager.GetJsonCache(HttpClient, url, useCache);
+        }
+        catch(Exception ex)
+        {
+            Logger.Warn("Error loading package: {0}", ex.Message);
+            return null;
+        }
+    }
+}

--- a/src/Shared/Metadata/DepsDevMetadataSource.cs
+++ b/src/Shared/Metadata/DepsDevMetadataSource.cs
@@ -2,18 +2,12 @@
 
 namespace Microsoft.CST.OpenSource;
 
-using RecursiveExtractor;
 using System;
-using System.IO;
-using System.Text;
 using System.Threading.Tasks;
 using System.Text.Json;
-using PackageUrl;
 using System.Linq;
 using System.Collections.Generic;
 using Microsoft.CST.OpenSource.PackageManagers;
-using Microsoft.Extensions.DependencyInjection;
-using System.Net.Http;
 
 public class DepsDevMetadataSource : BaseMetadataSource
 {

--- a/src/Shared/Metadata/LibrariesIoMetadataSource.cs
+++ b/src/Shared/Metadata/LibrariesIoMetadataSource.cs
@@ -8,6 +8,7 @@ using System.Text.Json;
 using System.Linq;
 using System.Collections.Generic;
 using Microsoft.CST.OpenSource.PackageManagers;
+using System.Threading;
 
 public class LibrariesIoMetadataSource : BaseMetadataSource
 {
@@ -16,6 +17,7 @@ public class LibrariesIoMetadataSource : BaseMetadataSource
     public static string? ENV_LIBRARIES_IO_API_KEY = null;
 
     // Reload periodically from https://libraries.io/api/platforms
+    // curl https://libraries.io/api/platforms | jq '.[].name' | sed 's/[A-Z]/\L&/g' | sed 's/$/,/g' | sort | sed '$ s/.$//'
     public static readonly List<string> VALID_TYPES = new List<string>() {
         "alcatraz",
         "bower",
@@ -66,12 +68,12 @@ public class LibrariesIoMetadataSource : BaseMetadataSource
 
         try
         {
-            return await BaseProjectManager.GetJsonCache(HttpClient, url, useCache);
+            return await GetJsonWithRetry(url);
         }
         catch(Exception ex)
         {
             Logger.Warn("Error loading package: {0}", ex.Message);
-            return null;
         }
+        return null;
     }
 }

--- a/src/Shared/Metadata/LibrariesIoMetadataSource.cs
+++ b/src/Shared/Metadata/LibrariesIoMetadataSource.cs
@@ -61,10 +61,14 @@ public class LibrariesIoMetadataSource : BaseMetadataSource
         }
 
         var apiKey = ENV_LIBRARIES_IO_API_KEY != null ? $"apiKey={ENV_LIBRARIES_IO_API_KEY}" : "";
-        var packageNamespaceEnc = ("/" + packageNamespace?.Replace("@", "%40").Replace("/", "%2F")) ?? "";
+        var packageNamespaceEnc = packageNamespace?.Replace("@", "%40").Replace("/", "%2F");
         var packageNameEnc = packageName.Replace("@", "%40").Replace("/", "%2F");
+
+        var fullPackageName = string.IsNullOrWhiteSpace(packageNamespaceEnc) ?
+            $"{packageNameEnc}" :
+            $"{packageNamespaceEnc}%2F{packageNameEnc}";
         
-        var url = $"{ENV_LIBRARIES_IO_ENDPOINT}/{packageTypeEnc}{packageNamespaceEnc}/{packageNameEnc}?{apiKey}";
+        var url = $"{ENV_LIBRARIES_IO_ENDPOINT}/{packageTypeEnc}/{fullPackageName}?{apiKey}";
 
         try
         {

--- a/src/Shared/Metadata/LibrariesIoMetadataSource.cs
+++ b/src/Shared/Metadata/LibrariesIoMetadataSource.cs
@@ -7,8 +7,6 @@ using System.Threading.Tasks;
 using System.Text.Json;
 using System.Linq;
 using System.Collections.Generic;
-using Microsoft.CST.OpenSource.PackageManagers;
-using System.Threading;
 
 public class LibrariesIoMetadataSource : BaseMetadataSource
 {

--- a/src/Shared/Metadata/NativeMetadataSource.cs
+++ b/src/Shared/Metadata/NativeMetadataSource.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+namespace Microsoft.CST.OpenSource;
+
+using RecursiveExtractor;
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using System.Text.Json;
+using PackageUrl;
+using System.Linq;
+using System.Collections.Generic;
+using Microsoft.CST.OpenSource.PackageManagers;
+using Microsoft.Extensions.DependencyInjection;
+using System.Net.Http;
+using System.Reflection;
+
+public class NativeMetadataSource : BaseMetadataSource
+{
+    public static readonly List<string> VALID_TYPES = new List<string>();
+
+    static NativeMetadataSource()
+    {
+        // Dynamically gather the list of valid types based on whether subtypes of
+        // BaseProjectManager implement GetMetadataAsync.
+        var projectManagers = typeof(BaseMetadataSource).Assembly.GetTypes()
+                .Where(t => t.IsSubclassOf(typeof(BaseProjectManager)));
+
+        foreach (var projectManager in projectManagers.Where(d => d != null))
+        {
+            MethodInfo? method = projectManager.GetMethod("GetMetadataAsync");
+            if (method != null)
+            {
+                var type = projectManager.GetField("Type", BindingFlags.Public | BindingFlags.Static)?.GetValue(null) as string;
+                if (type != null)
+                {
+                    VALID_TYPES.Add(type);
+                }
+            }
+        }
+        VALID_TYPES.Sort();
+    }
+
+    public override async Task<JsonDocument?> GetMetadataAsync(string packageType, string packageNamespace, string packageName, string packageVersion, bool useCache = false)
+    {
+        var packageUrl = new PackageURL(packageType, packageNamespace, packageName, packageVersion, null, null);
+
+        var packageManager = ProjectManagerFactory.ConstructPackageManager(packageUrl);
+        if (packageManager != null)
+        {
+            try
+            {
+                var metadata = await packageManager.GetMetadataAsync(packageUrl);
+                if (metadata != null)
+                {
+                    try
+                    {
+                        return JsonDocument.Parse(metadata);
+                    }
+                    catch(Exception ex)
+                    {
+                        Logger.Warn(ex, "Error parsing metadata: {0}", ex.Message);
+                        return JsonSerializer.SerializeToDocument(new Dictionary<string, string>() {
+                            { "content", metadata }
+                        });
+                    }
+                }
+            }
+            catch(Exception ex)
+            {
+                Logger.Warn(ex, "Error retrieving metadata: {0}", ex.Message);
+            }
+        }
+        return null;
+    }
+}

--- a/src/Shared/Metadata/NativeMetadataSource.cs
+++ b/src/Shared/Metadata/NativeMetadataSource.cs
@@ -2,18 +2,13 @@
 
 namespace Microsoft.CST.OpenSource;
 
-using RecursiveExtractor;
 using System;
-using System.IO;
-using System.Text;
 using System.Threading.Tasks;
 using System.Text.Json;
 using PackageUrl;
 using System.Linq;
 using System.Collections.Generic;
 using Microsoft.CST.OpenSource.PackageManagers;
-using Microsoft.Extensions.DependencyInjection;
-using System.Net.Http;
 using System.Reflection;
 
 public class NativeMetadataSource : BaseMetadataSource

--- a/src/Shared/nlog.config
+++ b/src/Shared/nlog.config
@@ -24,7 +24,7 @@
 	</targets>
 
 	<rules>
-		<logger name="Microsoft.CST.OpenSource.*" minlevel="Info" maxLevel="Error" writeTo="consoleLog" ruleName="console"/>
-		<logger name="*" minlevel="Trace" writeTo="fileLog,detailedFileLog" ruleName="fileLog" />
+		<logger name="Microsoft.CST.OpenSource.*" minlevel="Info" maxLevel="Error" writeTo="consoleLog" ruleName="consoleLog"/>
+		<logger name="*" minlevel="Trace" writeTo="fileLog" ruleName="fileLog" />
 	</rules>
 </nlog>

--- a/src/oss-metadata/MetadataTool.cs
+++ b/src/oss-metadata/MetadataTool.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CST.OpenSource
                 }
             }
             [Option('s', "data-source", Required = false, Default="deps.dev", 
-                HelpText = "The data source to use (deps.dev, libraries.io)")]
+                HelpText = "The data source to use (deps.dev, libraries.io, or native)")]
             public string DataSource { get; set; } = "deps.dev";
             
             [Option('j', "jmes-path", Required = false, Default = null,
@@ -115,6 +115,8 @@ namespace Microsoft.CST.OpenSource
                     metadataSource = new DepsDevMetadataSource();
                 else if (options.DataSource.Equals("libraries.io", StringComparison.InvariantCultureIgnoreCase))
                     metadataSource = new LibrariesIoMetadataSource();
+                else if (options.DataSource.Equals("native", StringComparison.InvariantCultureIgnoreCase))
+                    metadataSource = new NativeMetadataSource();
                 else
                     throw new ArgumentException($"Unknown data source: {options.DataSource}");
 

--- a/src/oss-metadata/oss-metadata.csproj
+++ b/src/oss-metadata/oss-metadata.csproj
@@ -38,4 +38,8 @@
     <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="" />
     <None Include="..\..\icon-128.png" Pack="true" PackagePath="" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="JmesPath.Net" Version="1.0.182" />
+  </ItemGroup>
 </Project>

--- a/src/oss-reproducible/ReproducibleTool.cs
+++ b/src/oss-reproducible/ReproducibleTool.cs
@@ -162,7 +162,7 @@ namespace Microsoft.CST.OpenSource
                         {
                             if (bestScore.Key < 0.90)
                             {
-                                bestScore = KeyValuePair.Create(0.90, "Package was re-built from source, with no ignored {filesString}.");
+                                bestScore = KeyValuePair.Create(0.90, $"Package was re-built from source, with no ignored {filesString}.");
                             }
                         }
                         else
@@ -182,7 +182,7 @@ namespace Microsoft.CST.OpenSource
                         {
                             if (bestScore.Key < 0.90)
                             {
-                                bestScore = KeyValuePair.Create(0.90, "Package was re-built from source, with no ignored {filesString}.");
+                                bestScore = KeyValuePair.Create(0.90, $"Package was re-built from source, with no ignored {filesString}.");
                             }
                         }
                         else

--- a/src/oss-tests/MetadataTests.cs
+++ b/src/oss-tests/MetadataTests.cs
@@ -17,7 +17,6 @@ public class MetadataTests
     [DataTestMethod]
     [DataRow("deps.dev", "pkg:npm/left-pad", "package.name", "left-pad")]
     [DataRow("deps.dev", "pkg:npm/left-pad@1.3.0", "package.name", "left-pad")]
-    [DataRow("libraries.io", "pkg:npm/left-pad", "name", "left-pad")]
     [DataRow("libraries.io", "pkg:npm/left-pad@1.3.0", "name", "left-pad")]
     public async Task Check_Metadata(string dataSource, string purlString, string jmesPathExpr, string targetResult)
     {

--- a/src/oss-tests/MetadataTests.cs
+++ b/src/oss-tests/MetadataTests.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+namespace Microsoft.CST.OpenSource.Tests;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using System.Threading.Tasks;
+using DevLab.JmesPath;
+using Microsoft.CST.OpenSource;
+using PackageUrl;
+using System;
+using System.Text.Json;
+
+[TestClass]
+public class MetadataTests
+{
+    [DataTestMethod]
+    [DataRow("deps.dev", "pkg:npm/left-pad", "package.name", "left-pad")]
+    [DataRow("deps.dev", "pkg:npm/left-pad@1.3.0", "package.name", "left-pad")]
+    [DataRow("libraries.io", "pkg:npm/left-pad", "name", "left-pad")]
+    [DataRow("libraries.io", "pkg:npm/left-pad@1.3.0", "name", "left-pad")]
+    public async Task Check_Metadata(string dataSource, string purlString, string jmesPathExpr, string targetResult)
+    {
+        BaseMetadataSource? metadataSource = null;
+        if (string.Equals(dataSource, "deps.dev", StringComparison.InvariantCultureIgnoreCase))
+            metadataSource = new DepsDevMetadataSource();
+        else if (string.Equals(dataSource, "libraries.io", StringComparison.InvariantCultureIgnoreCase))
+            metadataSource = new LibrariesIoMetadataSource();
+        else
+            Assert.Fail("Unknown data source: " + dataSource);
+
+        PackageURL purl = new(purlString);
+        JsonDocument? metadata = await metadataSource.GetMetadataForPackageUrlAsync(purl, false);
+        if (metadata == null)
+            Assert.Fail("Unable to load metadata for package: {}", purlString);
+        
+        var jmesPath = new JmesPath();
+        var result = jmesPath.Transform(System.Text.Json.JsonSerializer.Serialize(metadata), jmesPathExpr);
+        if (result == null)
+            Assert.Fail("Unable to evaluate JMESPath expression: {}", jmesPathExpr);
+        
+        var resultString = result.ToString().Trim('"');
+        Assert.AreEqual(targetResult, resultString);
+    }
+}

--- a/src/oss-tests/oss-tests.csproj
+++ b/src/oss-tests/oss-tests.csproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="JmesPath.Net" Version="1.0.182" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
@@ -33,6 +34,7 @@
     <ProjectReference Include="..\oss-find-source\oss-find-source.csproj" />
     <ProjectReference Include="..\oss-find-squats\oss-find-squats.csproj" />
     <ProjectReference Include="..\oss-health\oss-health.csproj" />
+     <ProjectReference Include="..\oss-metadata\oss-metadata.csproj" />
     <ProjectReference Include="..\oss-reproducible\oss-reproducible.csproj" />
     <ProjectReference Include="..\Shared\Shared.Lib.csproj" />
     <ProjectReference Include="..\Shared.CLI\Shared.CLI.csproj" />


### PR DESCRIPTION
Fixes #335 

This PR adds support for querying the deps.dev API (unauthenticated) and libraries.io (unauthenticated or authenticated via a user-supplied API token). The results are serialized (JSON) and written to the console.