### PR TITLE
Nuget package versions are case insensitive

### DIFF
--- a/src/Shared.CLI/Shared.CLI.csproj
+++ b/src/Shared.CLI/Shared.CLI.csproj
@@ -49,7 +49,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.0" />
     <PackageReference Include="NLog" Version="4.7.13" />
     <PackageReference Include="NLog.Schema" Version="4.7.13" />
-    <PackageReference Include="NuGet.Versioning" Version="6.1.0" />
+    <PackageReference Include="NuGet.Versioning" Version="6.2.2" />
     <PackageReference Include="Octokit" Version="0.50.0" />
     <PackageReference Include="Sarif.Sdk" Version="2.4.12" />
     <PackageReference Include="SemanticVersioning" Version="2.0.0" />

--- a/src/Shared/PackageActions/NuGetPackageActions.cs
+++ b/src/Shared/PackageActions/NuGetPackageActions.cs
@@ -86,7 +86,7 @@ public class NuGetPackageActions : IManagerPackageActions<NuGetPackageVersionMet
         {
             bool exists = await resource.DoesPackageExistAsync(
                 packageUrl.Name,
-                NuGetVersion.Parse(packageUrl.Version.ToLowerInvariant()),
+                NuGetVersion.Parse(packageUrl.Version),
                 _sourceCacheContext,
                 _logger, 
                 cancellationToken);

--- a/src/Shared/PackageActions/NuGetPackageActions.cs
+++ b/src/Shared/PackageActions/NuGetPackageActions.cs
@@ -86,7 +86,7 @@ public class NuGetPackageActions : IManagerPackageActions<NuGetPackageVersionMet
         {
             bool exists = await resource.DoesPackageExistAsync(
                 packageUrl.Name,
-                NuGetVersion.Parse(packageUrl.Version),
+                NuGetVersion.Parse(packageUrl.Version.ToLowerInvariant()),
                 _sourceCacheContext,
                 _logger, 
                 cancellationToken);

--- a/src/Shared/PackageManagers/NuGetProjectManager.cs
+++ b/src/Shared/PackageManagers/NuGetProjectManager.cs
@@ -183,8 +183,8 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                                     throw new InvalidOperationException($"Can't find the latest version of {purl}");;
 
             // Construct a new PackageURL that's guaranteed to have a version, the latest version is used if no version was provided.
-            string guaranteedVersion = !string.IsNullOrWhiteSpace(purl.Version) ? purl.Version.ToLowerInvariant() : latestVersion;
-            PackageURL purlWithVersion = new PackageURL(purl.Type, purl.Namespace, purl.Name, guaranteedVersion, purl.Qualifiers, purl.Subpath);
+            PackageURL purlWithVersion = !string.IsNullOrWhiteSpace(purl.Version) ?
+                purl : new PackageURL(purl.Type, purl.Namespace, purl.Name, latestVersion, purl.Qualifiers, purl.Subpath);
 
             NuGetPackageVersionMetadata? packageVersionMetadata =
                 await Actions.GetMetadataAsync(purlWithVersion, useCache: useCache);
@@ -231,8 +231,8 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             }
 
             // NuGet packages are case insensitive. Convert purl to lowercase before comparing against package versions list. 
-            var versionLowercase = purl.Version.ToLowerInvariant();
-            return (await EnumerateVersionsAsync(purl, useCache)).Contains(versionLowercase);
+            StringComparer invICCmp = StringComparer.InvariantCultureIgnoreCase;
+            return (await EnumerateVersionsAsync(purl, useCache)).Contains(purl.Version, invICCmp);
         }
     
         /// <summary>

--- a/src/Shared/PackageManagers/NuGetProjectManager.cs
+++ b/src/Shared/PackageManagers/NuGetProjectManager.cs
@@ -232,8 +232,8 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         /// Updates the package version specific values in <see cref="PackageMetadata"/>.
         /// </summary>
         /// <param name="metadata">The <see cref="PackageMetadata"/> object to update with the values for this version.</param>
