### PR TITLE
Add interfaces enabling consuming projects to mock ProjectManagerFactory, BaseProjectManager, and TypedManager

### DIFF
--- a/src/Shared/Contracts/IBaseProjectManager.cs
+++ b/src/Shared/Contracts/IBaseProjectManager.cs
@@ -1,0 +1,156 @@
+// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+namespace Microsoft.CST.OpenSource.Contracts;
+
+using Model;
+using PackageUrl;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Version = SemanticVersioning.Version;
+
+public interface IBaseProjectManager
+{
+    /// <summary>
+    /// The type of the project manager from the package-url type specifications.
+    /// </summary>
+    /// <remarks>This differs from the Type property defined in other ProjectManagers as this one isn't static.</remarks>
+    /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
+    public string ManagerType { get; }
+
+    /// <summary>
+    /// Per-object option container.
+    /// </summary>
+    public Dictionary<string, object> Options { get; }
+
+    /// <summary>
+    /// The location (directory) to extract files to.
+    /// </summary>
+    public string TopLevelExtractionDirectory { get; init; }
+
+    /// <summary>
+    /// The <see cref="IHttpClientFactory"/> for the manager.
+    /// </summary>
+    public IHttpClientFactory HttpClientFactory { get; }
+
+    /// <summary>
+    /// Downloads a given PackageURL and extracts it locally to a directory.
+    /// </summary>
+    /// <param name="purl">PackageURL to download</param>
+    /// <returns>Paths (either files or directory names) pertaining to the downloaded files.</returns>
+    public Task<IEnumerable<string>> DownloadVersionAsync(PackageURL purl, bool doExtract, bool cached = false);
+
+    /// <summary>
+    /// Enumerates all possible versions of the package identified by purl, in descending order.
+    /// </summary>
+    /// <remarks>The latest version is always first, then it is sorted by SemVer in descending order.</remarks>
+    /// <param name="purl">Package URL specifying the package. Version is ignored.</param>
+    /// <param name="useCache">If the cache should be used when looking for the versions.</param>
+    /// <param name="includePrerelease">If pre-release versions should be included.</param>
+    /// <returns> A list of package version numbers.</returns>
+    public Task<IEnumerable<string>> EnumerateVersionsAsync(PackageURL purl, bool useCache = true, bool includePrerelease = true);
+
+    /// <summary>
+    /// Gets the latest version from the package metadata.
+    /// </summary>
+    /// <param name="metadata">The package metadata to parse.</param>
+    /// <returns>The latest version of the package.</returns>
+    public Version? GetLatestVersion(JsonDocument metadata);
+
+    /// <summary>
+    /// Check if the package exists in the repository.
+    /// </summary>
+    /// <param name="purl">The PackageURL to check.</param>
+    /// <param name="useCache">If the cache should be checked for the existence of this package.</param>
+    /// <returns>True if the package is confirmed to exist in the repository. False otherwise.</returns>
+    public Task<bool> PackageExistsAsync(PackageURL purl, bool useCache = true);
+
+    /// <summary>
+    /// Check if the package exists/existed in the repository.
+    /// </summary>
+    /// <param name="purl">The PackageURL to check.</param>
+    /// <param name="useCache">If the cache should be checked for the existence of this package.</param>
+    /// <returns>A <see cref="IPackageExistence"/> detailing the existence of the package.</returns>
+    public Task<IPackageExistence> DetailedPackageExistsAsync(PackageURL purl, bool useCache = true);
+
+    /// <summary>
+    /// Check if the package version exists in the repository.
+    /// </summary>
+    /// <param name="purl">The PackageURL to check, requires a version.</param>
+    /// <param name="useCache">If the cache should be checked for the existence of this package.</param>
+    /// <returns>True if the package version is confirmed to exist in the repository. False otherwise.</returns>
+    public Task<bool> PackageVersionExistsAsync(PackageURL purl, bool useCache = true);
+
+    /// <summary>
+    /// Check if the package version exists/existed in the repository.
+    /// </summary>
+    /// <param name="purl">The PackageURL to check.</param>
+    /// <param name="useCache">If the cache should be checked for the existence of this package version.</param>
+    /// <returns>A <see cref="IPackageExistence"/> detailing the existence of the package version.</returns>
+    public Task<IPackageExistence> DetailedPackageVersionExistsAsync(PackageURL purl, bool useCache = true);
+
+    /// <summary>
+    /// This method should return text reflecting metadata for the given package. There is no
+    /// assumed format.
+    /// </summary>
+    /// <param name="purl">The <see cref="PackageURL"/> to get the metadata for.</param>
+    /// <param name="useCache">If the metadata should be retrieved from the cache, if it is available.</param>
+    /// <returns>A string representing the <see cref="PackageURL"/>'s metadata, or null if it wasn't found.</returns>
+    public Task<string?> GetMetadataAsync(PackageURL purl, bool useCache = true);
+
+    /// <summary>
+    /// Get the uri for the package home page (no version)
+    /// </summary>
+    /// <param name="purl"></param>
+    /// <returns></returns>
+    public Uri? GetPackageAbsoluteUri(PackageURL purl);
+
+    /// <summary>
+    /// Return a normalized package metadata.
+    /// </summary>
+    /// <param name="purl">The <see cref="PackageURL"/> to get the normalized metadata for.</param>
+    /// <param name="includePrerelease">If pre-releases should count for getting the latest version, and the list of versions. Defaults to <c>false</c>.</param>
+    /// <param name="useCache">If the <see cref="PackageMetadata"/> should be retrieved from the cache, if it is available.</param>
+    /// <remarks>If no version specified, defaults to latest version.</remarks>
+    /// <returns>A <see cref="PackageMetadata"/> object representing this <see cref="PackageURL"/>.</returns>
+    public Task<PackageMetadata?> GetPackageMetadataAsync(PackageURL purl, bool includePrerelease = false, bool useCache = true);
+
+    /// <summary>
+    /// Gets everything contained in a JSON element for the package version
+    /// </summary>
+    /// <param name="metadata"></param>
+    /// <param name="version"></param>
+    /// <returns></returns>
+    public JsonElement? GetVersionElement(JsonDocument contentJSON, Version version);
+
+    /// <summary>
+    /// Gets all the versions of a package
+    /// </summary>
+    /// <param name="metadata"></param>
+    /// <param name="version"></param>
+    /// <returns></returns>
+    public List<Version> GetVersions(JsonDocument? metadata);
+
+    /// <summary>
+    /// Tries to find out the package repository from the metadata of the package. Check with
+    /// the specific package manager, if they have any specific extraction to do, w.r.t the
+    /// metadata. If they found some package specific well defined metadata, use that. If that
+    /// doesn't work, do a search across the metadata to find probable source repository urls
+    /// </summary>
+    /// <param name="purl">PackageURL to search</param>
+    /// <param name="useCache">If the source repository should be returned from the cache, if available.</param>
+    /// <returns>
+    /// A dictionary, mapping each possible repo source entry to its probability/empty dictionary
+    /// </returns>
+    public Task<Dictionary<PackageURL, double>> IdentifySourceRepositoryAsync(PackageURL purl, bool useCache = true);
+
+    /// <summary>
+    /// Gets the <see cref="DateTime"/> a package version was published at.
+    /// </summary>
+    /// <param name="purl">Package URL specifying the package. Version is mandatory.</param>
+    /// <param name="useCache">If the cache should be used when looking for the published time.</param>
+    /// <returns>The <see cref="DateTime"/> when this version was published, or null if not found.</returns>
+    public Task<DateTime?> GetPublishedAtUtcAsync(PackageURL purl, bool useCache = true);
+}

