### PR TITLE
Cleanup the GetArtifactDownloadUris to instead be returned from the TypedManager class

### DIFF
--- a/src/Shared/PackageManagers/NPMProjectManager.cs
+++ b/src/Shared/PackageManagers/NPMProjectManager.cs
@@ -49,13 +49,6 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         }
 
         /// <inheritdoc />
-        [Obsolete("Deprecated in favor of GetArtifactDownloadUrisAsync.")]
-        public override IEnumerable<ArtifactUri<NPMArtifactType>> GetArtifactDownloadUris(PackageURL purl)
-        {
-            return GetArtifactDownloadUrisAsync(purl).ToListAsync().Result;
-        }
-
-        /// <inheritdoc />
         public override async IAsyncEnumerable<ArtifactUri<NPMArtifactType>> GetArtifactDownloadUrisAsync(PackageURL purl, bool useCache = true)
         {
             Check.NotNull(nameof(purl.Version), purl.Version);

--- a/src/Shared/PackageManagers/NuGetProjectManager.cs
+++ b/src/Shared/PackageManagers/NuGetProjectManager.cs
@@ -51,13 +51,6 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         {
             GetRegistrationEndpointAsync().Wait();
         }
-        
-        /// <inheritdoc />
-        [Obsolete("Deprecated in favor of GetArtifactDownloadUrisAsync.")]
-        public override IEnumerable<ArtifactUri<NuGetArtifactType>> GetArtifactDownloadUris(PackageURL purl)
-        {
-            return GetArtifactDownloadUrisAsync(purl).ToListAsync().Result;
-        }
 
         /// <inheritdoc />
         public override async IAsyncEnumerable<ArtifactUri<NuGetArtifactType>> GetArtifactDownloadUrisAsync(PackageURL purl, bool useCache = true)

--- a/src/Shared/PackageManagers/PyPIProjectManager.cs
+++ b/src/Shared/PackageManagers/PyPIProjectManager.cs
@@ -41,13 +41,6 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             : base(actions ?? new NoOpPackageActions(), httpClientFactory ?? new DefaultHttpClientFactory(), directory)
         {
         }
-
-        /// <inheritdoc />
-        [Obsolete("Deprecated in favor of GetArtifactDownloadUrisAsync.")]
-        public override IEnumerable<ArtifactUri<PyPIArtifactType>> GetArtifactDownloadUris(PackageURL purl)
-        {
-            return GetArtifactDownloadUrisAsync(purl).ToListAsync().Result;
-        }
         
         /// <inheritdoc />
         public override async IAsyncEnumerable<ArtifactUri<PyPIArtifactType>> GetArtifactDownloadUrisAsync(PackageURL purl, bool useCache = true)

--- a/src/Shared/PackageManagers/TypedManager.cs
+++ b/src/Shared/PackageManagers/TypedManager.cs
@@ -12,6 +12,7 @@ using Polly.Retry;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -95,7 +96,10 @@ public abstract class TypedManager<T, TArtifactUriType> : BaseProjectManager whe
     /// <returns>A list of the relevant <see cref="ArtifactUri{TArtifactUriType}"/>.</returns>
     /// <remarks>Returns the expected URIs for resources. Does not validate that the URIs resolve at the moment of enumeration.</remarks>
     [Obsolete(message: $"Deprecated in favor of {nameof(GetArtifactDownloadUrisAsync)}.")]
-    public abstract IEnumerable<ArtifactUri<TArtifactUriType>> GetArtifactDownloadUris(PackageURL purl);
+    public IEnumerable<ArtifactUri<TArtifactUriType>> GetArtifactDownloadUris(PackageURL purl)
+    {
+        return GetArtifactDownloadUrisAsync(purl).ToListAsync().GetAwaiter().GetResult();
+    }
     
     /// <summary>
     /// Gets the relevant URI(s) to download the files related to a <see cref="PackageURL"/>.


### PR DESCRIPTION
This pull request moves the implementation for GetArtifactDownloadUris to the TypedManager class since all of the implementations were the same.  It also switches from using .Result to use .GetAwaiter().GetResult() for the sync-to-async call to avoid issues with deadlocks.