### PR TITLE
Add revocation checking, tweaked suppressions.

### DIFF
--- a/src/Shared/DefaultHttpClientFactory.cs
+++ b/src/Shared/DefaultHttpClientFactory.cs
@@ -34,6 +34,9 @@ namespace Microsoft.CST.OpenSource
             PooledConnectionIdleTimeout = TimeSpan.FromSeconds(30),
             PooledConnectionLifetime = TimeSpan.FromSeconds(30),
             AutomaticDecompression = System.Net.DecompressionMethods.All,
+            SslOptions = new System.Net.Security.SslClientAuthenticationOptions() {
+                CertificateRevocationCheckMode = System.Security.Cryptography.X509Certificates.X509RevocationMode.Online
+            }
         };
 
         private readonly Lazy<HttpClient> _httpClientLazy;

--- a/src/Shared/Helpers/ArchiveHelper.cs
+++ b/src/Shared/Helpers/ArchiveHelper.cs
@@ -38,7 +38,7 @@ public static class ArchiveHelper
 
         foreach (char c in Path.GetInvalidPathChars())
         {
-            dirBuilder.Replace(c, '-'); // ignore: lgtm [cs/string-concatenation-in-loop]
+            dirBuilder.Replace(c, '-'); // CodeQL [cs/string-concatenation-in-loop] This is a small loop
         }
 
         string fullTargetPath = Path.Combine(topLevelDirectory, dirBuilder.ToString());
@@ -71,4 +71,4 @@ public static class ArchiveHelper
 
         return fullTargetPath;
     }
-} 
+}

--- a/src/Shared/PackageManagers/CocoapodsProjectManager.cs
+++ b/src/Shared/PackageManagers/CocoapodsProjectManager.cs
@@ -191,7 +191,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             // The Cocoapods standard uses MD5(project name) as a prefix for sharing. There is no security
             // issue here, but we cannot use another algorithm.
 #pragma warning disable SCS0006, CA5351, CA1308 // Weak hash, ToLowerInvarant()
-            using MD5 hashAlgorithm = MD5.Create();
+            using MD5 hashAlgorithm = MD5.Create(); // CodeQL [cs/weak-crypto] Required for compatibility with Cocoapods
 
             char[] prefixMD5 = BitConverter
                                 .ToString(hashAlgorithm.ComputeHash(packageNameBytes))


### PR DESCRIPTION
This PR fixes a few issued identified by CodeQL:

* We didn't explicitly have certificate revocation checking enabled when connecting to endpoints.
* The justification for a small StringBuilder modifying loop was not recognized correctly.
* The justification for using MD5 as part of the CocoaPods path sharding sheme wasn't suppressed.

