### PR TITLE
Fix environment variable processing. (#406)

### DIFF
--- a/src/Shared/DefaultHttpClientFactory.cs
+++ b/src/Shared/DefaultHttpClientFactory.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CST.OpenSource
     public sealed class DefaultHttpClientFactory : IHttpClientFactory
     {
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
-        private string ENV_HTTPCLIENT_USER_AGENT = "microsoft_oss_gadget (https://github.com/microsoft/OSSGadget)";
+        public string ENV_HTTPCLIENT_USER_AGENT = "microsoft_oss_gadget (https://github.com/microsoft/OSSGadget)";
 
         public DefaultHttpClientFactory(string? userAgent = null)
         {

--- a/src/Shared/DefaultHttpClientFactory.cs
+++ b/src/Shared/DefaultHttpClientFactory.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CST.OpenSource
     public sealed class DefaultHttpClientFactory : IHttpClientFactory
     {
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
-        public string ENV_HTTPCLIENT_USER_AGENT = "microsoft_oss_gadget (https://github.com/microsoft/OSSGadget)";
+        public string ENV_HTTPCLIENT_USER_AGENT { get; set; } = "microsoft_oss_gadget (https://github.com/microsoft/OSSGadget)";
 
         public DefaultHttpClientFactory(string? userAgent = null)
         {

--- a/src/Shared/Helpers/EnvironmentHelper.cs
+++ b/src/Shared/Helpers/EnvironmentHelper.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CST.OpenSource.Helpers
         /// <param name="targetObject"> Examine this object (using reflection) </param>
         public static void OverrideEnvironmentVariables(object targetObject)
         {
-            foreach (FieldInfo fieldInfo in targetObject.GetType().GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic))
+            foreach (FieldInfo fieldInfo in targetObject.GetType().GetFields(BindingFlags.Public))
             {
                 if (fieldInfo.FieldType == typeof(string) &&
                     fieldInfo.Name.StartsWith("ENV_") &&

--- a/src/Shared/Helpers/EnvironmentHelper.cs
+++ b/src/Shared/Helpers/EnvironmentHelper.cs
@@ -16,19 +16,19 @@ namespace Microsoft.CST.OpenSource.Helpers
         /// <param name="targetObject"> Examine this object (using reflection) </param>
         public static void OverrideEnvironmentVariables(object targetObject)
         {
-            foreach (FieldInfo fieldInfo in targetObject.GetType().GetFields(BindingFlags.Public))
+            foreach (PropertyInfo propertyInfo in targetObject.GetType().GetProperties())
             {
-                if (fieldInfo.FieldType == typeof(string) &&
-                    fieldInfo.Name.StartsWith("ENV_") &&
-                    fieldInfo.Name.Length > 4)
+                if (propertyInfo.PropertyType == typeof(string) &&
+                    propertyInfo.Name.StartsWith("ENV_") &&
+                    propertyInfo.Name.Length > 4)
                 {
-                    string? bareName = fieldInfo.Name[4..];
+                    string? bareName = propertyInfo.Name[4..];
 
                     string? value = Environment.GetEnvironmentVariable(bareName);
                     if (value != null)
                     {
-                        Logger.Debug("Assiging value of {0} to {1}", bareName, fieldInfo.Name);
-                        fieldInfo.SetValue(targetObject, value);
+                        Logger.Debug("Assiging value of {0} to {1}", bareName, propertyInfo.Name);
+                        propertyInfo.SetValue(targetObject, value);
                     }
                 }
             }

--- a/src/Shared/Helpers/EnvironmentHelper.cs
+++ b/src/Shared/Helpers/EnvironmentHelper.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CST.OpenSource.Helpers
         /// <param name="targetObject"> Examine this object (using reflection) </param>
         public static void OverrideEnvironmentVariables(object targetObject)
         {
-            foreach (FieldInfo fieldInfo in targetObject.GetType().GetFields(BindingFlags.Public))
+            foreach (FieldInfo fieldInfo in targetObject.GetType().GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic))
             {
                 if (fieldInfo.FieldType == typeof(string) &&
                     fieldInfo.Name.StartsWith("ENV_") &&

--- a/src/Shared/Metadata/BaseMetadataSource.cs
+++ b/src/Shared/Metadata/BaseMetadataSource.cs
@@ -2,6 +2,7 @@
 
 namespace Microsoft.CST.OpenSource;
 
+using Helpers;
 using System.Threading.Tasks;
 using System.Text.Json;
 using PackageUrl;
@@ -21,6 +22,7 @@ public abstract class BaseMetadataSource
     
     public BaseMetadataSource()
     {
+        EnvironmentHelper.OverrideEnvironmentVariables(this);
         ServiceProvider serviceProvider = new ServiceCollection()
             .AddHttpClient()
             .BuildServiceProvider();

--- a/src/Shared/Metadata/DepsDevMetadataSource.cs
+++ b/src/Shared/Metadata/DepsDevMetadataSource.cs
@@ -11,8 +11,9 @@ using Microsoft.CST.OpenSource.PackageManagers;
 
 public class DepsDevMetadataSource : BaseMetadataSource
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
-    public string ENV_DEPS_DEV_ENDPOINT = "https://deps.dev/_";
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier",
+        Justification = "Modified through reflection.")]
+    public string ENV_DEPS_DEV_ENDPOINT { get; set; } = "https://deps.dev/_";
 
     public static readonly List<string> VALID_TYPES = new List<string>() {
         "npm",

--- a/src/Shared/Metadata/DepsDevMetadataSource.cs
+++ b/src/Shared/Metadata/DepsDevMetadataSource.cs
@@ -12,7 +12,7 @@ using Microsoft.CST.OpenSource.PackageManagers;
 public class DepsDevMetadataSource : BaseMetadataSource
 {
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
-    public static string ENV_DEPS_DEV_ENDPOINT = "https://deps.dev/_";
+    public string ENV_DEPS_DEV_ENDPOINT = "https://deps.dev/_";
 
     public static readonly List<string> VALID_TYPES = new List<string>() {
         "npm",

--- a/src/Shared/Metadata/LibrariesIoMetadataSource.cs
+++ b/src/Shared/Metadata/LibrariesIoMetadataSource.cs
@@ -11,8 +11,8 @@ using System.Collections.Generic;
 public class LibrariesIoMetadataSource : BaseMetadataSource
 {
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
-    public string ENV_LIBRARIES_IO_ENDPOINT = "https://libraries.io/api";
-    public string? ENV_LIBRARIES_IO_API_KEY = null;
+    public string ENV_LIBRARIES_IO_ENDPOINT { get; set; }= "https://libraries.io/api";
+    public string? ENV_LIBRARIES_IO_API_KEY { get; set; }= null;
 
     // Reload periodically from https://libraries.io/api/platforms
     // curl https://libraries.io/api/platforms | jq '.[].name' | sed 's/[A-Z]/\L&/g' | sed 's/$/,/g' | sort | sed '$ s/.$//'

--- a/src/Shared/Metadata/LibrariesIoMetadataSource.cs
+++ b/src/Shared/Metadata/LibrariesIoMetadataSource.cs
@@ -11,8 +11,8 @@ using System.Collections.Generic;
 public class LibrariesIoMetadataSource : BaseMetadataSource
 {
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
-    public static string ENV_LIBRARIES_IO_ENDPOINT = "https://libraries.io/api";
-    public static string? ENV_LIBRARIES_IO_API_KEY = null;
+    public string ENV_LIBRARIES_IO_ENDPOINT = "https://libraries.io/api";
+    public string? ENV_LIBRARIES_IO_API_KEY = null;
 
     // Reload periodically from https://libraries.io/api/platforms
     // curl https://libraries.io/api/platforms | jq '.[].name' | sed 's/[A-Z]/\L&/g' | sed 's/$/,/g' | sort | sed '$ s/.$//'

--- a/src/Shared/OssGadgetLib.cs
+++ b/src/Shared/OssGadgetLib.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CST.OpenSource
     public abstract class OssGadgetLib
     {
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
-        protected static string ENV_HTTPCLIENT_USER_AGENT = "OSSDL";
+        public string ENV_HTTPCLIENT_USER_AGENT = "OSSDL";
 
         /// <summary>
         /// The <see cref="ProjectManagerFactory"/> to be used by classes that implement <see cref="OssGadgetLib"/>.

--- a/src/Shared/OssGadgetLib.cs
+++ b/src/Shared/OssGadgetLib.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CST.OpenSource
     public abstract class OssGadgetLib
     {
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
-        public string ENV_HTTPCLIENT_USER_AGENT = "OSSDL";
+        public string ENV_HTTPCLIENT_USER_AGENT { get; set; }= "OSSDL";
 
         /// <summary>
         /// The <see cref="ProjectManagerFactory"/> to be used by classes that implement <see cref="OssGadgetLib"/>.

--- a/src/Shared/PackageManagers/CPANProjectManager.cs
+++ b/src/Shared/PackageManagers/CPANProjectManager.cs
@@ -26,13 +26,13 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         public override string ManagerType => Type;
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
-        public string ENV_CPAN_BINARY_ENDPOINT = "https://cpan.metacpan.org";
+        public string ENV_CPAN_BINARY_ENDPOINT { get; set; } = "https://cpan.metacpan.org";
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
-        public string ENV_CPAN_ENDPOINT = "https://metacpan.org";
+        public string ENV_CPAN_ENDPOINT { get; set; } = "https://metacpan.org";
         
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
-        public string ENV_CPAN_API_ENDPOINT = "https://fastapi.metacpan.org";
+        public string ENV_CPAN_API_ENDPOINT { get; set; } = "https://fastapi.metacpan.org";
 
         public CPANProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory) : base(httpClientFactory, destinationDirectory)
         {

--- a/src/Shared/PackageManagers/CRANProjectManager.cs
+++ b/src/Shared/PackageManagers/CRANProjectManager.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         public override string ManagerType => Type;
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
-        public string ENV_CRAN_ENDPOINT = "https://cran.r-project.org";
+        public string ENV_CRAN_ENDPOINT { get; set; } = "https://cran.r-project.org";
 
         public CRANProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory) : base(httpClientFactory, destinationDirectory)
         {

--- a/src/Shared/PackageManagers/CargoProjectManager.cs
+++ b/src/Shared/PackageManagers/CargoProjectManager.cs
@@ -31,13 +31,13 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         public override string ManagerType => Type;
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
-        public string ENV_CARGO_ENDPOINT = "https://crates.io";
+        public string ENV_CARGO_ENDPOINT { get; set; } = "https://crates.io";
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
-        public string ENV_CARGO_ENDPOINT_STATIC = "https://static.crates.io";
+        public string ENV_CARGO_ENDPOINT_STATIC { get; set; } = "https://static.crates.io";
         
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
-        public string ENV_CARGO_INDEX_ENDPOINT = "https://raw.githubusercontent.com/rust-lang/crates.io-index/master";
+        public string ENV_CARGO_INDEX_ENDPOINT { get; set; } = "https://raw.githubusercontent.com/rust-lang/crates.io-index/master";
 
         public CargoProjectManager(
             string directory,

--- a/src/Shared/PackageManagers/CocoapodsProjectManager.cs
+++ b/src/Shared/PackageManagers/CocoapodsProjectManager.cs
@@ -28,13 +28,13 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         public override string ManagerType => Type;
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
-        public string ENV_COCOAPODS_SPECS_ENDPOINT = "https://github.com/CocoaPods/Specs/tree/master";
+        public string ENV_COCOAPODS_SPECS_ENDPOINT { get; set; } = "https://github.com/CocoaPods/Specs/tree/master";
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
-        public string ENV_COCOAPODS_SPECS_RAW_ENDPOINT = "https://raw.githubusercontent.com/CocoaPods/Specs/master";
+        public string ENV_COCOAPODS_SPECS_RAW_ENDPOINT { get; set; } = "https://raw.githubusercontent.com/CocoaPods/Specs/master";
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
-        public string ENV_COCOAPODS_METADATA_ENDPOINT = "https://cocoapods.org";
+        public string ENV_COCOAPODS_METADATA_ENDPOINT { get; set; } = "https://cocoapods.org";
 
         public CocoapodsProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory) : base(httpClientFactory, destinationDirectory)
         {

--- a/src/Shared/PackageManagers/ComposerProjectManager.cs
+++ b/src/Shared/PackageManagers/ComposerProjectManager.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         public override string ManagerType => Type;
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
-        public string ENV_COMPOSER_ENDPOINT = "https://repo.packagist.org";
+        public string ENV_COMPOSER_ENDPOINT { get; set; } = "https://repo.packagist.org";
 
         public ComposerProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory) : base(httpClientFactory, destinationDirectory)
         {

--- a/src/Shared/PackageManagers/GemProjectManager.cs
+++ b/src/Shared/PackageManagers/GemProjectManager.cs
@@ -24,8 +24,8 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
         public override string ManagerType => Type;
 
-        public string ENV_RUBYGEMS_ENDPOINT = "https://rubygems.org";
-        public string ENV_RUBYGEMS_ENDPOINT_API = "https://api.rubygems.org";
+        public string ENV_RUBYGEMS_ENDPOINT { get; set; } = "https://rubygems.org";
+        public string ENV_RUBYGEMS_ENDPOINT_API { get; set; } = "https://api.rubygems.org";
 
         public GemProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory) : base(httpClientFactory, destinationDirectory)
         {

--- a/src/Shared/PackageManagers/GitHubProjectManager.cs
+++ b/src/Shared/PackageManagers/GitHubProjectManager.cs
@@ -187,7 +187,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             try
             {
                 List<string> versionList = new();
-                string githubUrl = $"https://github.com/{purl.Namespace}/{purl.Name}";
+                string githubUrl = GeneratePackageUriString(purl);
 
                 ProcessStartInfo gitLsRemoteStartInfo = new()
                 {

--- a/src/Shared/PackageManagers/GitHubProjectManager.cs
+++ b/src/Shared/PackageManagers/GitHubProjectManager.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         public override string ManagerType => Type;
 
         private const string DEFAULT_GITHUB_ENDPOINT = "https://github.com";
-        public string ENV_GITHUB_ENDPOINT = DEFAULT_GITHUB_ENDPOINT;
+        public string ENV_GITHUB_ENDPOINT { get; set; } = DEFAULT_GITHUB_ENDPOINT;
 
         public GitHubProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory) : base(httpClientFactory, destinationDirectory)
         {

--- a/src/Shared/PackageManagers/GitHubProjectManager.cs
+++ b/src/Shared/PackageManagers/GitHubProjectManager.cs
@@ -245,13 +245,16 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         public override async Task<string?> GetMetadataAsync(PackageURL purl, bool useCache = true)
         {
             await Task.CompletedTask;
-            return $"{ENV_GITHUB_ENDPOINT}/{purl.Namespace}/{purl.Name}";
+            return GeneratePackageUriString(purl);
         }
 
         public override Uri GetPackageAbsoluteUri(PackageURL purl)
         {
-            return new Uri($"{ENV_GITHUB_ENDPOINT}/{purl.Namespace}/{purl.Name}");
+            return new Uri(GeneratePackageUriString(purl));
         }
+
+        private string GeneratePackageUriString(PackageURL purl) =>
+            $"{ENV_GITHUB_ENDPOINT}/{purl.Namespace}/{purl.Name}";
         
         /// <summary>
         /// Gets if the URL is a GitHub repo URL using the default endpoint.

--- a/src/Shared/PackageManagers/GitHubProjectManager.cs
+++ b/src/Shared/PackageManagers/GitHubProjectManager.cs
@@ -245,7 +245,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         public override async Task<string?> GetMetadataAsync(PackageURL purl, bool useCache = true)
         {
             await Task.CompletedTask;
-            return $"https://github.com/{purl.Namespace}/{purl.Name}";
+            return $"{ENV_GITHUB_ENDPOINT}/{purl.Namespace}/{purl.Name}";
         }
 
         public override Uri GetPackageAbsoluteUri(PackageURL purl)

--- a/src/Shared/PackageManagers/GolangProjectManager.cs
+++ b/src/Shared/PackageManagers/GolangProjectManager.cs
@@ -29,10 +29,10 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         public override string ManagerType => Type;
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
-        public string ENV_GO_PROXY_ENDPOINT = "https://proxy.golang.org";
+        public string ENV_GO_PROXY_ENDPOINT { get; set; } = "https://proxy.golang.org";
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
-        public string ENV_GO_PKG_ENDPOINT = "https://pkg.go.dev";
+        public string ENV_GO_PKG_ENDPOINT { get; set; } = "https://pkg.go.dev";
 
         public GolangProjectManager(
             string directory,

--- a/src/Shared/PackageManagers/HackageProjectManager.cs
+++ b/src/Shared/PackageManagers/HackageProjectManager.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         public override string ManagerType => Type;
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
-        public string ENV_HACKAGE_ENDPOINT = "https://hackage.haskell.org";
+        public string ENV_HACKAGE_ENDPOINT { get; set; } = "https://hackage.haskell.org";
 
         public HackageProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory) : base(httpClientFactory, destinationDirectory)
         {

--- a/src/Shared/PackageManagers/NuGetProjectManager.cs
+++ b/src/Shared/PackageManagers/NuGetProjectManager.cs
@@ -31,10 +31,10 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         public override string ManagerType => Type;
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
-        public string ENV_NUGET_ENDPOINT_API = "https://api.nuget.org";
+        public string ENV_NUGET_ENDPOINT_API { get; set; } = "https://api.nuget.org";
         
         // Unused currently.
-        public string ENV_NUGET_ENDPOINT = "https://www.nuget.org";
+        public string ENV_NUGET_ENDPOINT { get; set; } = "https://www.nuget.org";
         
         // These are named Default, do they need to be overridden as well?
         public const string NUGET_DEFAULT_REGISTRATION_ENDPOINT = "https://api.nuget.org/v3/registration5-gz-semver2/";
@@ -439,7 +439,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
-        public string ENV_NUGET_HOMEPAGE = "https://www.nuget.org/packages";
+        public string ENV_NUGET_HOMEPAGE { get; set; } = "https://www.nuget.org/packages";
 
         public enum NuGetArtifactType
         {

--- a/src/Shared/PackageManagers/NuGetProjectManager.cs
+++ b/src/Shared/PackageManagers/NuGetProjectManager.cs
@@ -439,7 +439,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
-        private static string ENV_NUGET_HOMEPAGE = "https://www.nuget.org/packages";
+        public string ENV_NUGET_HOMEPAGE = "https://www.nuget.org/packages";
 
         public enum NuGetArtifactType
         {

--- a/src/Shared/PackageManagers/UbuntuProjectManager.cs
+++ b/src/Shared/PackageManagers/UbuntuProjectManager.cs
@@ -26,13 +26,13 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         public override string ManagerType => Type;
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
-        public string ENV_UBUNTU_ARCHIVE_MIRROR = "https://mirror.math.princeton.edu/pub";
+        public string ENV_UBUNTU_ARCHIVE_MIRROR { get; set; } = "https://mirror.math.princeton.edu/pub";
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
-        public string ENV_UBUNTU_ENDPOINT = "https://packages.ubuntu.com";
+        public string ENV_UBUNTU_ENDPOINT { get; set; } = "https://packages.ubuntu.com";
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
-        public string ENV_UBUNTU_POOL_NAMES = "main,universe,multiverse,restricted";
+        public string ENV_UBUNTU_POOL_NAMES { get; set; } = "main,universe,multiverse,restricted";
 
         public UbuntuProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory) : base(httpClientFactory, destinationDirectory)
         {

--- a/src/Shared/PackageManagers/VSMProjectManager.cs
+++ b/src/Shared/PackageManagers/VSMProjectManager.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         public override string ManagerType => Type;
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
-        public string ENV_VS_MARKETPLACE_ENDPOINT = "https://marketplace.visualstudio.com";
+        public string ENV_VS_MARKETPLACE_ENDPOINT { get; set; } = "https://marketplace.visualstudio.com";
 
         public VSMProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory) : base(httpClientFactory, destinationDirectory)
         {

--- a/src/oss-health/GitHubHealthAlgorithm.cs
+++ b/src/oss-health/GitHubHealthAlgorithm.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CST.OpenSource.Health
         ///     Will be automatically set from matching Environment variable on class construction. 
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
-        public string? ENV_GITHUB_ACCESS_TOKEN = null;
+        public string? ENV_GITHUB_ACCESS_TOKEN { get; set; } = null;
 
         /// <summary>
         ///     User Agent used when connecting to GitHub.

--- a/src/oss-health/GitHubHealthAlgorithm.cs
+++ b/src/oss-health/GitHubHealthAlgorithm.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CST.OpenSource.Health
         ///     Will be automatically set from matching Environment variable on class construction. 
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
-        public string ENV_HTTPCLIENT_USER_AGENT = "GitHubProjectHealth";
+        public string ENV_HTTPCLIENT_USER_AGENT { get; set; } = "GitHubProjectHealth";
 
         /// <summary>
         ///     PackageURL to analyze

--- a/src/oss-health/GitHubHealthAlgorithm.cs
+++ b/src/oss-health/GitHubHealthAlgorithm.cs
@@ -32,17 +32,18 @@ namespace Microsoft.CST.OpenSource.Health
         private static readonly ApiOptions DEFAULT_API_OPTIONS = new ApiOptions { PageCount = 5, PageSize = 100 };
 
         /// <summary>
-        ///     Access token used when connecting to GitHub. Multiple allowed, separated by a comma. Updated
-        ///     automatically during program start.
+        ///     Access token used when connecting to GitHub. Multiple allowed, separated by a comma.
+        ///     Will be automatically set from matching Environment variable on class construction. 
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
-        private static string? ENV_GITHUB_ACCESS_TOKEN = null;
+        public string? ENV_GITHUB_ACCESS_TOKEN = null;
 
         /// <summary>
-        ///     User Agent used when connecting to GitHub. Updated automatically during program start, if needed.
+        ///     User Agent used when connecting to GitHub.
+        ///     Will be automatically set from matching Environment variable on class construction. 
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
-        private static string ENV_HTTPCLIENT_USER_AGENT = "GitHubProjectHealth";
+        public string ENV_HTTPCLIENT_USER_AGENT = "GitHubProjectHealth";
 
         /// <summary>
         ///     PackageURL to analyze


### PR DESCRIPTION
Search for static and non public members as well when overriding values. Here's how the member is defined in GitHubHealthAlgorithm.cs:
private static string? ENV_GITHUB_ACCESS_TOKEN = null;

Searching for public members only misses it and it's never set from the environment variable.
I don't know if this is the right way to fix this, but at least it get's me one step further and I can actually run the oss-health tool for an npm project. 