--- a/src/Shared/Contracts/IProjectManagerFactory.cs
+++ b/src/Shared/Contracts/IProjectManagerFactory.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+namespace Microsoft.CST.OpenSource.Contracts;
+
+using PackageManagers;
+using PackageUrl;
+
+public interface IProjectManagerFactory
+{
+    /// <summary>
+    /// Creates an appropriate project manager for a <see cref="PackageURL"/> given its <see cref="PackageURL.Type"/>.
+    /// </summary>
+    /// <param name="purl">The <see cref="PackageURL"/> for the package to create the project manager for.</param>
+    /// <param name="destinationDirectory">The new destination directory, if provided.</param>
+    /// <returns>The implementation of <see cref="BaseProjectManager"/> for this <paramref name="purl"/>'s type.</returns>
+    BaseProjectManager? CreateProjectManager(PackageURL purl, string destinationDirectory = ".");
+}

--- a/src/Shared/Contracts/ITypedManager.cs
+++ b/src/Shared/Contracts/ITypedManager.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+namespace Microsoft.CST.OpenSource.Contracts;
+
+using Model;
+using PackageUrl;
+using Polly.Retry;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+public interface ITypedManager<TArtifactUriType> : IBaseProjectManager where TArtifactUriType : Enum
+{
+    /// <summary>
+    /// Gets the relevant URI(s) to download the files related to a <see cref="PackageURL"/>.
+    /// </summary>
+    /// <param name="purl">The <see cref="PackageURL"/> to get the URI(s) for.</param>
+    /// <returns>A list of the relevant <see cref="ArtifactUri{TArtifactUriType}"/>.</returns>
+    /// <remarks>Returns the expected URIs for resources. Does not validate that the URIs resolve at the moment of enumeration.</remarks>
+    [Obsolete(message: $"Deprecated in favor of {nameof(GetArtifactDownloadUrisAsync)}.")]
+    IEnumerable<ArtifactUri<TArtifactUriType>> GetArtifactDownloadUris(PackageURL purl);
+
+    /// <summary>
+    /// Gets the relevant URI(s) to download the files related to a <see cref="PackageURL"/>.
+    /// </summary>
+    /// <param name="purl">The <see cref="PackageURL"/> to get the URI(s) for.</param>
+    /// <param name="useCache">If the data should be retrieved from the cache. Defaults to <c>true</c>.</param>
+    /// <returns>A list of the relevant <see cref="ArtifactUri{TArtifactUriType}"/>.</returns>
+    /// <remarks>Returns the expected URIs for resources. Does not validate that the URIs resolve at the moment of enumeration.</remarks>
+    IAsyncEnumerable<ArtifactUri<TArtifactUriType>> GetArtifactDownloadUrisAsync(PackageURL purl, bool useCache = true);
+
+    /// <summary>
+    /// Gets all <see cref="PackageURL"/>s associated with an owner.
+    /// </summary>
+    /// <param name="owner">The username of the owner.</param>
+    /// <param name="useCache">If the data should be retrieved from the cache. Defaults to <c>true</c>.</param>
+    /// <returns>A list of the <see cref="PackageURL"/>s from this owner.</returns>
+    IAsyncEnumerable<PackageURL> GetPackagesFromOwnerAsync(string owner, bool useCache = true);
+
+    /// <summary>
+    /// Check to see if the <see cref="Uri"/> exists.
+    /// </summary>
+    /// <param name="artifactUri">The <see cref="Uri"/> to check if exists.</param>
+    /// <param name="policy">An optional <see cref="AsyncRetryPolicy"/> to use with the http request.</param>
+    /// <returns>If the request returns <see cref="HttpStatusCode.OK"/>.</returns>
+    Task<bool> UriExistsAsync(Uri artifactUri, AsyncRetryPolicy<HttpResponseMessage>? policy = null);
+}

