### PR TITLE
Support environment variable overrides in package managers

### DIFF
--- a/src/Shared/PackageManagers/BaseProjectManager.cs
+++ b/src/Shared/PackageManagers/BaseProjectManager.cs
@@ -33,6 +33,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         /// </summary>
         public BaseProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory = ".")
         {
+            EnvironmentHelper.OverrideEnvironmentVariables(this);
             Options = new Dictionary<string, object>();
             TopLevelExtractionDirectory = destinationDirectory;
             HttpClientFactory = httpClientFactory;

--- a/src/Shared/PackageManagers/MavenProjectManager.cs
+++ b/src/Shared/PackageManagers/MavenProjectManager.cs
@@ -54,10 +54,10 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                 return downloadedPaths;
             }
 
-            try
+            string[] suffixes = new string[] { "-javadoc", "-sources", "" };
+            foreach (string suffix in suffixes)
             {
-                string[] suffixes = new string[] { "-javadoc", "-sources", "" };
-                foreach (string suffix in suffixes)
+                try
                 {
                     string url = $"{ENV_MAVEN_ENDPOINT}/{packageNamespace}/{packageName}/{packageVersion}/{packageName}-{packageVersion}{suffix}.jar";
                     HttpClient httpClient = CreateHttpClient();
@@ -85,10 +85,10 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                         downloadedPaths.Add(extractionPath);
                     }
                 }
-            }
-            catch (Exception ex)
-            {
-                Logger.Warn(ex, "Error downloading Maven package: {0}", ex.Message);
+                catch (Exception ex)
+                {
+                    Logger.Warn(ex, "Error downloading Maven package: {0}", ex.Message);
+                }
             }
             return downloadedPaths;
         }

--- a/src/oss-tests/DownloadTests.cs
+++ b/src/oss-tests/DownloadTests.cs
@@ -113,6 +113,7 @@ namespace Microsoft.CST.OpenSource.Tests
 
         [DataTestMethod]
         [DataRow("pkg:maven/org%2Fapache%2Fxmlgraphics/batik-anim@1.9", "MANIFEST.MF", 3)]
+        [DataRow("pkg:maven/ant/ant-junit@1.6.5", "MANIFEST.MF", 1)] // this project only has a jar file
         public async Task Maven_Download_Version_Succeeds(string purl, string targetFilename, int expectedDirectoryCount)
         {
             await TestDownload(purl, targetFilename, expectedDirectoryCount);


### PR DESCRIPTION
This change adds environment variable overrides for package managers. The [wiki documentation](https://github.com/microsoft/OSSGadget/wiki/Advanced-Usage) implies that this works for tools like `oss-download` by adding a `MAVEN_ENDPOINT` environment variable, but the code did not support it.

Additionally, there is a change to the Maven package manager to download jars that do not have javadoc or source jars available. Previously, if one or both jars were missing the actual jar would not be downloaded as an exception was encountered and the loop exited early