### PR TITLE
Fix issues with EnumerateVersionsAsync not handling 404s

### DIFF
--- a/src/Shared/Contracts/IPackageExistence.cs
+++ b/src/Shared/Contracts/IPackageExistence.cs
@@ -2,9 +2,6 @@
 
 namespace Microsoft.CST.OpenSource.Contracts;
 
-using Model.Enums;
-using System.Collections.Generic;
-
 /// <summary>
 /// An interface representing the existence of a package/version.
 /// </summary>

--- a/src/Shared/Model/PackageExistence/PackageExistence.cs
+++ b/src/Shared/Model/PackageExistence/PackageExistence.cs
@@ -4,7 +4,10 @@ namespace Microsoft.CST.OpenSource.Model.PackageExistence;
 
 using Contracts;
 using Enums;
+using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 
 /// <summary>
 /// Represents a package that currently exists.
@@ -31,4 +34,17 @@ public record PackageNotFound : IPackageExistence
 public record PackageRemoved(IReadOnlySet<PackageRemovalReason> RemovalReasons) : PackageNotFound
 {
     public override bool HasEverExisted => true;
+
+    protected override bool PrintMembers(StringBuilder stringBuilder)
+    {
+        if (base.PrintMembers(stringBuilder))
+        {
+            stringBuilder.Append(", ");
+        }
+
+        string reasons = string.Join(',', this.RemovalReasons.Select(r => r.ToString()));
+
+        stringBuilder.Append($"RemovalReasons = [{reasons}]");
+        return true;
+    }
 }

--- a/src/Shared/Model/PackageExistence/PackageVersionExistence.cs
+++ b/src/Shared/Model/PackageExistence/PackageVersionExistence.cs
@@ -5,6 +5,8 @@ namespace Microsoft.CST.OpenSource.Model.PackageExistence;
 using Contracts;
 using Enums;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 
 /// <summary>
 /// Represents a package version that currently exists.
@@ -31,4 +33,17 @@ public record PackageVersionNotFound : IPackageExistence
 public record PackageVersionRemoved(IReadOnlySet<PackageVersionRemovalReason> RemovalReasons) : PackageVersionNotFound
 {
     public override bool HasEverExisted => true;
+    
+    protected override bool PrintMembers(StringBuilder stringBuilder)
+    {
+        if (base.PrintMembers(stringBuilder))
+        {
+            stringBuilder.Append(", ");
+        }
+
+        string reasons = string.Join(',', this.RemovalReasons.Select(r => r.ToString()));
+
+        stringBuilder.Append($"RemovalReasons = [{reasons}]");
+        return true;
+    }
 }

--- a/src/Shared/PackageManagers/CPANProjectManager.cs
+++ b/src/Shared/PackageManagers/CPANProjectManager.cs
@@ -9,6 +9,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Net;
     using System.Net.Http;
     using System.Text.RegularExpressions;
     using System.Threading.Tasks;
@@ -177,6 +178,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
                 IEnumerable<string> result = SortVersions(versionList.Distinct());
                 return result;
+            }
+            catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+            {
+                Logger.Debug("Unable to enumerate versions (404): {0}", ex.Message);
+                return Array.Empty<string>();
             }
             catch (Exception ex)
             {

--- a/src/Shared/PackageManagers/CRANProjectManager.cs
+++ b/src/Shared/PackageManagers/CRANProjectManager.cs
@@ -9,6 +9,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Net;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -168,6 +169,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                     }
                 }
                 return SortVersions(versionList.Distinct());
+            }
+            catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+            {
+                Logger.Debug("Unable to enumerate versions (404): {0}", ex.Message);
+                return Array.Empty<string>();
             }
             catch (Exception ex)
             {

--- a/src/Shared/PackageManagers/CargoProjectManager.cs
+++ b/src/Shared/PackageManagers/CargoProjectManager.cs
@@ -10,6 +10,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Net;
     using System.Net.Http;
     using System.Text.Json;
     using System.Threading.Tasks;
@@ -140,6 +141,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                     }
                 }
                 return SortVersions(versionList.Distinct());
