### PR TITLE
Fix some issues with the squat mutators

### DIFF
--- a/src/oss-find-squats-lib/MutateExtension.cs
+++ b/src/oss-find-squats-lib/MutateExtension.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CST.OpenSource.FindSquats.ExtensionMethods
         /// <summary>
         /// Common variations known uniquely for NPM/Javascript. 
         /// </summary>
-        internal static IEnumerable<IMutator> NpmMutators { get; } = BaseMutators.Where(x => x is not UnicodeHomoglyphMutator and not SuffixMutator)
+        internal static IEnumerable<IMutator> NpmMutators { get; } = BaseMutators.Where(x => x is not UnicodeHomoglyphMutator and not PrefixMutator and not SuffixMutator)
             .Concat(new IMutator[]
                 {
                     new SubstitutionMutator(new List<(string Original, string Substitution)>()
@@ -60,8 +60,22 @@ namespace Microsoft.CST.OpenSource.FindSquats.ExtensionMethods
                         ("js", "javascript"),
                         ("ts", "typescript"),
                     }),
-                    new SuffixMutator(additionalSuffixes: new[] { "js", ".js", "javascript", "ts", ".ts", "typescript"})
+                    new PrefixMutator(additionalPrefixes: new[] { "js", "js-", "node", "node-","ts", "ts-"}),
+                    new SuffixMutator(additionalSuffixes: new[] { "js", ".js", "-js", "javascript", "-javascript", "ts", ".ts", "-ts", "typescript", "-typescript", "node", "-node"})
                 });
+                
+        /// <summary>
+        /// Common variations known uniquely for Python. 
+        /// </summary>
+        internal static IEnumerable<IMutator> PythonMutators { get; } = BaseMutators.Where(x => x is not UnicodeHomoglyphMutator and not SuffixMutator)
+            .Concat(new IMutator[]
+            {
+                new SubstitutionMutator(new List<(string Original, string Substitution)>()
+                {
+                    ("py", "python"),
+                }),
+                new SuffixMutator(additionalSuffixes: new[] { "py", ".py", "-py", "python", "-python"})
+            });
 
         /// <summary>
         /// Gets the default set of mutators for a given BaseProjectManager based on its Type.
@@ -72,6 +86,7 @@ namespace Microsoft.CST.OpenSource.FindSquats.ExtensionMethods
         {
             NuGetProjectManager => NugetMutators,
             NPMProjectManager => NpmMutators,
+            PyPIProjectManager => PythonMutators,
             _ => BaseMutators
         };
 

--- a/src/oss-find-squats-lib/Mutators/CloseLettersMutator.cs
+++ b/src/oss-find-squats-lib/Mutators/CloseLettersMutator.cs
@@ -35,6 +35,18 @@ namespace Microsoft.CST.OpenSource.FindSquats.Mutators
                         reason: $"Close Letters on QWERTY Keyboard: {arg[i]} => {c}");
                 }
             }
+            
+            // Also try adding an additional character at the end of neighbouring characters.
+            List<char>? n2 = QwertyKeyboardHelper.GetNeighboringCharacters(arg.Last()).ToList();
+
+            foreach (char c in n2)
+            {
+                yield return new Mutation(
+                    mutated: string.Concat(arg, c),
+                    original: arg,
+                    mutator: Kind,
+                    reason: $"Close Letters on QWERTY Keyboard, added to end: {arg} => {c}");
+            }
         }
     }
 }

--- a/src/oss-find-squats-lib/Mutators/SubstitutionMutator.cs
+++ b/src/oss-find-squats-lib/Mutators/SubstitutionMutator.cs
@@ -20,14 +20,11 @@ namespace Microsoft.CST.OpenSource.FindSquats.Mutators
         /// They get replaced in both directions.
         /// e.g. "js" -> "javascript" and "javascript" -> "js".
         /// </summary>
-        private static IList<(string Original, string Substitution)> _substitutions = new List<(string Original, string Substitution)>();
+        private readonly IList<(string Original, string Substitution)> _substitutions;
 
         public SubstitutionMutator(IList<(string Original, string Substitution)>? substitutions = null)
         {
-            if (substitutions != null)
-            {
-                _substitutions = substitutions;
-            }
+            _substitutions = substitutions ?? new List<(string Original, string Substitution)>();
         }
 
         public IEnumerable<Mutation> Generate(string arg)

