### PR TITLE
Update squat logic to address bugs.

### DIFF
--- a/src/oss-find-squats-lib/MutateExtension.cs
+++ b/src/oss-find-squats-lib/MutateExtension.cs
@@ -36,7 +36,6 @@ namespace Microsoft.CST.OpenSource.FindSquats.ExtensionMethods
             new RemoveSeparatedSectionMutator(),
             new ReplaceCharacterMutator(),
             new SeparatorChangedMutator(),
-            new SeparatorRemovedMutator(),
             new SuffixMutator(),
             new SwapOrderOfLettersMutator(),
             new UnicodeHomoglyphMutator(),
@@ -74,11 +73,12 @@ namespace Microsoft.CST.OpenSource.FindSquats.ExtensionMethods
         /// Common variations known uniquely for Python. 
         /// </summary>
         internal static IEnumerable<IMutator> PythonMutators { get; } = BaseMutators.Where(x => 
-                x is not UnicodeHomoglyphMutator and not SuffixMutator and not CloseLettersMutator and not DoubleHitMutator)
+                x is not UnicodeHomoglyphMutator and not SuffixMutator and not CloseLettersMutator and not DoubleHitMutator and not SeparatorChangedMutator)
             .Concat(new IMutator[]
             {
                 new CloseLettersMutator(additionalExcludedChars: new[] { '/' }),
                 new DoubleHitMutator(additionalExcludedChars: new[] { '/' }),
+                new SeparatorChangedMutator(overrideSeparators: new[] { '.', '-' }),
                 new SubstitutionMutator(new List<(string Original, string Substitution)>()
                 {
                     ("py", "python"),

--- a/src/oss-find-squats-lib/Mutators/DuplicatorMutator.cs
+++ b/src/oss-find-squats-lib/Mutators/DuplicatorMutator.cs
@@ -24,18 +24,24 @@ namespace Microsoft.CST.OpenSource.FindSquats.Mutators
 
             for (int i = 0; i < arg.Length - 2; i++)
             {
+                if (!string.Concat(arg[..(i + 1)], arg[i], arg[(i + 2)..]).Equals(arg))
+                {
+                    yield return new Mutation(
+                        mutated: string.Concat(arg[..(i + 1)], arg[i], arg[(i + 2)..]),
+                        original: arg,
+                        mutator: Kind,
+                        reason: $"Letter Duplicated and Replaced: {arg[i]}");
+                }
+            }
+
+            if (!string.Concat(arg[..arg.Length], arg[^1]).Equals(arg))
+            {
                 yield return new Mutation(
-                    mutated: string.Concat(arg[..(i + 1)], arg[i], arg[(i + 2)..]),
+                    mutated: string.Concat(arg[..arg.Length], arg[^1]),
                     original: arg,
                     mutator: Kind,
                     reason: "Letter Duplicated and Replaced");
             }
-
-            yield return new Mutation(
-                mutated: string.Concat(arg[..arg.Length], arg[^1]),
-                original: arg,
-                mutator: Kind,
-                reason: "Letter Duplicated and Replaced");
         }
     }
 }


### PR DESCRIPTION
- Remove `SeparatorRemovedMutator` from the list of `BaseMutators` as it was causing problems and usually doesn't catch squats. Squats that would be caught by it are also caught by the prefix or suffix mutator.
- Overrode the `SeparatorChangedMutator` for PyPi as PyPi considers `-` and `_` to be the same character. So just removed `_` from the list. There might be a better way of doing this, but I haven't thought of one yet.
- Fixed issues with the `DuplicatorMutator` that was giving the original name back as a mutated one.