### PR TITLE
Add the ability to exclude mutators, and added a new NamespaceInName mutator.

### DIFF
--- a/src/oss-find-squats-lib/MutateExtension.cs
+++ b/src/oss-find-squats-lib/MutateExtension.cs
@@ -133,6 +133,12 @@ namespace Microsoft.CST.OpenSource.FindSquats.ExtensionMethods
 
             foreach (IMutator mutator in mutators)
             {
+                // If the mutator is in the list of mutators to exclude in the options, then skip.
+                if (options is { ExcludedMutators: { } } && options.ExcludedMutators.Contains(mutator.Kind))
+                {
+                    continue;
+                }
+
                 foreach (Mutation mutation in mutator.Generate(purl))
                 {
                     generatedMutations.AddOrUpdate(mutation.Mutated, new List<Mutation>() { mutation }, (_, list) =>

--- a/src/oss-find-squats-lib/MutateExtension.cs
+++ b/src/oss-find-squats-lib/MutateExtension.cs
@@ -30,6 +30,7 @@ namespace Microsoft.CST.OpenSource.FindSquats.ExtensionMethods
             new CloseLettersMutator(),
             new DoubleHitMutator(),
             new DuplicatorMutator(),
+            new NamespaceInNameMutator(),
             new PrefixMutator(),
             new RemovedCharacterMutator(),
             new RemoveNamespaceMutator(),

--- a/src/oss-find-squats-lib/MutateOptions.cs
+++ b/src/oss-find-squats-lib/MutateOptions.cs
@@ -2,6 +2,9 @@
 
 namespace Microsoft.CST.OpenSource.FindSquats
 {
+    using Mutators;
+    using System.Collections.Generic;
+
     /// <summary>
     /// Options to provide to MutateExtension.EnumerateSquats
     /// </summary>
@@ -16,5 +19,10 @@ namespace Microsoft.CST.OpenSource.FindSquats
         /// If the cache should be used when checking if mutations exist.
         /// </summary>
         public bool UseCache { get; set; } = true;
+        
+        /// <summary>
+        /// Mutators that should be excluded.
+        /// </summary>
+        public IEnumerable<MutatorType>? ExcludedMutators { get; set; }
     }
 }

--- a/src/oss-find-squats-lib/Mutators/MutatorType.cs
+++ b/src/oss-find-squats-lib/Mutators/MutatorType.cs
@@ -40,6 +40,10 @@ namespace Microsoft.CST.OpenSource.FindSquats.Mutators
         /// </summary>
         Duplicator,
         /// <summary>
+        /// The <see cref="NamespaceInNameMutator"/> mutator.
+        /// </summary>
+        NamespaceInName,
+        /// <summary>
         /// The <see cref="PrefixMutator"/> mutator.
         /// </summary>
         Prefix,
@@ -48,7 +52,7 @@ namespace Microsoft.CST.OpenSource.FindSquats.Mutators
         /// </summary>
         RemovedCharacter,
         /// <summary>
-        /// A mutator which removes the namespace.
+        /// The <see cref="RemoveNamespaceMutator"/> mutator.
         /// </summary>
         RemovedNamespace,
         /// <summary>

--- a/src/oss-find-squats-lib/Mutators/NamespaceInNameMutator.cs
+++ b/src/oss-find-squats-lib/Mutators/NamespaceInNameMutator.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+namespace Microsoft.CST.OpenSource.FindSquats.Mutators
+{
+    using Extensions;
+    using PackageUrl;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    /// <summary>
+    /// Generates mutations for moving the namespace to the name.
+    /// </summary>
+    public class NamespaceInNameMutator : IMutator
+    {
+        public MutatorType Kind { get; } = MutatorType.NamespaceInName;
+
+        public HashSet<char> Separators { get; set; } = SeparatorRemovedMutator.DefaultSeparators.ToHashSet();
+
+        public IEnumerable<Mutation> Generate(string arg)
+        {
+            PackageURL purl = new(arg);
+
+            string namespaceStr = purl.Namespace.Replace("@", string.Empty).Replace("%40", string.Empty);
+
+            foreach (var separator in Separators)
+            {
+                yield return new Mutation(
+                    mutated: purl.CreateWithNewNames($"{namespaceStr}{separator}{purl.Name}", null).ToString(),
+                    original: arg,
+                    mutator: Kind,
+                    reason: $"Namespace '{namespaceStr}' added to name with the separator: {separator}");
+            }
+
+            yield return new Mutation(
+                    mutated: purl.CreateWithNewNames($"{namespaceStr}{purl.Name}", null).ToString(),
+                    original: arg,
+                    mutator: Kind,
+                    reason: $"Namespace '{namespaceStr}' added to name with no separator");
+        }
+
+        public IEnumerable<Mutation> Generate(PackageURL arg)
+        {
+            if (!arg.HasNamespace())
+            {
+                yield break;
+            }
+
+            foreach (Mutation mutation in Generate(arg.ToString()))
+            {
+                yield return mutation;
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Add a field to `MutateOptions` called `ExcludedMutators` that is of type `IEnumerable<MutatorType>?` which will exclude a given `MutatorType` from being used when generating mutations.
  - We needed this for the way we are generating mutations, we don't want the `RemoveNamespaceMutator` for our use case, but I don't want to remove it from the base mutators.
- Added a new mutator `NamespaceInNameMutator` that performs a mutation to move the namespace to the name.
  - Example: Given `pkg:npm/%40angular/core`
    - `pkg:npm/angular-core`
    - `pkg:npm/angular.core`
    - `pkg:npm/angular_core`
    - `pkg:npm/angularcore`