-        /// <param name="packageVersionPackageVersionMetadata">The <see cref="NuGetPackageVersionMetadata"/> representing this version.</param>
-        private async Task UpdateVersionMetadata(PackageMetadata metadata, NuGetPackageVersionMetadata packageVersionPackageVersionMetadata)
+        /// <param name="packageVersionMetadata">The <see cref="NuGetPackageVersionMetadata"/> representing this version.</param>
+        private async Task UpdateVersionMetadata(PackageMetadata metadata, NuGetPackageVersionMetadata packageVersionMetadata)
         {
             if (metadata.PackageVersion is null)
             {
@@ -241,45 +241,45 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             }
 
             // Set the version specific URI values.
-            metadata.VersionUri = $"{metadata.PackageManagerUri}/packages/{packageVersionPackageVersionMetadata.Name}/{metadata.PackageVersion}";
-            metadata.ApiVersionUri = packageVersionPackageVersionMetadata.CatalogUri.ToString();
+            metadata.VersionUri = $"{metadata.PackageManagerUri}/packages/{packageVersionMetadata.Name}/{metadata.PackageVersion}";
+            metadata.ApiVersionUri = packageVersionMetadata.CatalogUri.ToString();
             
             // Construct the artifact contents url.
-            metadata.VersionDownloadUri = GetNupkgUrl(packageVersionPackageVersionMetadata.Name, metadata.PackageVersion);
+            metadata.VersionDownloadUri = GetNupkgUrl(packageVersionMetadata.Name, metadata.PackageVersion);
 
             // TODO: size and hash
 
             // Homepage url
-            metadata.Homepage = packageVersionPackageVersionMetadata.ProjectUrl?.ToString();
+            metadata.Homepage = packageVersionMetadata.ProjectUrl?.ToString();
 
             // Authors and Maintainers
-            UpdateMetadataAuthorsAndMaintainers(metadata, packageVersionPackageVersionMetadata);
+            UpdateMetadataAuthorsAndMaintainers(metadata, packageVersionMetadata);
 
             // Repository
             await UpdateMetadataRepository(metadata);
 
             // Dependencies
-            IList<PackageDependencyGroup> dependencyGroups = packageVersionPackageVersionMetadata.DependencySets.ToList();
+            IList<PackageDependencyGroup> dependencyGroups = packageVersionMetadata.DependencySets.ToList();
             metadata.Dependencies ??= dependencyGroups.SelectMany(group => group.Packages, (dependencyGroup, package) => new { dependencyGroup, package})
                 .Select(dependencyGroupAndPackage => new Dependency() { Package = dependencyGroupAndPackage.package.ToString(), Framework = dependencyGroupAndPackage.dependencyGroup.TargetFramework?.ToString()})
                 .ToList();
 
             // Keywords
-            metadata.Keywords = new List<string>(packageVersionPackageVersionMetadata.Tags.Split(", "));
+            metadata.Keywords = new List<string>(packageVersionMetadata.Tags.Split(", "));
 
             // Licenses
-            if (packageVersionPackageVersionMetadata.LicenseMetadata is not null)
+            if (packageVersionMetadata.LicenseMetadata is not null)
             {
                 metadata.Licenses ??= new List<License>();
                 metadata.Licenses.Add(new License()
                 {
-                    Name = packageVersionPackageVersionMetadata.LicenseMetadata.License,
-                    Url = packageVersionPackageVersionMetadata.LicenseMetadata.LicenseUrl.ToString()
+                    Name = packageVersionMetadata.LicenseMetadata.License,
+                    Url = packageVersionMetadata.LicenseMetadata.LicenseUrl.ToString()
                 });
             }
 
             // publishing info
-            metadata.UploadTime = packageVersionPackageVersionMetadata.Published?.DateTime;
+            metadata.UploadTime = packageVersionMetadata.Published?.DateTime;
         }
 
         /// <summary>

--- a/src/Shared/PackageManagers/NuGetProjectManager.cs
+++ b/src/Shared/PackageManagers/NuGetProjectManager.cs
@@ -150,12 +150,6 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                                            throw new InvalidOperationException($"Can't find the latest version of {purl}");
                     packageVersion = latestVersion;
                 }
-                // NuGet package versions are case insensitive
-                else
-                {
-                    packageVersion = packageVersion.ToLowerInvariant();
-                }
-
                 // Construct a new PackageURL that's guaranteed to have a version.
                 PackageURL purlWithVersion = new (purl.Type, purl.Namespace, packageName, packageVersion, purl.Qualifiers, purl.Subpath);
                 
@@ -230,9 +224,8 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                 return false;
             }
 
-            // NuGet packages are case insensitive. Convert purl to lowercase before comparing against package versions list. 
-            StringComparer invICCmp = StringComparer.InvariantCultureIgnoreCase;
-            return (await EnumerateVersionsAsync(purl, useCache)).Contains(purl.Version, invICCmp);
+            // NuGet packages are case insensitive.
+            return (await EnumerateVersionsAsync(purl, useCache)).Contains(purl.Version, StringComparer.InvariantCultureIgnoreCase);
         }
     
         /// <summary>
@@ -247,11 +240,8 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                 return;
             }
 
-            string nameLowercase = packageVersionPackageVersionMetadata.Name.ToLowerInvariant();
-            string versionLowercase = metadata.PackageVersion.ToLowerInvariant();
-
             // Set the version specific URI values.
-            metadata.VersionUri = $"{metadata.PackageManagerUri}/packages/{nameLowercase}/{versionLowercase}";
+            metadata.VersionUri = $"{metadata.PackageManagerUri}/packages/{packageVersionPackageVersionMetadata.Name}/{metadata.PackageVersion}";
             metadata.ApiVersionUri = packageVersionPackageVersionMetadata.CatalogUri.ToString();
             
             // Construct the artifact contents url.

