### PR TITLE
Remove HasEverExisted and WasRemoved flags from IPackageExistence

### DIFF
--- a/src/Shared/Contracts/IPackageExistence.cs
+++ b/src/Shared/Contracts/IPackageExistence.cs
@@ -11,15 +11,4 @@ public interface IPackageExistence
     /// Gets if the package/version currently exists.
     /// </summary>
     bool Exists { get; }
-
-    /// <summary>
-    /// Gets if the package/version had existed at one point.
-    /// </summary>
-    bool HasEverExisted { get; }
-
-    /// <summary>
-    /// Gets if the package/version was removed.
-    /// So if it doesn't exist now, but at one point did exist.
-    /// </summary>
-    bool WasRemoved => !this.Exists && this.HasEverExisted;
 }

--- a/src/Shared/Model/PackageExistence/PackageExistence.cs
+++ b/src/Shared/Model/PackageExistence/PackageExistence.cs
@@ -4,7 +4,6 @@ namespace Microsoft.CST.OpenSource.Model.PackageExistence;
 
 using Contracts;
 using Enums;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -15,7 +14,6 @@ using System.Text;
 public record PackageExists : IPackageExistence
 {
     public bool Exists => true;
-    public bool HasEverExisted => true;
 }
 
 /// <summary>
@@ -24,7 +22,6 @@ public record PackageExists : IPackageExistence
 public record PackageNotFound : IPackageExistence
 {
     public bool Exists => false;
-    public virtual bool HasEverExisted => false;
 }
 
 /// <summary>
@@ -33,7 +30,6 @@ public record PackageNotFound : IPackageExistence
 /// <param name="RemovalReasons">The reasons (if any) for why a package was removed.</param>
 public record PackageRemoved(IReadOnlySet<PackageRemovalReason> RemovalReasons) : PackageNotFound
 {
-    public override bool HasEverExisted => true;
 
     protected override bool PrintMembers(StringBuilder stringBuilder)
     {

--- a/src/Shared/Model/PackageExistence/PackageVersionExistence.cs
+++ b/src/Shared/Model/PackageExistence/PackageVersionExistence.cs
@@ -14,7 +14,6 @@ using System.Text;
 public record PackageVersionExists : IPackageExistence
 {
     public bool Exists => true;
-    public bool HasEverExisted => true;
 }
 
 /// <summary>
@@ -23,7 +22,6 @@ public record PackageVersionExists : IPackageExistence
 public record PackageVersionNotFound : IPackageExistence
 {
     public bool Exists => false;
-    public virtual bool HasEverExisted => false;
 }
 
 /// <summary>
@@ -32,8 +30,6 @@ public record PackageVersionNotFound : IPackageExistence
 /// <param name="RemovalReasons">The reasons (if any) for why a package was removed.</param>
 public record PackageVersionRemoved(IReadOnlySet<PackageVersionRemovalReason> RemovalReasons) : PackageVersionNotFound
 {
-    public override bool HasEverExisted => true;
-    
     protected override bool PrintMembers(StringBuilder stringBuilder)
     {
         if (base.PrintMembers(stringBuilder))

--- a/src/oss-tests/PackageExistenceTests.cs
+++ b/src/oss-tests/PackageExistenceTests.cs
@@ -24,9 +24,9 @@ public class PackageExistenceTests
         }));
 
         packageExistenceRemoved.Should().BeAssignableTo<PackageNotFound>()
-            .Subject.HasEverExisted.Should().BeTrue();
+            .Subject.Exists.Should().Be(false);
 
-        packageExistenceRemoved.HasEverExisted.Should().BeTrue();
+        packageExistenceRemoved.Exists.Should().Be(false);
         
         if (packageExistenceRemoved is not PackageNotFound)
         {
@@ -46,13 +46,21 @@ public class PackageExistenceTests
         }));
 
         packageVersionExistenceRemoved.Should().BeAssignableTo<PackageVersionNotFound>()
-            .Subject.HasEverExisted.Should().BeTrue();
+            .Subject.Exists.Should().Be(false);
 
-        packageVersionExistenceRemoved.HasEverExisted.Should().BeTrue();
+        packageVersionExistenceRemoved.Exists.Should().Be(false);
 
         if (packageVersionExistenceRemoved is not PackageVersionNotFound)
         {
             Assert.Fail();
         }
+    }
+    
+    [TestMethod]
+    public void PackageExistence_NotFound()
+    {
+        IPackageExistence packageExistenceRemoved = new PackageNotFound();
+
+        packageExistenceRemoved.Exists.Should().Be(false);
     }
 }

--- a/src/oss-tests/ProjectManagerTests/NPMProjectManagerTests.cs
+++ b/src/oss-tests/ProjectManagerTests/NPMProjectManagerTests.cs
@@ -184,7 +184,7 @@ namespace Microsoft.CST.OpenSource.Tests.ProjectManagerTests
             bool versionPulled = _packageVersionExistence[key].versionPulled;
             bool consideredMalicious = _packageVersionExistence[key].consideredMalicious;
             
-            if (!expectedPackageVersionExistence.HasEverExisted)
+            if (!expectedPackageVersionExistence.Exists)
             {
                 _projectManager
                     .Setup(p => 
@@ -225,7 +225,7 @@ namespace Microsoft.CST.OpenSource.Tests.ProjectManagerTests
             bool pulled = _packageExistence[key].pulled;
             bool consideredMalicious = _packageExistence[key].consideredMalicious;
 
-            if (!expectedPackageExistence.HasEverExisted)
+            if (!expectedPackageExistence.Exists)
             {
                 _projectManager
                     .Setup(p => 


### PR DESCRIPTION
Remove HasEverExisted and WasRemoved flags from IPackageExistence as we can't be sure those values are correct as the registries aren't 100% immutable. We can't guarantee that HasEverExisted would be correct in those cases.

ex: this package [@softvisio/webview](https://registry.npmjs.org/@softvisio/webview) did exist, but now 404s.