--- a/src/Shared/PackageManagers/BaseProjectManager.cs
+++ b/src/Shared/PackageManagers/BaseProjectManager.cs
@@ -19,13 +19,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
     using Version = SemanticVersioning.Version;
     using PackageUrl;
 
-    public abstract class BaseProjectManager
+    public abstract class BaseProjectManager : IBaseProjectManager
     {
-        /// <summary>
-        /// The type of the project manager from the package-url type specifications.
-        /// </summary>
-        /// <remarks>This differs from the Type property defined in other ProjectManagers as this one isn't static.</remarks>
-        /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
+        /// <inheritdoc />
         public abstract string ManagerType { get; }
 
         /// <summary>
@@ -43,19 +39,13 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         {
         }
 
-        /// <summary>
-        /// Per-object option container.
-        /// </summary>
+        /// <inheritdoc />
         public Dictionary<string, object> Options { get; private set; }
 
-        /// <summary>
-        /// The location (directory) to extract files to.
-        /// </summary>
+        /// <inheritdoc />
         public string TopLevelExtractionDirectory { get; init; }
 
-        /// <summary>
-        /// The <see cref="IHttpClientFactory"/> for the manager.
-        /// </summary>
+        /// <inheritdoc />
         public IHttpClientFactory HttpClientFactory { get; }
 
         /// <summary>
@@ -291,43 +281,23 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             return versionPartsList.Select(s => string.Join("", s));
         }
 