+            }
+            catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+            {
+                Logger.Debug("Unable to enumerate versions (404): {0}", ex.Message);
+                return Array.Empty<string>();
             }
             catch (Exception ex)
             {

--- a/src/Shared/PackageManagers/CocoapodsProjectManager.cs
+++ b/src/Shared/PackageManagers/CocoapodsProjectManager.cs
@@ -10,6 +10,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Net;
     using System.Net.Http;
     using System.Security.Cryptography;
     using System.Text;
@@ -170,6 +171,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                     versionList.Add(navItem.TextContent);
                 }
                 return SortVersions(versionList.Distinct());
+            }
+            catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+            {
+                Logger.Debug("Unable to enumerate versions (404): {0}", ex.Message);
+                return Array.Empty<string>();
             }
             catch (Exception ex)
             {

--- a/src/Shared/PackageManagers/ComposerProjectManager.cs
+++ b/src/Shared/PackageManagers/ComposerProjectManager.cs
@@ -8,6 +8,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Net;
     using System.Net.Http;
     using System.Threading.Tasks;
     using Utilities;
@@ -154,6 +155,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                     }
                 }
                 return SortVersions(versionList.Distinct());
+            }
+            catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+            {
+                Logger.Debug("Unable to enumerate versions (404): {0}", ex.Message);
+                return Array.Empty<string>();
             }
             catch (Exception ex)
             {

--- a/src/Shared/PackageManagers/GemProjectManager.cs
+++ b/src/Shared/PackageManagers/GemProjectManager.cs
@@ -8,6 +8,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Net;
     using System.Net.Http;
     using System.Text.Json;
     using System.Text.RegularExpressions;
@@ -133,6 +134,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                     }
                 }
                 return SortVersions(versionList.Distinct());
+            }
+            catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+            {
+                Logger.Debug("Unable to enumerate versions (404): {0}", ex.Message);
+                return Array.Empty<string>();
             }
             catch (Exception ex)
             {

--- a/src/Shared/PackageManagers/GitHubProjectManager.cs
+++ b/src/Shared/PackageManagers/GitHubProjectManager.cs
@@ -9,6 +9,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
     using System.Diagnostics;
     using System.IO;
     using System.Linq;
+    using System.Net;
     using System.Net.Http;
     using System.Text.RegularExpressions;
     using System.Threading.Tasks;
@@ -226,6 +227,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                     Logger.Warn("Unable to run 'git'. Is it installed?");
                 }
                 return SortVersions(versionList);
+            }
+            catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+            {
+                Logger.Debug("Unable to enumerate versions (404): {0}", ex.Message);
+                return Array.Empty<string>();
             }
             catch (Exception ex)
             {

--- a/src/Shared/PackageManagers/GolangProjectManager.cs
+++ b/src/Shared/PackageManagers/GolangProjectManager.cs
@@ -8,6 +8,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Net;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -139,6 +140,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                     throw new Exception("Invalid response from Go Proxy.");
                 }
                 return SortVersions(versionList.Distinct());
+            }
+            catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+            {
+                Logger.Debug("Unable to enumerate versions (404): {0}", ex.Message);
+                return Array.Empty<string>();
             }
             catch (Exception ex)
             {

--- a/src/Shared/PackageManagers/HackageProjectManager.cs
+++ b/src/Shared/PackageManagers/HackageProjectManager.cs
@@ -9,6 +9,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Net;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -124,6 +125,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                 }
 
                 return SortVersions(versionList.Distinct());
+            }
+            catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+            {
+                Logger.Debug("Unable to enumerate versions (404): {0}", ex.Message);
+                return Array.Empty<string>();
             }
             catch (Exception ex)
             {

--- a/src/Shared/PackageManagers/MavenProjectManager.cs
+++ b/src/Shared/PackageManagers/MavenProjectManager.cs
@@ -8,6 +8,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Net;
     using System.Net.Http;
     using System.Threading.Tasks;
     using System.Xml;
@@ -139,6 +140,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                     }
                 }
                 return SortVersions(versionList.Distinct());
