### PR TITLE
Add a nuget suffix for squats "core" and ".core"

### DIFF
--- a/src/oss-find-squats-lib/MutateExtension.cs
+++ b/src/oss-find-squats-lib/MutateExtension.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CST.OpenSource.FindSquats.ExtensionMethods
                 {
                     new CloseLettersMutator(additionalExcludedChars: new[] { '/' }),
                     new DoubleHitMutator(additionalExcludedChars: new[] { '/' }),
-                    new SuffixMutator(additionalSuffixes: new[] { "net", ".net", "nuget" }, skipSuffixes: new[] { "." })
+                    new SuffixMutator(additionalSuffixes: new[] { "net", ".net", "nuget", "core", ".core" }, skipSuffixes: new[] { "." })
                 });
 
         /// <summary>

--- a/src/oss-tests/FindSquatsTests.cs
+++ b/src/oss-tests/FindSquatsTests.cs
@@ -93,6 +93,9 @@ namespace Microsoft.CST.OpenSource.Tests
         [DataRow("pkg:npm/angular/core", "pkg:npm/angularcore")] // NamespaceInName, 'angular'
         [DataRow("pkg:npm/%40angular/core", "pkg:npm/angular.core")] // NamespaceInName, 'angular'
         [DataRow("pkg:nuget/Microsoft.CST.OAT", "pkg:nuget/microsoft.cst.oat.net")] // SuffixAdded, .net
+
+        // Based on attack seen here: https://medium.com/checkmarx-security/new-attack-vector-observed-targeting-net-developers-in-a-software-supply-chain-attack-c28bfe4decd2
+        [DataRow("pkg:nuget/Coinbase", "pkg:nuget/Coinbase.Core")] // SuffixAdded, .core
         public void GenerateManagerSpecific(string packageUrl, string expectedToFind)
         {
             PackageURL purl = new(packageUrl);


### PR DESCRIPTION
Based on attack seen here: https://medium.com/checkmarx-security/new-attack-vector-observed-targeting-net-developers-in-a-software-supply-chain-attack-c28bfe4decd2