### PR TITLE
Parse nuget version to exclude metadata when creating package URL's

### DIFF
--- a/src/Shared/PackageManagers/NuGetProjectManager.cs
+++ b/src/Shared/PackageManagers/NuGetProjectManager.cs
@@ -63,15 +63,8 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                     $"NuGet package URLs having a repository URL other than '{NUGET_DEFAULT_INDEX}' are not currently supported.");
             }
             
-            var basePath = NUGET_DEFAULT_CONTENT_ENDPOINT.EnsureTrailingSlash();
-            var nameLowercase = purl.Name.ToLowerInvariant();
-            var versionLowercase = NuGetVersion.Parse(purl.Version.ToLowerInvariant());
-
-            yield return new ArtifactUri<NuGetArtifactType>(NuGetArtifactType.Nupkg,
-                $"{basePath}{nameLowercase}/{versionLowercase}/{nameLowercase}.{versionLowercase}.nupkg");
-
-            yield return new ArtifactUri<NuGetArtifactType>(NuGetArtifactType.Nuspec, 
-                $"{basePath}{nameLowercase}/{versionLowercase}/{nameLowercase}.nuspec");
+            yield return new ArtifactUri<NuGetArtifactType>(NuGetArtifactType.Nupkg, GetNupkgUrl(purl.Name, purl.Version));
+            yield return new ArtifactUri<NuGetArtifactType>(NuGetArtifactType.Nuspec, GetNuspecUrl(purl.Name, purl.Version));
         }
 
         /// <inheritdoc />
@@ -236,12 +229,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                 throw new ArgumentNullException(nameof(purl), "Provided PackageURL was null.");
             }
 
-            HttpClient httpClient = CreateHttpClient();
-            
-            // NuGet packages are case insensitive
-            string endpoint = $"{RegistrationEndpoint}{purl.Name.ToLowerInvariant()}/index.json";
-
-            return await CheckHttpCacheForPackage(httpClient, endpoint, useCache);
+            return await this.Actions.DoesPackageExistAsync(purl, useCache);
         }
 
         /// <inheritdoc />
@@ -254,18 +242,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                 return false;
             }
 
-            if (!NuGetVersion.TryParse(purl.Version.ToLowerInvariant(), out NuGetVersion nugetVersion))
-            {
-                Logger.Trace("Provided PackageURL version was null or blank.");
-                return false;
-            }
-
-            HttpClient httpClient = CreateHttpClient();
-
-            // NuGet packages are case insensitive
-            string endpoint = $"{NUGET_DEFAULT_CONTENT_ENDPOINT.EnsureTrailingSlash()}{purl.Name.ToLowerInvariant()}/{nugetVersion}/{purl.Name.ToLowerInvariant()}.nuspec";
-
-            return await CheckHttpCacheForPackage(httpClient, endpoint, useCache);
+            return await this.Actions.DoesPackageExistAsync(purl, useCache);
         }
 
         /// <summary>
@@ -379,6 +356,20 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         }
 
         /// <summary>
+        /// Helper method to get the URL to download a NuGet package's .nuspec.
+        /// </summary>
+        /// <param name="id">The id/name of the package to get the .nuspec for.</param>
+        /// <param name="version">The version of the package to get the .nuspec for.</param>
+        /// <returns>The URL for the nuspec file.</returns>
+        private static string GetNuspecUrl(string id, string version)
+        {
+            string lowerId = id.ToLowerInvariant();
+            string lowerVersion = NuGetVersion.Parse(version).ToNormalizedString().ToLowerInvariant();
+            string url = $"{NUGET_DEFAULT_CONTENT_ENDPOINT.TrimEnd('/')}/{lowerId}/{lowerVersion}/{lowerId}.nuspec";
+            return url;
+        }
+
+        /// <summary>
         /// Searches the package manager metadata to figure out the source code repository.
         /// </summary>
         /// <param name="purl">The <see cref="PackageURL"/> that we need to find the source code repository.</param>
