### PR TITLE
Fix Detect Blake3 Test

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning">
-      <Version>3.4.244</Version>
+      <Version>3.5.119</Version>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/Shared.CLI/Shared.CLI.csproj
+++ b/src/Shared.CLI/Shared.CLI.csproj
@@ -40,19 +40,19 @@
 
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.0.0-alpha-844" />
-    <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
-    <PackageReference Include="Crayon" Version="2.0.64" />
-    <PackageReference Include="F23.StringSimilarity" Version="4.1.0" />
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.0-beta.74" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.39" />
-    <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.0" />
-    <PackageReference Include="NLog" Version="4.7.13" />
-    <PackageReference Include="NLog.Schema" Version="4.7.13" />
-    <PackageReference Include="NuGet.Versioning" Version="6.2.2" />
-    <PackageReference Include="Octokit" Version="0.50.0" />
-    <PackageReference Include="Sarif.Sdk" Version="2.4.12" />
-    <PackageReference Include="SemanticVersioning" Version="2.0.0" />
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
+    <PackageReference Include="Crayon" Version="2.0.69" />
+    <PackageReference Include="F23.StringSimilarity" Version="5.0.0" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.1" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
+    <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.1.18" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
+    <PackageReference Include="NLog" Version="5.0.4" />
+    <PackageReference Include="NLog.Schema" Version="5.0.4" />
+    <PackageReference Include="NuGet.Versioning" Version="6.3.1" />
+    <PackageReference Include="Octokit" Version="4.0.1" />
+    <PackageReference Include="Sarif.Sdk" Version="3.1.0" />
+    <PackageReference Include="SemanticVersioning" Version="2.0.2" />
     <PackageReference Include="System.Console" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/Shared/Shared.Lib.csproj
+++ b/src/Shared/Shared.Lib.csproj
@@ -30,31 +30,31 @@
 
     <ItemGroup>
         <PackageReference Include="AngleSharp" Version="1.0.0-alpha-844" />
-        <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
-        <PackageReference Include="Crayon" Version="2.0.62" />
-        <PackageReference Include="F23.StringSimilarity" Version="4.1.0" />
-        <PackageReference Include="HtmlAgilityPack" Version="1.11.37" />
-        <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.1.5" />
-        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+        <PackageReference Include="CommandLineParser" Version="2.9.1" />
+        <PackageReference Include="Crayon" Version="2.0.69" />
+        <PackageReference Include="F23.StringSimilarity" Version="5.0.0" />
+        <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
+        <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.1.18" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.0" />
-        <PackageReference Include="NLog" Version="4.7.12" />
-        <PackageReference Include="NLog.Schema" Version="4.7.12" />
-        <PackageReference Include="NuGet.Packaging" Version="6.2.2" />
-        <PackageReference Include="NuGet.Protocol" Version="6.2.2" />
-        <PackageReference Include="Octokit" Version="0.50.0" />
+        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.10" />
+        <PackageReference Include="NLog" Version="5.0.4" />
+        <PackageReference Include="NLog.Schema" Version="5.0.4" />
+        <PackageReference Include="NuGet.Packaging" Version="6.3.1" />
+        <PackageReference Include="NuGet.Protocol" Version="6.3.1" />
+        <PackageReference Include="Octokit" Version="4.0.1" />
         <PackageReference Include="packageurl-dotnet" Version="1.1.0" />
         <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
-        <PackageReference Include="Sarif.Sdk" Version="2.4.12" />
-        <PackageReference Include="SemanticVersioning" Version="2.0.0" />
+        <PackageReference Include="Sarif.Sdk" Version="3.1.0" />
+        <PackageReference Include="SemanticVersioning" Version="2.0.2" />
         <PackageReference Include="System.Console" Version="4.3.1" />
         <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.240">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="System.Linq.Async" Version="5.1.0" />