-        /// <summary>
-        /// Downloads a given PackageURL and extracts it locally to a directory.
-        /// </summary>
-        /// <param name="purl">PackageURL to download</param>
-        /// <returns>Paths (either files or directory names) pertaining to the downloaded files.</returns>
+        /// <inheritdoc />
         public virtual Task<IEnumerable<string>> DownloadVersionAsync(PackageURL purl, bool doExtract, bool cached = false)
         {
             throw new NotImplementedException("BaseProjectManager does not implement DownloadVersionAsync.");
         }
 
-        /// <summary>
-        /// Enumerates all possible versions of the package identified by purl, in descending order.
-        /// </summary>
-        /// <remarks>The latest version is always first, then it is sorted by SemVer in descending order.</remarks>
-        /// <param name="purl">Package URL specifying the package. Version is ignored.</param>
-        /// <param name="useCache">If the cache should be used when looking for the versions.</param>
-        /// <param name="includePrerelease">If pre-release versions should be included.</param>
-        /// <returns> A list of package version numbers.</returns>
+        /// <inheritdoc />
         public abstract Task<IEnumerable<string>> EnumerateVersionsAsync(PackageURL purl, bool useCache = true, bool includePrerelease = true);
 
-        /// <summary>
-        /// Gets the latest version from the package metadata.
-        /// </summary>
-        /// <param name="metadata">The package metadata to parse.</param>
-        /// <returns>The latest version of the package.</returns>
+        /// <inheritdoc />
         public Version? GetLatestVersion(JsonDocument metadata)
         {
             List<Version> versions = GetVersions(metadata);
             return GetLatestVersion(versions);
         }
 
-        /// <summary>
-        /// Check if the package exists in the repository.
-        /// </summary>
-        /// <param name="purl">The PackageURL to check.</param>
-        /// <param name="useCache">If the cache should be checked for the existence of this package.</param>
-        /// <returns>True if the package is confirmed to exist in the repository. False otherwise.</returns>
+        /// <inheritdoc />
         public virtual async Task<bool> PackageExistsAsync(PackageURL purl, bool useCache = true)
         {
             Logger.Trace("PackageExists {0}", purl?.ToString());
@@ -339,12 +309,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             return (await EnumerateVersionsAsync(purl, useCache)).Any();
         }
         
-        /// <summary>
-        /// Check if the package exists/existed in the repository.
-        /// </summary>
-        /// <param name="purl">The PackageURL to check.</param>
-        /// <param name="useCache">If the cache should be checked for the existence of this package.</param>
-        /// <returns>A <see cref="IPackageExistence"/> detailing the existence of the package.</returns>
+        /// <inheritdoc />
         public virtual async Task<IPackageExistence> DetailedPackageExistsAsync(PackageURL purl, bool useCache = true)
         {
             bool exists = await PackageExistsAsync(purl, useCache);
@@ -357,12 +322,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             return new PackageNotFound();
         }
 
-        /// <summary>
-        /// Check if the package version exists in the repository.
-        /// </summary>
-        /// <param name="purl">The PackageURL to check, requires a version.</param>
-        /// <param name="useCache">If the cache should be checked for the existence of this package.</param>
-        /// <returns>True if the package version is confirmed to exist in the repository. False otherwise.</returns>
+        /// <inheritdoc />
         public virtual async Task<bool> PackageVersionExistsAsync(PackageURL purl, bool useCache = true)
         {
             Logger.Trace("PackageExists {0}", purl?.ToString());
@@ -381,12 +341,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             return (await EnumerateVersionsAsync(purl, useCache)).Contains(purl.Version);
         }
         
-        /// <summary>
-        /// Check if the package version exists/existed in the repository.
-        /// </summary>
-        /// <param name="purl">The PackageURL to check.</param>
-        /// <param name="useCache">If the cache should be checked for the existence of this package version.</param>
-        /// <returns>A <see cref="IPackageExistence"/> detailing the existence of the package version.</returns>
+        /// <inheritdoc />
         public virtual async Task<IPackageExistence> DetailedPackageVersionExistsAsync(PackageURL purl, bool useCache = true)
         {
             bool exists = await PackageVersionExistsAsync(purl, useCache);
@@ -414,74 +369,37 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             return null;
         }
 