@@ -422,7 +413,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         {
             string lowerId = id.ToLowerInvariant();
             string lowerVersion = NuGetVersion.Parse(version).ToNormalizedString().ToLowerInvariant();
-            string uri = $"{NUGET_DEFAULT_CONTENT_ENDPOINT.TrimEnd('/')}/{lowerId}/{lowerVersion}/{lowerId}.nuspec";
+            string uri = GetNuspecUrl(lowerId, lowerVersion);
             try
             {
                 HttpClient httpClient = this.CreateHttpClient();

--- a/src/Shared/PackageManagers/NuGetProjectManager.cs
+++ b/src/Shared/PackageManagers/NuGetProjectManager.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             
             var basePath = NUGET_DEFAULT_CONTENT_ENDPOINT.EnsureTrailingSlash();
             var nameLowercase = purl.Name.ToLowerInvariant();
-            var versionLowercase = purl.Version.ToLowerInvariant();
+            var versionLowercase = NuGetVersion.Parse(purl.Version.ToLowerInvariant());
 
             yield return new ArtifactUri<NuGetArtifactType>(NuGetArtifactType.Nupkg,
                 $"{basePath}{nameLowercase}/{versionLowercase}/{nameLowercase}.{versionLowercase}.nupkg");
@@ -254,7 +254,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                 return false;
             }
 
-            if (purl.Version.IsBlank())
+            if (!NuGetVersion.TryParse(purl.Version.ToLowerInvariant(), out NuGetVersion nugetVersion))
             {
                 Logger.Trace("Provided PackageURL version was null or blank.");
                 return false;
@@ -263,7 +263,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             HttpClient httpClient = CreateHttpClient();
 
             // NuGet packages are case insensitive
-            string endpoint = $"{NUGET_DEFAULT_CONTENT_ENDPOINT.EnsureTrailingSlash()}{purl.Name.ToLowerInvariant()}/{purl.Version.ToLowerInvariant()}/{purl.Name.ToLowerInvariant()}.nuspec";
+            string endpoint = $"{NUGET_DEFAULT_CONTENT_ENDPOINT.EnsureTrailingSlash()}{purl.Name.ToLowerInvariant()}/{nugetVersion}/{purl.Name.ToLowerInvariant()}.nuspec";
 
             return await CheckHttpCacheForPackage(httpClient, endpoint, useCache);
         }

--- a/src/oss-tests/ProjectManagerTests/NuGetProjectManagerTests.cs
+++ b/src/oss-tests/ProjectManagerTests/NuGetProjectManagerTests.cs
@@ -107,6 +107,17 @@ namespace Microsoft.CST.OpenSource.Tests.ProjectManagerTests
             Assert.IsTrue(exists);
         }
 
+        [TestMethod]
+        public async Task TestNugetPackageWithVersionMetadataInPurlExists()
+        {
+            PackageURL purl = new("pkg:nuget/Pulumi@3.29.0-alpha.1649173720+667fd085");
+            _projectManager = new NuGetProjectManager(".", null, _httpFactory);
+
+            bool exists = await _projectManager.PackageVersionExistsAsync(purl, useCache: false);
+
+            Assert.IsTrue(exists);
+        }
+
         [DataTestMethod]
         [DataRow("pkg:nuget/razorengine@4.2.3-beta1", false, "RazorEngine - A Templating Engine based on the Razor parser.", "Matthew Abbott, Ben Dornis, Matthias Dittrich")] // Normal package
         [DataRow("pkg:nuget/razorengine", false, "RazorEngine - A Templating Engine based on the Razor parser.", "Matthew Abbott, Ben Dornis, Matthias Dittrich", "4.5.1-alpha001")] // Normal package, no specified version
@@ -297,6 +308,9 @@ namespace Microsoft.CST.OpenSource.Tests.ProjectManagerTests
         [DataRow("pkg:nuget/SlipeServer.Scripting@0.1.0-CI-20220607-083949", 
             "https://api.nuget.org/v3-flatcontainer/slipeserver.scripting/0.1.0-ci-20220607-083949/slipeserver.scripting.0.1.0-ci-20220607-083949.nupkg",
             "https://api.nuget.org/v3-flatcontainer/slipeserver.scripting/0.1.0-ci-20220607-083949/slipeserver.scripting.nuspec")]
