### PR TITLE
Fix some bugs

### DIFF
--- a/src/oss-find-squats-lib/MutateExtension.cs
+++ b/src/oss-find-squats-lib/MutateExtension.cs
@@ -34,6 +34,7 @@ namespace Microsoft.CST.OpenSource.FindSquats.ExtensionMethods
             new PrefixMutator(),
             new RemovedCharacterMutator(),
             new RemoveNamespaceMutator(),
+            new RemoveSeparatedSectionMutator(),
             new ReplaceCharacterMutator(),
             new SeparatorChangedMutator(),
             new SeparatorRemovedMutator(),
@@ -58,7 +59,7 @@ namespace Microsoft.CST.OpenSource.FindSquats.ExtensionMethods
         /// <summary>
         /// Common variations known uniquely for NPM/Javascript. 
         /// </summary>
-        internal static IEnumerable<IMutator> NpmMutators { get; } = BaseMutators.Where(x => x is not UnicodeHomoglyphMutator and not PrefixMutator and not SuffixMutator)
+        internal static IEnumerable<IMutator> NpmMutators { get; } = BaseMutators.Where(x => x is not UnicodeHomoglyphMutator and not PrefixMutator and not SuffixMutator and not RemoveSeparatedSectionMutator)
             .Concat(new IMutator[]
                 {
                     new SubstitutionMutator(new List<(string Original, string Substitution)>()

--- a/src/oss-find-squats-lib/Mutators/IMutator.cs
+++ b/src/oss-find-squats-lib/Mutators/IMutator.cs
@@ -42,12 +42,12 @@ namespace Microsoft.CST.OpenSource.FindSquats.Mutators
                     continue;
                 }
                 
-                if (mutation.Mutated.Length == 1 &&
-                    SeparatorRemovedMutator.DefaultSeparators.Contains(Convert.ToChar(mutation.Mutated)))
+                if (mutation.Mutated.Length == 1 && !char.IsLetterOrDigit(Convert.ToChar(mutation.Mutated)))
                 {
                     // Don't make mutations that are just one separator. i.e pkg:npm/. isn't valid.
                     continue;
                 }
+
                 if (hasNamespace)
                 {
                     yield return new Mutation(

--- a/src/oss-find-squats-lib/Mutators/IMutator.cs
+++ b/src/oss-find-squats-lib/Mutators/IMutator.cs
@@ -4,6 +4,7 @@ namespace Microsoft.CST.OpenSource.FindSquats.Mutators
 {
     using Extensions;
     using PackageUrl;
+    using System;
     using System.Collections.Generic;
     using System.Web;
 
@@ -35,6 +36,12 @@ namespace Microsoft.CST.OpenSource.FindSquats.Mutators
             bool hasNamespace = arg.HasNamespace();
             foreach (Mutation mutation in Generate(hasNamespace ? arg.Namespace : arg.Name))
             {
+                if (mutation.Mutated.Length == 1 &&
+                    SeparatorRemovedMutator.DefaultSeparators.Contains(Convert.ToChar(mutation.Mutated)))
+                {
+                    // Don't make mutations that are just one separator. i.e pkg:npm/. isn't valid.
+                    continue;
+                }
                 if (hasNamespace)
                 {
                     yield return new Mutation(

--- a/src/oss-find-squats-lib/Mutators/IMutator.cs
+++ b/src/oss-find-squats-lib/Mutators/IMutator.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CST.OpenSource.FindSquats.Mutators
                     continue;
                 }
                 
-                if (mutation.Mutated.Length == 1 && !char.IsLetterOrDigit(Convert.ToChar(mutation.Mutated)))
+                if (mutation.Mutated.Length == 1 && !char.IsLetterOrDigit(mutation.Mutated[0]))
                 {
                     // Don't make mutations that are just one separator. i.e pkg:npm/. isn't valid.
                     continue;

--- a/src/oss-find-squats-lib/Mutators/IMutator.cs
+++ b/src/oss-find-squats-lib/Mutators/IMutator.cs
@@ -36,6 +36,12 @@ namespace Microsoft.CST.OpenSource.FindSquats.Mutators
             bool hasNamespace = arg.HasNamespace();
             foreach (Mutation mutation in Generate(hasNamespace ? arg.Namespace : arg.Name))
             {
+                if (mutation.Mutated.Length == 0)
+                {
+                    // Don't make mutations that are empty. i.e pkg:npm/ isn't valid.
+                    continue;
+                }
+                
                 if (mutation.Mutated.Length == 1 &&
                     SeparatorRemovedMutator.DefaultSeparators.Contains(Convert.ToChar(mutation.Mutated)))
                 {

--- a/src/oss-find-squats-lib/Mutators/PrefixMutator.cs
+++ b/src/oss-find-squats-lib/Mutators/PrefixMutator.cs
@@ -40,6 +40,24 @@ namespace Microsoft.CST.OpenSource.FindSquats.Mutators
 
         public IEnumerable<Mutation> Generate(string arg)
         {
+            // Can't add a character before an @ for a scoped package.
+            if (arg.StartsWith('@'))
+            {
+                var addedPrefixesWithScope = _prefixes.Select(s => new Mutation(
+                    mutated: $"@{s}{arg[1..]}",
+                    original: arg,
+                    mutator: Kind,
+                    reason: $"Prefix Added: {s}"));
+
+                var removedPrefixesWithScope = _prefixes.Where(arg[1..].StartsWith).Select(s => new Mutation(
+                    mutated: '@' + arg[1..].ReplaceAtStart(s, string.Empty),
+                    original: arg,
+                    mutator: Kind,
+                    reason: $"Prefix Removed: {s}"));
+
+                return addedPrefixesWithScope.Concat(removedPrefixesWithScope);
+            }
+            
             var addedPrefixes = _prefixes.Select(s => new Mutation(
                 mutated: string.Concat(s, arg),
                 original: arg,

--- a/src/oss-tests/FindSquatsTests.cs
+++ b/src/oss-tests/FindSquatsTests.cs
@@ -163,7 +163,7 @@ namespace Microsoft.CST.OpenSource.Tests
                             {
                                 var mutatedPurl = new PackageURL(m.Mutated);
                                 return mutatedPurl.Name.Length == 1 &&
-                                       SeparatorRemovedMutator.DefaultSeparators.Contains(Convert.ToChar(mutatedPurl.Name));
+                                       !char.IsLetterOrDigit(Convert.ToChar(mutatedPurl.Name));
                             }))
                         {
                             Assert.Fail($"Found a mutation that's a separator.");

--- a/src/oss-tests/FindSquatsTests.cs
+++ b/src/oss-tests/FindSquatsTests.cs
@@ -163,7 +163,7 @@ namespace Microsoft.CST.OpenSource.Tests
                             {
                                 var mutatedPurl = new PackageURL(m.Mutated);
                                 return mutatedPurl.Name.Length == 1 &&
-                                       !char.IsLetterOrDigit(Convert.ToChar(mutatedPurl.Name));
+                                       !char.IsLetterOrDigit(mutatedPurl.Name[0]);
                             }))
                         {
                             Assert.Fail($"Found a mutation that's a separator.");

--- a/src/oss-tests/FindSquatsTests.cs
+++ b/src/oss-tests/FindSquatsTests.cs
@@ -64,8 +64,8 @@ namespace Microsoft.CST.OpenSource.Tests
         }
 
         [DataTestMethod]
-        [DataRow("pkg:npm/angular/core", "pkg:npm/engular/core", "pkg:npm/angullar/core", "pkg:npm/core", "pkg:npm/angular-core", "pkg:npm/angular.core", "pkg:npm/angularcore")]
-        [DataRow("pkg:npm/%40angular/core", "pkg:npm/%40engular/core", "pkg:npm/%40angullar/core", "pkg:npm/core","pkg:npm/angular-core", "pkg:npm/angular.core", "pkg:npm/angularcore")] // back compat check
+        [DataRow("pkg:npm/angular/core", "pkg:npm/engular/core", "pkg:npm/angullar/core", "pkg:npm/node-angular/core", "pkg:npm/core", "pkg:npm/angular-core", "pkg:npm/angular.core", "pkg:npm/angularcore")]
+        [DataRow("pkg:npm/%40angular/core", "pkg:npm/%40engular/core", "pkg:npm/%40angullar/core", "pkg:npm/%40node-angular/core", "pkg:npm/core","pkg:npm/angular-core", "pkg:npm/angular.core", "pkg:npm/angularcore")] // back compat check
         [DataRow("pkg:npm/lodash", "pkg:npm/odash", "pkg:npm/lodah")]
         [DataRow("pkg:npm/babel/runtime", "pkg:npm/abel/runtime", "pkg:npm/bable/runtime", "pkg:npm/runtime")]
         public void ScopedNpmPackageSquats(string packageUrl, params string[] expectedSquats)

--- a/src/oss-tests/FindSquatsTests.cs
+++ b/src/oss-tests/FindSquatsTests.cs
@@ -145,6 +145,31 @@ namespace Microsoft.CST.OpenSource.Tests
         }
         
         [DataTestMethod]
+        [DataRow("pkg:npm/i")]
+        [DataRow("pkg:npm/ts")]
+        [DataRow("pkg:nuget/d")]
+        [DataRow("pkg:pypi/python")]
+        public void DontMakeMutationsOfJustSeparators(string packageUrl)
+        {
+            PackageURL purl = new(packageUrl);
+            if (purl.Name is not null && purl.Type is not null)
+            {
+                BaseProjectManager? manager = ProjectManagerFactory.ConstructPackageManager(purl, null);
+                if (manager is not null)
+                {
+                    foreach ((string _, IList<Mutation> mutations) in manager.EnumerateSquatCandidates(purl)!)
+                    {
+                        if (mutations.Any(m => m.Mutated.Length == 1 && SeparatorRemovedMutator.DefaultSeparators.Contains(Convert.ToChar(m.Mutated))))
+                        {
+                            Assert.Fail($"Found a mutation that's a separator.");
+                        }
+                    }
+                }
+            }
+
+        }
+        
+        [DataTestMethod]
         [DataRow("pkg:npm/foo")]
         [DataRow("pkg:npm/rx")]
         [DataRow("pkg:npm/q")]


### PR DESCRIPTION
- Readd `RemoveSeparatedSectionMutator` to the list of defaults, but remove it specifically for NPM.
- Fix issues where mutations would be just a separator. EX: `pkg:npm/q` would make `pkg:npm/.` or `pkg:npm/typescript` could make `pkg:npm/-`
- Fix bug with scoped npm packages with the prefix mutator would add before the `@` resulting in mutations like `pkg:npm/-%40types/node` when that isn't possible. It now adds after the `@` but before the namespace begins, resulting in `pkg:npm/%40-types/node`