-        /// <summary>
-        /// This method should return text reflecting metadata for the given package. There is no
-        /// assumed format.
-        /// </summary>
-        /// <param name="purl">The <see cref="PackageURL"/> to get the metadata for.</param>
-        /// <param name="useCache">If the metadata should be retrieved from the cache, if it is available.</param>
-        /// <returns>A string representing the <see cref="PackageURL"/>'s metadata, or null if it wasn't found.</returns>
+        /// <inheritdoc />
         public abstract Task<string?> GetMetadataAsync(PackageURL purl, bool useCache = true);
 
-        /// <summary>
-        /// Get the uri for the package home page (no version)
-        /// </summary>
-        /// <param name="purl"></param>
-        /// <returns></returns>
+        /// <inheritdoc />
         public virtual Uri? GetPackageAbsoluteUri(PackageURL purl)
         {
             throw new NotImplementedException($"{GetType().Name} does not implement GetPackageAbsoluteUri.");
         }
 
-        /// <summary>
-        /// Return a normalized package metadata.
-        /// </summary>
-        /// <param name="purl">The <see cref="PackageURL"/> to get the normalized metadata for.</param>
-        /// <param name="includePrerelease">If pre-releases should count for getting the latest version, and the list of versions. Defaults to <c>false</c>.</param>
-        /// <param name="useCache">If the <see cref="PackageMetadata"/> should be retrieved from the cache, if it is available.</param>
-        /// <remarks>If no version specified, defaults to latest version.</remarks>
-        /// <returns>A <see cref="PackageMetadata"/> object representing this <see cref="PackageURL"/>.</returns>
+        /// <inheritdoc />
         public virtual Task<PackageMetadata?> GetPackageMetadataAsync(PackageURL purl, bool includePrerelease = false, bool useCache = true)
         {
             string typeName = GetType().Name;
             throw new NotImplementedException($"{typeName} does not implement GetPackageMetadata.");
         }
 
-        /// <summary>
-        /// Gets everything contained in a JSON element for the package version
-        /// </summary>
-        /// <param name="metadata"></param>
-        /// <param name="version"></param>
-        /// <returns></returns>
+        /// <inheritdoc />
         public virtual JsonElement? GetVersionElement(JsonDocument contentJSON, Version version)
         {
             string typeName = GetType().Name;
             throw new NotImplementedException($"{typeName} does not implement GetVersions.");
         }
 
-        /// <summary>
-        /// Gets all the versions of a package
-        /// </summary>
-        /// <param name="metadata"></param>
-        /// <param name="version"></param>
-        /// <returns></returns>
+        /// <inheritdoc />
         public virtual List<Version> GetVersions(JsonDocument? metadata)
         {
             string typeName = GetType().Name;
             throw new NotImplementedException($"{typeName} does not implement GetVersions.");
         }
 
-        /// <summary>
-        /// Tries to find out the package repository from the metadata of the package. Check with
-        /// the specific package manager, if they have any specific extraction to do, w.r.t the
-        /// metadata. If they found some package specific well defined metadata, use that. If that
-        /// doesn't work, do a search across the metadata to find probable source repository urls
-        /// </summary>
-        /// <param name="purl">PackageURL to search</param>
-        /// <param name="useCache">If the source repository should be returned from the cache, if available.</param>
-        /// <returns>
-        /// A dictionary, mapping each possible repo source entry to its probability/empty dictionary
-        /// </returns>
+        /// <inheritdoc />
         public async Task<Dictionary<PackageURL, double>> IdentifySourceRepositoryAsync(PackageURL purl, bool useCache = true)
         {
             Logger.Trace("IdentifySourceRepository({0})", purl);
@@ -517,12 +435,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             return sourceRepositoryMap;
         }
 