+        [DataRow("pkg:nuget/Pulumi@3.29.0-alpha.1649173720+667fd085",
+           "https://api.nuget.org/v3-flatcontainer/pulumi/3.29.0-alpha.1649173720/pulumi.3.29.0-alpha.1649173720.nupkg",
+            "https://api.nuget.org/v3-flatcontainer/pulumi/3.29.0-alpha.1649173720/pulumi.nuspec")]
         public async Task GetArtifactDownloadUrisSucceeds_Async(string purlString, string expectedNuPkgUrl, string expectedNuSpecUri)
         {
             PackageURL purl = new(purlString);

--- a/src/oss-tests/ProjectManagerTests/NuGetProjectManagerTests.cs
+++ b/src/oss-tests/ProjectManagerTests/NuGetProjectManagerTests.cs
@@ -118,6 +118,17 @@ namespace Microsoft.CST.OpenSource.Tests.ProjectManagerTests
             Assert.IsTrue(exists);
         }
 
+        [TestMethod]
+        public async Task TestNugetPackageWithNormalizedVersionInPurlExists()
+        {
+            PackageURL purl = new("pkg:nuget/Pulumi@3.29.0-alpha.1649173720");
+            _projectManager = new NuGetProjectManager(".", null, _httpFactory);
+
+            bool exists = await _projectManager.PackageVersionExistsAsync(purl, useCache: false);
+
+            Assert.IsTrue(exists);
+        }
+
         [DataTestMethod]
         [DataRow("pkg:nuget/razorengine@4.2.3-beta1", false, "RazorEngine - A Templating Engine based on the Razor parser.", "Matthew Abbott, Ben Dornis, Matthias Dittrich")] // Normal package
         [DataRow("pkg:nuget/razorengine", false, "RazorEngine - A Templating Engine based on the Razor parser.", "Matthew Abbott, Ben Dornis, Matthias Dittrich", "4.5.1-alpha001")] // Normal package, no specified version
@@ -309,6 +320,9 @@ namespace Microsoft.CST.OpenSource.Tests.ProjectManagerTests
             "https://api.nuget.org/v3-flatcontainer/slipeserver.scripting/0.1.0-ci-20220607-083949/slipeserver.scripting.0.1.0-ci-20220607-083949.nupkg",
             "https://api.nuget.org/v3-flatcontainer/slipeserver.scripting/0.1.0-ci-20220607-083949/slipeserver.scripting.nuspec")]
         [DataRow("pkg:nuget/Pulumi@3.29.0-alpha.1649173720+667fd085",
+           "https://api.nuget.org/v3-flatcontainer/pulumi/3.29.0-alpha.1649173720/pulumi.3.29.0-alpha.1649173720.nupkg",
+            "https://api.nuget.org/v3-flatcontainer/pulumi/3.29.0-alpha.1649173720/pulumi.nuspec")]
+        [DataRow("pkg:nuget/Pulumi@3.29.0-alpha.1649173720",
            "https://api.nuget.org/v3-flatcontainer/pulumi/3.29.0-alpha.1649173720/pulumi.3.29.0-alpha.1649173720.nupkg",
             "https://api.nuget.org/v3-flatcontainer/pulumi/3.29.0-alpha.1649173720/pulumi.nuspec")]
         public async Task GetArtifactDownloadUrisSucceeds_Async(string purlString, string expectedNuPkgUrl, string expectedNuSpecUri)


### PR DESCRIPTION
"PackageVersionExistsAsync" and "GetArtifactDownloadUris"  methods return incorrect response when a package version with metadata is requested. This happens as the version string is not normalized as per NuGet standards when creating a download URL. Fixed the logic to parse nuget version using NuGet SDK.