--- a/src/oss-find-squats-lib/Mutators/SwapOrderOfLettersMutator.cs
+++ b/src/oss-find-squats-lib/Mutators/SwapOrderOfLettersMutator.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CST.OpenSource.FindSquats.Mutators
 
         public IEnumerable<Mutation> Generate(string arg)
         {
-            for (int i = 1; i < arg.Length - 1; i++)
+            for (int i = 0; i < arg.Length - 1; i++)
             {
                 // Don't want to swap the same character for the same character, foo -> foo.
                 if (arg[i + 1] == arg[i])

--- a/src/oss-tests/FindSquatsTests.cs
+++ b/src/oss-tests/FindSquatsTests.cs
@@ -258,6 +258,60 @@ namespace Microsoft.CST.OpenSource.Tests
         }
         
         [TestMethod]
+        public async Task UniversalifyMutations_Succeeds_Async()
+        {
+            // arrange
+            PackageURL universalify = new("pkg:npm/universalify");
+
+            string[] squattingPackages = new[]
+            {
+                "pkg:npm/universalfiy", 
+                "pkg:npm/nuiversalify",
+                "pkg:npm/universalifyt",
+            };
+
+            IHttpClientFactory httpClientFactory =
+                FindSquatsHelper.SetupHttpCalls(purl: universalify, validSquats: squattingPackages);
+
+            FindPackageSquats findPackageSquats = new(new ProjectManagerFactory(httpClientFactory), universalify);
+
+            // act
+            IDictionary<string, IList<Mutation>>? squatCandidates = findPackageSquats.GenerateSquatCandidates();
+            List<FindPackageSquatResult> existingMutations = await findPackageSquats.FindExistingSquatsAsync(squatCandidates, new MutateOptions(){UseCache = false}).ToListAsync();
+            Assert.IsNotNull(existingMutations);
+            Assert.IsTrue(existingMutations.Any());
+            string[] resultingMutationNames = existingMutations.Select(m => m.MutatedPackageUrl.ToString()).ToArray();
+            CollectionAssert.AreEquivalent(squattingPackages, resultingMutationNames);
+        }
+        
+        [TestMethod]
+        public async Task WebidlConversionsMutations_Succeeds_Async()
+        {
+            // arrange
+            PackageURL webidlConversions = new("pkg:npm/webidl-conversions");
+
+            string[] squattingPackages = new[]
+            {
+                "pkg:npm/webidl-conversion", 
+                "pkg:npm/webidl-covnersions",
+                "pkg:npm/ewbidl-conversions",
+            };
+
+            IHttpClientFactory httpClientFactory =
+                FindSquatsHelper.SetupHttpCalls(purl: webidlConversions, validSquats: squattingPackages);
+
+            FindPackageSquats findPackageSquats = new(new ProjectManagerFactory(httpClientFactory), webidlConversions);
+
+            // act
+            IDictionary<string, IList<Mutation>>? squatCandidates = findPackageSquats.GenerateSquatCandidates();
+            List<FindPackageSquatResult> existingMutations = await findPackageSquats.FindExistingSquatsAsync(squatCandidates, new MutateOptions(){UseCache = false}).ToListAsync();
+            Assert.IsNotNull(existingMutations);
+            Assert.IsTrue(existingMutations.Any());
+            string[] resultingMutationNames = existingMutations.Select(m => m.MutatedPackageUrl.ToString()).ToArray();
+            CollectionAssert.AreEquivalent(squattingPackages, resultingMutationNames);
+        }
+
+        [TestMethod]
         public async Task FooMutations_Succeeds_Async()
         {
             // arrange


### PR DESCRIPTION
- Add a few more prefixes and suffixes for npm.
- Add substitution and suffix mutators for PyPi.
- Update the close letters mutator to add a close letter to the end of a string. We missed the node package sqliter from sqlite as a typosquat. 
- Fix substitution mutator.
- Fix Swap Order Of Letters mutator.
- Update FindSquatsTests.