### PR TITLE
Add character limits for GitHub repo detection Regex

### DIFF
--- a/src/Shared/PackageManagers/GitHubProjectManager.cs
+++ b/src/Shared/PackageManagers/GitHubProjectManager.cs
@@ -279,31 +279,45 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             }
             return false;
         }
-        
-        
 
         private static readonly Regex GithubExtractorRegex = new(
-                    @"((?<protocol>https?|git|ssh|rsync)\+?)+\://" +
-                    @"(?:(?<username>[\w-]+)@)*" +
-                    @"(github\.com)" +
-                    @"[:/]*" +
-                    @"(?<port>[\d]+)?" +
-                    @"/(?<user>[\w-\.]+)" +
-                    @"/(?<repo>[\w-\.]+)/?",
-                        RegexOptions.Compiled);
+            @"(?<protocol>https?|git|ssh|rsync)\://" +
+            @"(?:(?<user>.+)@)*" +
+            @"(github\.com)" +
+            @"[:/]*" +
+            @"(?<port>[\d]+){0,1}" +
+            @"(?<pathname>\/((?<owner>[\w\-]{1,39})\/)?" + // GitHub Username Limit is 39
+            @"((?<name>[\w\-\.]{1,250}?)(\.git|\/)?)?)$" + // GitHub Repository name limit is 250
+            @"|" +
+            @"(git\+)?" +
+            @"((?<protocol>\w+)://)" +
+            @"((?<user>\w+)@)?" +
+            @"(github\.com)" +
+            @"(:(?<port>\d+))?" +
+            @"(?<pathname>\/((?<owner>[\w\-]{1,39})\/)?" + // GitHub Username Limit is 39
+            @"((?<name>[\w\-\.]{1,250}?)(\.git|\/)?)?)$", // GitHub Repository name limit is 250
+                RegexOptions.Compiled);
 
         /// <summary>
         ///     Regular expression that matches possible GitHub URLs
         /// </summary>
+        // Based on https://github.com/coala/git-url-parse/blob/d3eac95b21b2b166562e657fdfd974545653dfcc/giturlparse/parser.py#L38-L62
         private static readonly Regex GithubMatchRegex = new(
-            @"^((?<protocol>https?|git|ssh|rsync)\+?)+\://" +
-            @"(?:(?<user>.+)@)*" +
-            @"(?<resource>[a-z0-9_.-]*)" +
+            @"(?<protocol>https?|git|ssh|rsync)\://" +
+            @"(?:(?<user>.+)@){0,1}" +
+            @"(?<resource>[a-z0-9_.-]{0,253})" + // Hostname limit is 253
             @"[:/]*" +
-            @"(?<port>[\d]+)?" +
-            @"(?<pathname>\/((?<namespace>[\w\-\.]+)/)" +
-            @"(?<subpath>[\w\-]+/)*" +
-            @"((?<name>[\w\-\.]+?)(\.git|/)?)?)$",
+            @"(?<port>[\d]+){0,1}" +
+            @"(?<pathname>\/((?<owner>[\w\-]{1,39})\/)?" + // GitHub Username Limit is 39
+            @"((?<name>[\w\-\.]{1,250}?)(\.git|\/)?)?)$" + // GitHub Repository name limit is 250
+            @"|" +
+            @"(git\+)?" +
+            @"((?<protocol>\w+)://)" +
+            @"((?<user>\w+)@)?" +
+            @"((?<resource>[\w\.\-]{0,253}))" + // Hostname limit is 253
+            @"(:(?<port>\d+))?" +
+            @"(?<pathname>\/((?<owner>[\w\-]{1,39})\/)?" + // GitHub Username Limit is 39
+            @"((?<name>[\w\-\.]{1,250}?)(\.git|\/)?)?)$", // GitHub Repository name limit is 250
                 RegexOptions.Singleline | RegexOptions.Compiled);
     }
 }