+        <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/oss-characteristics/CharacteristicTool.cs
+++ b/src/oss-characteristics/CharacteristicTool.cs
@@ -101,12 +101,10 @@ namespace Microsoft.CST.OpenSource
             // Call Application Inspector using the NuGet package
             AnalyzeOptions? analyzeOptions = new AnalyzeOptions()
             {
-                ConsoleVerbosityLevel = "None",
-                LogFileLevel = "Off",
                 SourcePath = new[] { directory },
                 IgnoreDefaultRules = options.DisableDefaultRules,
                 CustomRulesPath = options.CustomRuleDirectory,
-                ConfidenceFilters = "high,medium,low",
+                ConfidenceFilters = new [] { Confidence.High | Confidence.Medium | Confidence.Low },
                 ScanUnknownTypes = true,
                 AllowAllTagsInBuildFiles = options.AllowTagsInBuildFiles,
                 SingleThread = false,

--- a/src/oss-characteristics/oss-characteristic.csproj
+++ b/src/oss-characteristics/oss-characteristic.csproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CST.ApplicationInspector.Commands" Version="1.4.14" />
+    <PackageReference Include="Microsoft.CST.ApplicationInspector.Commands" Version="1.6.24" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/oss-detect-cryptography/DetectCryptographyTool.cs
+++ b/src/oss-detect-cryptography/DetectCryptographyTool.cs
@@ -523,8 +523,8 @@ namespace Microsoft.CST.OpenSource
                     //processor.AnalyzeFile
                     FileEntry? holderEntry = new FileEntry("placeholder", new MemoryStream(Encoding.UTF8.GetBytes(buffer)));
                     LanguageInfo languageInfo = new LanguageInfo();
-
-                    Language.FromFileName(filename, ref languageInfo);
+                    var languages = new Languages();
+                    languages.FromFileName(filename, ref languageInfo);
                     Task<List<MatchRecord>>? task = Task.Run(() => processor.AnalyzeFile(holderEntry,languageInfo));
                     if (task.Wait(TimeSpan.FromSeconds(30)))
                     {

--- a/src/oss-detect-cryptography/oss-detect-cryptography.csproj
+++ b/src/oss-detect-cryptography/oss-detect-cryptography.csproj
@@ -70,13 +70,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ELFSharp" Version="2.13.2" />
-    <PackageReference Include="ICSharpCode.Decompiler" Version="7.1.0.6543" />
-    <PackageReference Include="Microsoft.CST.ApplicationInspector.Commands" Version="1.4.14" />
-    <PackageReference Include="Microsoft.CST.DevSkim" Version="0.6.5" />
-    <PackageReference Include="PeNet" Version="2.9.2" />
+    <PackageReference Include="ELFSharp" Version="2.15.0" />
+    <PackageReference Include="ICSharpCode.Decompiler" Version="7.2.1.6856" />
+    <PackageReference Include="Microsoft.CST.ApplicationInspector.Commands" Version="1.6.24" />
+    <PackageReference Include="Microsoft.CST.DevSkim" Version="0.6.32" />
+    <PackageReference Include="PeNet" Version="2.9.9" />
     <PackageReference Include="SharpDisasm" Version="1.1.11" />
-    <PackageReference Include="WebAssembly" Version="1.2.0" />
+    <PackageReference Include="WebAssembly" Version="1.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/oss-diff/oss-diff.csproj
+++ b/src/oss-diff/oss-diff.csproj
@@ -28,8 +28,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DiffPlex" Version="1.7.0" />
-    <PackageReference Include="Pastel" Version="3.0.0" />
+    <PackageReference Include="DiffPlex" Version="1.7.1" />
+    <PackageReference Include="Pastel" Version="3.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/oss-find-domain-squats/oss-find-domain-squats.csproj
+++ b/src/oss-find-domain-squats/oss-find-domain-squats.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pastel" Version="3.0.0" />
+    <PackageReference Include="Pastel" Version="3.0.1" />
     <PackageReference Include="Whois" Version="3.0.1" />
   </ItemGroup>
 

--- a/src/oss-find-source/oss-find-source.csproj
+++ b/src/oss-find-source/oss-find-source.csproj
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Sarif.Sdk" Version="2.4.12" />
+    <PackageReference Include="Sarif.Sdk" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/oss-find-squats/oss-find-squats.csproj
+++ b/src/oss-find-squats/oss-find-squats.csproj
@@ -28,7 +28,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Sarif.Sdk" Version="2.4.12" />
+    <PackageReference Include="Sarif.Sdk" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/oss-health/oss-health.csproj
+++ b/src/oss-health/oss-health.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Octokit" Version="0.50.0" />
+    <PackageReference Include="Octokit" Version="4.0.1" />
     <PackageReference Include="System.Console" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/oss-metadata/oss-metadata.csproj
+++ b/src/oss-metadata/oss-metadata.csproj
@@ -40,6 +40,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="JmesPath.Net" Version="1.0.182" />
+    <PackageReference Include="JmesPath.Net" Version="1.0.205" />
   </ItemGroup>
 </Project>

--- a/src/oss-reproducible/oss-reproducible.csproj
+++ b/src/oss-reproducible/oss-reproducible.csproj
@@ -71,9 +71,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DiffPlex" Version="1.7.0" />
+    <PackageReference Include="DiffPlex" Version="1.7.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="SharpCompress" Version="0.30.1" />
+    <PackageReference Include="SharpCompress" Version="0.32.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/oss-tests/DetectCryptographyTests.cs
+++ b/src/oss-tests/DetectCryptographyTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CST.OpenSource.Tests
     {
         [DataTestMethod]
         [DataRow("pkg:npm/blake2", "Cryptography.Implementation.Hash.Blake", "Cryptography.Implementation.Hash.Blake2", "Cryptography.Implementation.Hash.JH", "Cryptography.Implementation.Hash.SHA-512")]
-        [DataRow("pkg:npm/blake3", "Cryptography.Implementation.Hash.Blake3", "Cryptography.Implementation.Hash.SHA-512")]
+        [DataRow("pkg:cargo/blake3", "Cryptography.Implementation.Hash.Blake3", "Cryptography.Implementation.Hash.SHA-512")]
         [DataRow("pkg:cargo/md2", "Cryptography.Implementation.Hash.MD2")]
         [DataRow("pkg:cargo/md4", "Cryptography.Implementation.Hash.MD4", "Cryptography.Implementation.Hash.SHA-1")]
         [DataRow("pkg:npm/md5", "Cryptography.Implementation.Hash.MD5")]

--- a/src/oss-tests/MetadataTests.cs
+++ b/src/oss-tests/MetadataTests.cs
@@ -15,9 +15,9 @@ using System.Text.Json;
 public class MetadataTests
 {
     [DataTestMethod]
-    [DataRow("deps.dev", "pkg:npm/left-pad", "package.name", "left-pad")]
-    [DataRow("deps.dev", "pkg:npm/left-pad@1.3.0", "package.name", "left-pad")]
-    [DataRow("libraries.io", "pkg:npm/left-pad@1.3.0", "name", "left-pad")]
+    [DataRow("deps.dev", "pkg:npm/blake3", "package.name", "blake3")]
+    [DataRow("deps.dev", "pkg:npm/blake3@3.0.0", "package.name", "blake3")]
+    [DataRow("libraries.io", "pkg:npm/blake3@3.0.0", "name", "blake3")]
     public async Task Check_Metadata(string dataSource, string purlString, string jmesPathExpr, string targetResult)
     {
         BaseMetadataSource? metadataSource = null;

--- a/src/oss-tests/oss-tests.csproj
+++ b/src/oss-tests/oss-tests.csproj
@@ -12,16 +12,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="JmesPath.Net" Version="1.0.182" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="FluentAssertions" Version="6.8.0" />
+    <PackageReference Include="JmesPath.Net" Version="1.0.205" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.17.2" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
   </ItemGroup>


### PR DESCRIPTION
The previous target did a large refactor where they now call into the WASM implementation of Blake3. Switching the target for the test to be the cargo for that implementation.