### PR TITLE
Add missing SDK for NuGet builds

### DIFF
--- a/Pipelines/templates/nuget-build-job.yml
+++ b/Pipelines/templates/nuget-build-job.yml
@@ -90,6 +90,10 @@ jobs:
       TreatSignatureUpdateFailureAs: 'Warning'
       SignatureFreshness: 'UpToDate'
       TreatStaleSignatureAs: 'Warning'
+  - task: UseDotNet@2
+    inputs:
+      packageType: 'sdk'
+      version: '2.1.804'
   - task: EsrpCodeSigning@1
     displayName: Code Sign Nuget Packages
     condition: and(succeeded(), eq('${{ parameters.publishToNuget }}', 'true'))


### PR DESCRIPTION
The build is currently failing to build NuGet packages on the code signing step due to a missing .NET SDK.  This change adds in that missing SDK prior to the code signing.