### PR TITLE
Update to PackageUrl 1.2.0

### DIFF
--- a/src/Shared/Shared.Lib.csproj
+++ b/src/Shared/Shared.Lib.csproj
@@ -45,7 +45,7 @@
         <PackageReference Include="NuGet.Packaging" Version="6.3.1" />
         <PackageReference Include="NuGet.Protocol" Version="6.3.1" />
         <PackageReference Include="Octokit" Version="4.0.1" />
-        <PackageReference Include="packageurl-dotnet" Version="1.1.0" />
+        <PackageReference Include="packageurl-dotnet" Version="1.2.0" />
         <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
         <PackageReference Include="Sarif.Sdk" Version="3.1.0" />
         <PackageReference Include="SemanticVersioning" Version="2.0.2" />


### PR DESCRIPTION
This pull request updates the PackageURL dependency to version 1.2.0.  This version incorporates updates to how package names are normalized, so as to better handle package managers that allow for case-sensitive packages.