### PR TITLE
Check additional fields in PyPI metadata for source repo.

### DIFF
--- a/src/Shared/PackageManagers/PyPIProjectManager.cs
+++ b/src/Shared/PackageManagers/PyPIProjectManager.cs
@@ -400,7 +400,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             JsonDocument contentJSON = JsonDocument.Parse(metadata);
 
             List<string> possibleProperties = new() { "homepage", "home_page" };
-            List<string> searchPropertiesProjectURLs = new() { "Source", "Source Code", "homepage", "Bug Tracker" };
+            List<string> searchPropertiesProjectURLs = new() { "Source", "Source Code", "homepage", "Bug Tracker", "Repository", "Bug Reports" };
 
             JsonElement infoJSON;
             try

--- a/src/oss-tests/FindSourceTests.cs
+++ b/src/oss-tests/FindSourceTests.cs
@@ -90,6 +90,7 @@ namespace Microsoft.CST.OpenSource.Tests
         [DataRow("pkg:pypi/moment", "pkg:github/zachwill/moment")]
         [DataRow("pkg:nuget/Newtonsoft.Json", "pkg:github/jamesnk/newtonsoft.json")]
         [DataRow("pkg:pypi/django", "pkg:github/django/django")]
+        [DataRow("pkg:pypi/pylint", "pkg:github/pycqa/pylint")]
         public async Task FindSource_Success(string purl, string targetResult)
         {
             // for initialization

--- a/src/oss-tests/FindSourceTests.cs
+++ b/src/oss-tests/FindSourceTests.cs
@@ -91,6 +91,7 @@ namespace Microsoft.CST.OpenSource.Tests
         [DataRow("pkg:nuget/Newtonsoft.Json", "pkg:github/jamesnk/newtonsoft.json")]
         [DataRow("pkg:pypi/django", "pkg:github/django/django")]
         [DataRow("pkg:pypi/pylint", "pkg:github/pycqa/pylint")]
+        [DataRow("pkg:pypi/arrow", "pkg:github/arrow-py/arrow")]
         public async Task FindSource_Success(string purl, string targetResult)
         {
             // for initialization


### PR DESCRIPTION
This PR updates the logic to identify source repos within PyPI. Instead of just checking for "project_urls.source", we have a list of keys and look through each one.

It's necessary because prior versions failed on pypi/jslint.