--- a/src/Shared/Shared.Lib.csproj
+++ b/src/Shared/Shared.Lib.csproj
@@ -42,7 +42,7 @@
         <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.0" />
         <PackageReference Include="NLog" Version="4.7.12" />
         <PackageReference Include="NLog.Schema" Version="4.7.12" />
-        <PackageReference Include="NuGet.Packaging" Version="6.1.0" />
+        <PackageReference Include="NuGet.Packaging" Version="6.2.2" />
         <PackageReference Include="NuGet.Protocol" Version="6.2.2" />
         <PackageReference Include="Octokit" Version="0.50.0" />
         <PackageReference Include="packageurl-dotnet" Version="1.1.0" />

--- a/src/oss-tests/ProjectManagerTests/NuGetProjectManagerTests.cs
+++ b/src/oss-tests/ProjectManagerTests/NuGetProjectManagerTests.cs
@@ -77,7 +77,7 @@ namespace Microsoft.CST.OpenSource.Tests.ProjectManagerTests
         [DataRow("pkg:nuget/razorengine@4.2.3-beta1")]
         [DataRow("pkg:nuget/razorengine@4.2.3-Beta1")]
         [DataRow("pkg:nuget/rAzOrEnGiNe@4.2.3-Beta1")]
-        public async Task PackageVersionExistsSucceeds(string purlString)
+        public async Task TestNugetCaseInsensitiveHandlingPackageExistsSucceeds(string purlString)
         {
             PackageURL purl = new(purlString);
             _projectManager = new NuGetProjectManager(".", null, _httpFactory);

--- a/src/oss-tests/ProjectManagerTests/NuGetProjectManagerTests.cs
+++ b/src/oss-tests/ProjectManagerTests/NuGetProjectManagerTests.cs
@@ -31,14 +31,14 @@ namespace Microsoft.CST.OpenSource.Tests.ProjectManagerTests
             { "https://api.nuget.org/v3/registration5-gz-semver2/razorengine/index.json", Resources.razorengine_json },
             { "https://api.nuget.org/v3/catalog0/data/2022.03.11.23.17.27/razorengine.4.2.3-beta1.json", Resources.razorengine_4_2_3_beta1_json },
         }.ToImmutableDictionary();
-        
+
         // Map PackageURLs to metadata as json.
         private readonly IDictionary<string, string> _metadata = new Dictionary<string, string>()
         {
             { "pkg:nuget/razorengine@4.2.3-beta1", Resources.razorengine_4_2_3_beta1_metadata_json },
             { "pkg:nuget/razorengine", Resources.razorengine_latest_metadata_json },
         }.ToImmutableDictionary();
-        
+
         // Map PackageURLs to the list of versions as json.
         private readonly IDictionary<string, string> _versions = new Dictionary<string, string>()
         {
@@ -71,6 +71,19 @@ namespace Microsoft.CST.OpenSource.Tests.ProjectManagerTests
             mockFactory.Setup(_ => _.CreateClient(It.IsAny<string>())).Returns(mockHttp.ToHttpClient());
             _httpFactory = mockFactory.Object;
             _projectManager = new NuGetProjectManager(".", new NuGetPackageActions(), _httpFactory);
+        }
+
+        [DataTestMethod]
+        [DataRow("pkg:nuget/razorengine@4.2.3-beta1")]
+        [DataRow("pkg:nuget/razorengine@4.2.3-Beta1")]
+        public async Task PackageVersionExistsSucceeds(string purlString)
+        {
+            PackageURL purl = new(purlString);
+            _projectManager = new NuGetProjectManager(".", null, _httpFactory);
+
+            bool exists = await _projectManager.PackageVersionExistsAsync(purl, useCache: false);
+
+            Assert.IsTrue(exists);
         }
 
         [DataTestMethod]

--- a/src/oss-tests/ProjectManagerTests/NuGetProjectManagerTests.cs
+++ b/src/oss-tests/ProjectManagerTests/NuGetProjectManagerTests.cs
@@ -76,6 +76,7 @@ namespace Microsoft.CST.OpenSource.Tests.ProjectManagerTests
         [DataTestMethod]
         [DataRow("pkg:nuget/razorengine@4.2.3-beta1")]
         [DataRow("pkg:nuget/razorengine@4.2.3-Beta1")]
+        [DataRow("pkg:nuget/rAzOrEnGiNe@4.2.3-Beta1")]
         public async Task PackageVersionExistsSucceeds(string purlString)
         {
             PackageURL purl = new(purlString);


### PR DESCRIPTION
Package versions in NuGet are case insensitive, and NuGet's GET package versions API returns a list of all package versions in lowercase. OSSGadget's NuGetProjectManager should lowercase a package version before comparing it against the returned list of package versions. 