### PR TITLE
Improve oss-find-source for PyPI packages.

### DIFF
--- a/src/Shared/PackageManagers/BaseProjectManager.cs
+++ b/src/Shared/PackageManagers/BaseProjectManager.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         /// <returns>PackageURLs (type=GitHub) located in the text.</returns>
         public static IEnumerable<PackageURL> ExtractGitHubPackageURLs(string content)
         {
-            Logger.Trace("ExtractGitHubPackageURLs({0})", content?.Substring(0, 30));
+            Logger.Trace("ExtractGitHubPackageURLs({0})", content?.Take(30));
 
             if (string.IsNullOrWhiteSpace(content))
             {


### PR DESCRIPTION
Fix #398 
Currently, oss-find-source only searches properties with certain keys in the `project_urls` filed. But it is possible that other properties (e.g., the `Download` property in tensorflow package's metadata) also contain source code repository information.