### PR TITLE
Remove extra dot in suspicious hostname check.

### DIFF
--- a/src/oss-detect-backdoor/Resources/BackdoorRules/dependency_confusion.json
+++ b/src/oss-detect-backdoor/Resources/BackdoorRules/dependency_confusion.json
@@ -29,7 +29,7 @@
         "scopes": [ "code", "comment" ],
         "modifiers": [ "i" ],
         "confidence": "high"
-      }   
+      }
     ]
   },
   {
@@ -43,7 +43,7 @@
     "severity": "critical",
     "patterns": [
       {
-        "pattern": ".{1,45}\\.(pipedream\\.net|ceye\\.io|burpcollaborator\\.net|interact\\.sh|requestbin\\.net|nmnfbb\\.com)",
+        "pattern": ".{1,45}(pipedream\\.net|ceye\\.io|burpcollaborator\\.net|interact\\.sh|requestbin\\.net|nmnfbb\\.com)",
         "type": "regex",
         "scopes": [ "code", "comment" ],
         "modifiers": [ "i" ],
@@ -69,5 +69,5 @@
         "confidence": "high"
       }
     ]
-  }  
+  }
 ]


### PR DESCRIPTION
Simple change, just modifies a regex used to detect certain backdoors. Turns out, the period prefix isn't needed.

Signed-off-by: Michael Scovetta <michael.scovetta@microsoft.com>