### PR TITLE
Add new AddContainingCharacterMutator

### DIFF
--- a/src/oss-find-squats-lib/MutateExtension.cs
+++ b/src/oss-find-squats-lib/MutateExtension.cs
@@ -25,6 +25,7 @@ namespace Microsoft.CST.OpenSource.FindSquats.ExtensionMethods
         internal static IEnumerable<IMutator> BaseMutators { get; } = new List<IMutator>()
         {
             new AddCharacterMutator(),
+            new AddContainingCharacterMutator(),
             new AsciiHomoglyphMutator(),
             new BitFlipMutator(),
             new CloseLettersMutator(),

--- a/src/oss-find-squats-lib/Mutators/AddContainingCharacterMutator.cs
+++ b/src/oss-find-squats-lib/Mutators/AddContainingCharacterMutator.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+namespace Microsoft.CST.OpenSource.FindSquats.Mutators
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    /// <summary>
+    /// Generates mutations for adding a character in the string, where the character being added already exists in the string.
+    /// </summary>
+    /// <example>requests -> reuquests. But won't generate something like requests -> regquests</example>
+    public class AddContainingCharacterMutator : IMutator
+    {
+        public MutatorType Kind { get; } = MutatorType.AddContainingCharacter;
+
+        public IEnumerable<Mutation> Generate(string arg)
+        {
+            var chars = arg.Distinct().ToArray();
+            for (int i = 0; i < arg.Length+1; i++)
+            {
+                // Can't add a character before an @ for a scoped package.
+                if (i == 0 && arg[i] == '@')
+                {
+                    continue;
+                }
+
+                foreach (var c in chars)
+                {
+                    yield return new Mutation(
+                        mutated: $"{arg[..i]}{c}{arg[i..]}",
+                        original: arg,
+                        mutator: Kind,
+                        reason: $"Containing Character Added: {c}");
+                }
+            }
+        }
+    }
+}

--- a/src/oss-find-squats-lib/Mutators/MutatorType.cs
+++ b/src/oss-find-squats-lib/Mutators/MutatorType.cs
@@ -20,6 +20,10 @@ namespace Microsoft.CST.OpenSource.FindSquats.Mutators
         /// </summary>
         AddCharacter,
         /// <summary>
+        /// The <see cref="AddContainingCharacterMutator"/> mutator.
+        /// </summary>
+        AddContainingCharacter,
+        /// <summary>
         /// The <see cref="AsciiHomoglyphMutator"/> mutator.
         /// </summary>
         AsciiHomoglyph,


### PR DESCRIPTION
This new mutator was added to help with scenarios of going from squat candidate, to popular package name, and then confirming that said squat candidate is a squat on the popular package.

Example being, without the AddCharacterMutator, pkg:pypi/reuquests would not be a squat on pkg:pypi/requests, this mutator adds that ability without adding too much noise such as saying pkg:pypi/requestsn is also a squat on pkg:pypi/requests