+            }
+            catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+            {
+                Logger.Debug("Unable to enumerate versions (404): {0}", ex.Message);
+                return Array.Empty<string>();
             }
             catch (Exception ex)
             {

--- a/src/Shared/PackageManagers/NPMProjectManager.cs
+++ b/src/Shared/PackageManagers/NPMProjectManager.cs
@@ -14,6 +14,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Net;
     using System.Net.Http;
     using System.Text.Json;
     using System.Threading.Tasks;
@@ -174,6 +175,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                 sortedList.Insert(0, latestVersion);
 
                 return sortedList;
+            }
+            catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+            {
+                Logger.Debug("Unable to enumerate versions (404): {0}", ex.Message);
+                return Array.Empty<string>();
             }
             catch (Exception ex)
             {

--- a/src/Shared/PackageManagers/NPMProjectManager.cs
+++ b/src/Shared/PackageManagers/NPMProjectManager.cs
@@ -544,6 +544,12 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
             JsonDocument contentJSON = JsonDocument.Parse(content);
             JsonElement root = contentJSON.RootElement;
+
+            // Check to make sure that the package version ever existed.
+            if (!PackageVersionEverExisted(purl, root))
+            {
+                return new PackageVersionNotFound();
+            }
             
             HashSet<PackageVersionRemovalReason> removalReasons = new();
 
@@ -622,7 +628,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         }
         
         /// <summary>
-        /// Check to see if the package only has a NPM security holding package.
+        /// Check to see if the package has a NPM security holding package.
         /// </summary>
         /// <param name="root">The <see cref="JsonElement"/> root content of the metadata.</param>
         /// <returns>True if this package is a NPM security holding package. False otherwise.</returns>
@@ -632,6 +638,35 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             return time.EnumerateObject().Any(timeEntry => timeEntry.Name == NPM_SECURITY_HOLDING_VERSION);
         }
         
+        /// <summary>
+        /// Check to see if the package version ever existed.
+        /// </summary>
+        /// <param name="purl">The <see cref="PackageURL"/> to check.</param>
+        /// <param name="root">The <see cref="JsonElement"/> root content of the metadata.</param>
+        /// <returns>True if this package version ever existed. False otherwise.</returns>
+        internal virtual bool PackageVersionEverExisted(PackageURL purl, JsonElement root)
+        {
+            // Did this version ever exist? Start with assuming not.
+            bool everExisted = false;
+
+            JsonElement time = root.GetProperty("time");
+            
+            // Check the unpublished property in time if it exists for the purl's version.
+            if (time.TryGetProperty("unpublished", out JsonElement unpublishedElement))
+            {
+                List<string>? versions = OssUtilities.ConvertJSONToList(OssUtilities.GetJSONPropertyIfExists(unpublishedElement, "versions"));
+                everExisted = versions?.Contains(purl.Version) ?? false;
+            }
+
+            // If the version wasn't in unpublished, then check if any of the versions in time match.
+            if (!everExisted)
+            {
+                everExisted = time.EnumerateObject().Any(timeEntry => timeEntry.Name == purl.Version);
+            }
+
+            return everExisted;
+        }
+
         /// <summary>
         /// Searches the package manager metadata to figure out the source code repository
         /// </summary>

--- a/src/Shared/PackageManagers/PyPIProjectManager.cs
+++ b/src/Shared/PackageManagers/PyPIProjectManager.cs
@@ -12,6 +12,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Net;
     using System.Net.Http;
     using System.Text.Json;
     using System.Threading.Tasks;
@@ -179,6 +180,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                 }
 
                 return SortVersions(versionList.Distinct());