--- a/src/Shared/PackageManagers/GitHubProjectManager.cs
+++ b/src/Shared/PackageManagers/GitHubProjectManager.cs
@@ -68,6 +68,10 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         public static PackageURL ParseUri(Uri uri)
         {
             Match match = GithubMatchRegex.Match(uri.AbsoluteUri);
+            if (!match.Success)
+            {
+                var x = 1;
+            }
             GroupCollection matches = match.Groups;
             PackageURL packageURL = new(
                 "github",
@@ -286,7 +290,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             @"(github\.com)" +
             @"[:/]*" +
             @"(?<port>[\d]+){0,1}" +
-            @"(?<pathname>\/((?<owner>[\w\-]{1,39})\/)?" + // GitHub Username Limit is 39
+            @"(?<pathname>\/((?<namespace>[\w\-]{1,39})\/)?" + // GitHub Username Limit is 39
             @"((?<name>[\w\-\.]{1,250}?)(\.git|\/)?)?)$" + // GitHub Repository name limit is 250
             @"|" +
             @"(git\+)?" +
@@ -294,7 +298,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             @"((?<user>\w+)@)?" +
             @"(github\.com)" +
             @"(:(?<port>\d+))?" +
-            @"(?<pathname>\/((?<owner>[\w\-]{1,39})\/)?" + // GitHub Username Limit is 39
+            @"(?<pathname>\/((?<namespace>[\w\-]{1,39})\/)?" + // GitHub Username Limit is 39
             @"((?<name>[\w\-\.]{1,250}?)(\.git|\/)?)?)$", // GitHub Repository name limit is 250
                 RegexOptions.Compiled);
 
@@ -308,7 +312,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             @"(?<resource>[a-z0-9_.-]{0,253})" + // Hostname limit is 253
             @"[:/]*" +
             @"(?<port>[\d]+){0,1}" +
-            @"(?<pathname>\/((?<owner>[\w\-]{1,39})\/)?" + // GitHub Username Limit is 39
+            @"(?<pathname>\/((?<namespace>[\w\-]{1,39})\/)?" + // GitHub Username Limit is 39
             @"((?<name>[\w\-\.]{1,250}?)(\.git|\/)?)?)$" + // GitHub Repository name limit is 250
             @"|" +
             @"(git\+)?" +
@@ -316,7 +320,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             @"((?<user>\w+)@)?" +
             @"((?<resource>[\w\.\-]{0,253}))" + // Hostname limit is 253
             @"(:(?<port>\d+))?" +
-            @"(?<pathname>\/((?<owner>[\w\-]{1,39})\/)?" + // GitHub Username Limit is 39
+            @"(?<pathname>\/((?<namespace>[\w\-]{1,39})\/)?" + // GitHub Username Limit is 39
             @"((?<name>[\w\-\.]{1,250}?)(\.git|\/)?)?)$", // GitHub Repository name limit is 250
                 RegexOptions.Singleline | RegexOptions.Compiled);
     }

--- a/src/Shared/PackageManagers/GitHubProjectManager.cs
+++ b/src/Shared/PackageManagers/GitHubProjectManager.cs
@@ -286,18 +286,18 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
         private static readonly Regex GithubExtractorRegex = new(
             @"(?<protocol>https?|git|ssh|rsync)\://" +
-            @"(?:(?<user>.+)@)*" +
+            @"(?:(?<user>.{1,255})@){0,1}" +
             @"(github\.com)" +
             @"[:/]*" +
-            @"(?<port>[\d]+){0,1}" +
+            @"(?<port>[\d]{1,10}){0,1}" +
             @"(?<pathname>\/((?<namespace>[\w\-]{1,39})\/)?" + // GitHub Username Limit is 39
             @"((?<name>[\w\-\.]{1,250}?)(\.git|\/)?)?)$" + // GitHub Repository name limit is 250
             @"|" +
             @"(git\+)?" +
-            @"((?<protocol>\w+)://)" +
-            @"((?<user>\w+)@)?" +
+            @"((?<protocol>\w{1,20})://)" +
+            @"(?:(?<user>.{1,255})@){0,1}" +
             @"(github\.com)" +
-            @"(:(?<port>\d+))?" +
+            @"(?<port>[\d]{1,10}){0,1}" +
             @"(?<pathname>\/((?<namespace>[\w\-]{1,39})\/)?" + // GitHub Username Limit is 39
             @"((?<name>[\w\-\.]{1,250}?)(\.git|\/)?)?)$", // GitHub Repository name limit is 250
                 RegexOptions.Compiled);
@@ -308,20 +308,20 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         // Based on https://github.com/coala/git-url-parse/blob/d3eac95b21b2b166562e657fdfd974545653dfcc/giturlparse/parser.py#L38-L62
         private static readonly Regex GithubMatchRegex = new(
             @"(?<protocol>https?|git|ssh|rsync)\://" +
-            @"(?:(?<user>.+)@){0,1}" +
+            @"(?:(?<user>.{1,255})@){0,1}" +
             @"(?<resource>[a-z0-9_.-]{0,253})" + // Hostname limit is 253
             @"[:/]*" +
-            @"(?<port>[\d]+){0,1}" +
+            @"(?<port>[\d]{1,10}){0,1}" +
             @"(?<pathname>\/((?<namespace>[\w\-]{1,39})\/)?" + // GitHub Username Limit is 39
             @"((?<name>[\w\-\.]{1,250}?)(\.git|\/)?)?)$" + // GitHub Repository name limit is 250
             @"|" +
             @"(git\+)?" +
-            @"((?<protocol>\w+)://)" +
-            @"((?<user>\w+)@)?" +
+            @"((?<protocol>\w{1,10})://)" +
+            @"(?:(?<user>.{1,255})@){0,1}" +
             @"((?<resource>[\w\.\-]{0,253}))" + // Hostname limit is 253
-            @"(:(?<port>\d+))?" +
-            @"(?<pathname>\/((?<namespace>[\w\-]{1,39})\/)?" + // GitHub Username Limit is 39
+            @"(?<port>[\d]{1,10}){0,1}" +
+            @"(?<pathname>/((?<namespace>[\w\-]{1,39})\/)?" + // GitHub Username Limit is 39
             @"((?<name>[\w\-\.]{1,250}?)(\.git|\/)?)?)$", // GitHub Repository name limit is 250
-                RegexOptions.Singleline | RegexOptions.Compiled);
+            RegexOptions.Singleline | RegexOptions.Compiled);
     }
 }


### PR DESCRIPTION
Adds reasonable limits on length of matches for various components of the github url.