### PR TITLE
Fix broken formatting for oss-reproducible.

### DIFF
--- a/src/oss-reproducible/ReproducibleTool.cs
+++ b/src/oss-reproducible/ReproducibleTool.cs
@@ -162,7 +162,7 @@ namespace Microsoft.CST.OpenSource
                         {
                             if (bestScore.Key < 0.90)
                             {
-                                bestScore = KeyValuePair.Create(0.90, "Package was re-built from source, with no ignored {filesString}.");
+                                bestScore = KeyValuePair.Create(0.90, $"Package was re-built from source, with no ignored {filesString}.");
                             }
                         }
                         else
@@ -182,7 +182,7 @@ namespace Microsoft.CST.OpenSource
                         {
                             if (bestScore.Key < 0.90)
                             {
-                                bestScore = KeyValuePair.Create(0.90, "Package was re-built from source, with no ignored {filesString}.");
+                                bestScore = KeyValuePair.Create(0.90, $"Package was re-built from source, with no ignored {filesString}.");
                             }
                         }
                         else


### PR DESCRIPTION
I missed a $-prefix on a few output lines, so the literal `{filesString}` was being shown instead of the content.