+            }
+            catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+            {
+                Logger.Debug("Unable to enumerate versions (404): {0}", ex.Message);
+                return Array.Empty<string>();
             }
             catch (Exception ex)
             {

--- a/src/Shared/PackageManagers/UbuntuProjectManager.cs
+++ b/src/Shared/PackageManagers/UbuntuProjectManager.cs
@@ -9,6 +9,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Net;
     using System.Net.Http;
     using System.Text;
     using System.Text.RegularExpressions;
@@ -244,6 +245,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                             }
                         }
                     }
+                }
+                catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+                {
+                    Logger.Debug("Unable to enumerate versions (404): {0}", ex.Message);
+                    return Array.Empty<string>();
                 }
                 catch (Exception ex)
                 {

--- a/src/Shared/PackageManagers/VSMProjectManager.cs
+++ b/src/Shared/PackageManagers/VSMProjectManager.cs
@@ -9,6 +9,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Net;
     using System.Net.Http;
     using System.Text;
     using System.Text.Json;
@@ -247,6 +248,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                 }
 
                 return SortVersions(versionList.Distinct());
+            }
+            catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+            {
+                Logger.Debug("Unable to enumerate versions (404): {0}", ex.Message);
+                return Array.Empty<string>();
             }
             catch (Exception ex)
             {

--- a/src/oss-tests/ProjectManagerTests/NuGetProjectManagerTests.cs
+++ b/src/oss-tests/ProjectManagerTests/NuGetProjectManagerTests.cs
@@ -122,6 +122,67 @@ namespace Microsoft.CST.OpenSource.Tests.ProjectManagerTests
             Assert.AreEqual(count, versions.Count);
             Assert.AreEqual(latestVersion, versions.First());
         }
+        
+        [DataTestMethod]
+        [DataRow("pkg:nuget/razorengine@4.2.3-beta1", true)]
+        [DataRow("pkg:nuget/razorengine", true)]
+        public async Task DetailedPackageExistsAsync_ExistsSucceeds(string purlString, bool exists)
+        {
+            PackageURL purl = new(purlString);
+
+            IManagerPackageActions<NuGetPackageVersionMetadata>? nugetPackageActions = PackageActionsHelper<NuGetPackageVersionMetadata>.SetupPackageActions(
+                purl,
+                JsonConvert.DeserializeObject<NuGetPackageVersionMetadata>(_metadata[purl.ToString()]),
+                JsonConvert.DeserializeObject<IEnumerable<string>>(_versions[purl.ToString()])?.Reverse());
+            _projectManager = new NuGetProjectManager(".", nugetPackageActions, _httpFactory);
+
+            IPackageExistence existence = await _projectManager.DetailedPackageExistsAsync(purl, useCache: false);
+
+            Assert.AreEqual(exists, existence.Exists);
+        }
+        
+        [TestMethod]
+        public async Task DetailedPackageExistsAsync_NotFoundSucceeds()
+        {
+            PackageURL purl = new("pkg:nuget/notarealpackage");
+
+            IManagerPackageActions<NuGetPackageVersionMetadata>? nugetPackageActions = PackageActionsHelper<NuGetPackageVersionMetadata>.SetupPackageActions();
+
+            _projectManager = new NuGetProjectManager(".", nugetPackageActions, _httpFactory);
+
+            IPackageExistence existence = await _projectManager.DetailedPackageExistsAsync(purl, useCache: false);
+
+            Assert.IsFalse(existence.Exists);
+        }
+
+        [TestMethod]
+        public async Task DetailedPackageVersionExistsAsync_ExistsSucceeds()
+        {
+            PackageURL purl = new("pkg:nuget/razorengine@4.2.3-beta1");
+
+            IManagerPackageActions<NuGetPackageVersionMetadata>? nugetPackageActions = PackageActionsHelper<NuGetPackageVersionMetadata>.SetupPackageActions(
+                purl,
+                JsonConvert.DeserializeObject<NuGetPackageVersionMetadata>(_metadata[purl.ToString()]),
+                JsonConvert.DeserializeObject<IEnumerable<string>>(_versions[purl.ToString()])?.Reverse());
+            _projectManager = new NuGetProjectManager(".", nugetPackageActions, _httpFactory);
+
+            IPackageExistence existence = await _projectManager.DetailedPackageVersionExistsAsync(purl, useCache: false);
+
+            Assert.IsTrue(existence.Exists);
+        }
+        
+        [TestMethod]
+        public async Task DetailedPackageVersionExistsAsync_NotFoundSucceeds()
+        {
+            PackageURL purl = new("pkg:nuget/notarealpackage@0.0.0");
+
+            IManagerPackageActions<NuGetPackageVersionMetadata>? nugetPackageActions = PackageActionsHelper<NuGetPackageVersionMetadata>.SetupPackageActions();
+            _projectManager = new NuGetProjectManager(".", nugetPackageActions, _httpFactory);
+
+            IPackageExistence existence = await _projectManager.DetailedPackageVersionExistsAsync(purl, useCache: false);
+
+            Assert.IsFalse(existence.Exists);
+        }
 
         [DataTestMethod]
         [DataRow("pkg:nuget/razorengine@4.2.3-beta1", "2015-10-06T17:53:46.37+00:00")]