-        /// <summary>
-        /// Gets the <see cref="DateTime"/> a package version was published at.
-        /// </summary>
-        /// <param name="purl">Package URL specifying the package. Version is mandatory.</param>
-        /// <param name="useCache">If the cache should be used when looking for the published time.</param>
-        /// <returns>The <see cref="DateTime"/> when this version was published, or null if not found.</returns>
+        /// <inheritdoc />
         public async Task<DateTime?> GetPublishedAtUtcAsync(PackageURL purl, bool useCache = true)
         {
             Check.NotNull(nameof(purl.Version), purl.Version);

--- a/src/Shared/PackageManagers/ProjectManagerFactory.cs
+++ b/src/Shared/PackageManagers/ProjectManagerFactory.cs
@@ -2,6 +2,7 @@
 
 namespace Microsoft.CST.OpenSource.PackageManagers
 {
+    using Contracts;
     using PackageActions;
     using PackageUrl;
     using System;
@@ -9,7 +10,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
     using System.Linq;
     using System.Net.Http;
 
-    public class ProjectManagerFactory
+    public class ProjectManagerFactory : IProjectManagerFactory
     {
         /// <summary>
         /// This delegate takes the path to operate a project manager in and returns a new ProjectManager.
@@ -130,12 +131,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             };
         }
 
-        /// <summary>
-        /// Creates an appropriate project manager for a <see cref="PackageURL"/> given its <see cref="PackageURL.Type"/>.
-        /// </summary>
-        /// <param name="purl">The <see cref="PackageURL"/> for the package to create the project manager for.</param>
-        /// <param name="destinationDirectory">The new destination directory, if provided.</param>
-        /// <returns>The implementation of <see cref="BaseProjectManager"/> for this <paramref name="purl"/>'s type.</returns>
+        /// <inheritdoc />
         public BaseProjectManager? CreateProjectManager(PackageURL purl, string destinationDirectory = ".")
         {
             ConstructProjectManager? projectManager = _projectManagers.GetValueOrDefault(purl.Type);

--- a/src/Shared/PackageManagers/TypedManager.cs
+++ b/src/Shared/PackageManagers/TypedManager.cs
@@ -28,7 +28,7 @@ using System.Threading.Tasks;
 /// The <see cref="Enum"/> for the valid types a URI of this manager could be.
 /// </typeparam>
 /// TODO: Combine ArtifactUriType and PackageVersionMetadata as they will always be linked. https://github.com/microsoft/OSSGadget/issues/333
-public abstract class TypedManager<T, TArtifactUriType> : BaseProjectManager where T : IManagerPackageVersionMetadata where TArtifactUriType : Enum
+public abstract class TypedManager<T, TArtifactUriType> : BaseProjectManager, ITypedManager<TArtifactUriType> where T : IManagerPackageVersionMetadata where TArtifactUriType : Enum
 {
     /// <summary>
     /// The actions object to be used in the project manager.
@@ -89,12 +89,7 @@ public abstract class TypedManager<T, TArtifactUriType> : BaseProjectManager whe
         return (await Actions.GetMetadataAsync(purl, useCache))?.ToString();
     }
 
-    /// <summary>
-    /// Gets the relevant URI(s) to download the files related to a <see cref="PackageURL"/>.
-    /// </summary>
-    /// <param name="purl">The <see cref="PackageURL"/> to get the URI(s) for.</param>
-    /// <returns>A list of the relevant <see cref="ArtifactUri{TArtifactUriType}"/>.</returns>
-    /// <remarks>Returns the expected URIs for resources. Does not validate that the URIs resolve at the moment of enumeration.</remarks>
+    /// <inheritdoc />
     [Obsolete(message: $"Deprecated in favor of {nameof(GetArtifactDownloadUrisAsync)}.")]
     public IEnumerable<ArtifactUri<TArtifactUriType>> GetArtifactDownloadUris(PackageURL purl)
     {
@@ -118,12 +113,7 @@ public abstract class TypedManager<T, TArtifactUriType> : BaseProjectManager whe
     /// <returns>A list of the <see cref="PackageURL"/>s from this owner.</returns>
     public abstract IAsyncEnumerable<PackageURL> GetPackagesFromOwnerAsync(string owner, bool useCache = true);
 
-    /// <summary>
-    /// Check to see if the <see cref="Uri"/> exists.
-    /// </summary>
-    /// <param name="artifactUri">The <see cref="Uri"/> to check if exists.</param>
-    /// <param name="policy">An optional <see cref="AsyncRetryPolicy"/> to use with the http request.</param>
-    /// <returns>If the request returns <see cref="HttpStatusCode.OK"/>.</returns>
+    /// <inheritdoc />
     public async Task<bool> UriExistsAsync(Uri artifactUri, AsyncRetryPolicy<HttpResponseMessage>? policy = null)
     {
         policy ??= DefaultPolicy;


### PR DESCRIPTION
Adds IProjectManagerFactory.cs, IBaseProjectManager, ITypedManager interfaces, such that consuming projects can mock ProjectManagerFactory, BaseProjectManager, and TypedManager using tools like `FakeItEasy` or `Moq`.