--- a/src/oss-tests/ProjectManagerTests/PyPIProjectManagerTests.cs
+++ b/src/oss-tests/ProjectManagerTests/PyPIProjectManagerTests.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.CST.OpenSource.Tests.ProjectManagerTests
 {
+    using Contracts;
     using Model;
     using Moq;
     using oss;
@@ -95,6 +96,32 @@ namespace Microsoft.CST.OpenSource.Tests.ProjectManagerTests
             Assert.AreEqual(latestVersion, versions.First());
         }
         
+        [DataTestMethod]
+        [DataRow("pkg:pypi/pandas", true)]
+        [DataRow("pkg:pypi/plotly@3.7.1", true)]
+        [DataRow("pkg:pypi/notarealpackage", false)]
+        public async Task DetailedPackageExistsAsync_WorksAsExpected(string purlString, bool exists)
+        {
+            PackageURL purl = new(purlString);
+            IPackageExistence existence = await _projectManager.DetailedPackageExistsAsync(purl, useCache: false);
+
+            Assert.AreEqual(exists, existence.Exists);
+        }
+
+        [DataTestMethod]
+        [DataRow("pkg:pypi/pandas@1.4.2", true)]
+        [DataRow("pkg:pypi/pandas@12.34.56.78", false)]
+        [DataRow("pkg:pypi/plotly@3.7.1", true)]
+        [DataRow("pkg:pypi/requests@2.27.1", true)]
+        [DataRow("pkg:pypi/notarealpackage@0.0.0", false)]
+        public async Task DetailedPackageVersionExistsAsync_WorksAsExpected(string purlString, bool exists)
+        {
+            PackageURL purl = new(purlString);
+            IPackageExistence existence = await _projectManager.DetailedPackageVersionExistsAsync(purl, useCache: false);
+
+            Assert.AreEqual(exists, existence.Exists);
+        }
+
         [DataTestMethod]
         [DataRow("pkg:pypi/pandas@1.4.2", "https://pypi.org/packages/source/p/pandas/pandas-1.4.2.tar.gz")]
         [DataRow("pkg:pypi/plotly@5.7.0", "https://pypi.org/packages/source/p/plotly/plotly-5.7.0.tar.gz")]


### PR DESCRIPTION
I noticed when implementing version 0.1.346 of OSSGadget that our unit tests for package versions that don't exist would fail, as 
`var packageVersionExistence = await projectManager.DetailedPackageVersionExistsAsync(purl);` would throw an `HttpRequestException` where the `StatusCode` is `HttpStatusCode.NotFound`.
I would expect this case to return a `PackageVersionNotFound` instance of `IPackageExistence` instead of throwing a 404.

This PR adds:
``` cs
catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
{
    Logger.Debug("Unable to enumerate versions (404): {0}", ex.Message);
    return Array.Empty<string>();
}
```
to each `ProjectManager`'s implementation of `EnumerateVersionsAsync`.