### PR TITLE
IProjectManagerFactory now returns IBaseProjectManager instead of BaseProjectManager

### DIFF
--- a/src/Shared.CLI/Helpers/OutputBuilder/SarifOutputBuilder.cs
+++ b/src/Shared.CLI/Helpers/OutputBuilder/SarifOutputBuilder.cs
@@ -2,6 +2,7 @@
 
 namespace Microsoft.CST.OpenSource.Shared
 {
+    using Contracts;
     using Microsoft.CodeAnalysis.Sarif;
     using Microsoft.CST.OpenSource.PackageManagers;
     using Newtonsoft.Json;
@@ -26,7 +27,7 @@ namespace Microsoft.CST.OpenSource.Shared
         /// <returns>Location list with single location object</returns>
         public static List<Location> BuildPurlLocation(PackageURL purl)
         {
-            BaseProjectManager? projectManager = ProjectManagerFactory.ConstructPackageManager(purl, null);
+            IBaseProjectManager? projectManager = ProjectManagerFactory.ConstructPackageManager(purl, null);
             if (projectManager == null)
             {
                 Logger.Debug("Cannot determine the package type");

--- a/src/Shared.CLI/Helpers/PackageDownloader.cs
+++ b/src/Shared.CLI/Helpers/PackageDownloader.cs
@@ -2,6 +2,7 @@
 
 namespace Microsoft.CST.OpenSource
 {
+    using Contracts;
     using Extensions;
     using Microsoft.CST.OpenSource.Helpers;
     using Microsoft.CST.OpenSource.PackageManagers;
@@ -293,7 +294,7 @@ namespace Microsoft.CST.OpenSource
         // folders created
         private List<string> downloadPaths { get; set; } = new List<string>();
 
-        private BaseProjectManager? packageManager { get; set; }
+        private IBaseProjectManager? packageManager { get; set; }
         public List<PackageURL> PackageVersions { get; set; }
     }
 }

--- a/src/Shared.CLI/Helpers/RepoSearch.cs
+++ b/src/Shared.CLI/Helpers/RepoSearch.cs
@@ -2,6 +2,7 @@
 
 namespace Microsoft.CST.OpenSource.Shared
 {
+    using Contracts;
     using Microsoft.CST.OpenSource.PackageManagers;
     using PackageUrl;
     using System;
@@ -59,7 +60,7 @@ namespace Microsoft.CST.OpenSource.Shared
             Logger.Debug("Searching for source code for: {0}", purlNoVersion.ToString());
 
             // Get the correct project manager using the factory.
-            BaseProjectManager? projectManager = _projectManagerFactory.CreateProjectManager(purl);
+            IBaseProjectManager? projectManager = _projectManagerFactory.CreateProjectManager(purl);
 
             if (projectManager != null)
             {

--- a/src/Shared/Contracts/IProjectManagerFactory.cs
+++ b/src/Shared/Contracts/IProjectManagerFactory.cs
@@ -13,5 +13,5 @@ public interface IProjectManagerFactory
     /// <param name="purl">The <see cref="PackageURL"/> for the package to create the project manager for.</param>
     /// <param name="destinationDirectory">The new destination directory, if provided.</param>
     /// <returns>The implementation of <see cref="BaseProjectManager"/> for this <paramref name="purl"/>'s type.</returns>
-    BaseProjectManager? CreateProjectManager(PackageURL purl, string destinationDirectory = ".");
+    IBaseProjectManager? CreateProjectManager(PackageURL purl, string destinationDirectory = ".");
 }

--- a/src/Shared/PackageManagers/ProjectManagerFactory.cs
+++ b/src/Shared/PackageManagers/ProjectManagerFactory.cs
@@ -132,7 +132,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         }
 
         /// <inheritdoc />
-        public BaseProjectManager? CreateProjectManager(PackageURL purl, string destinationDirectory = ".")
+        public IBaseProjectManager? CreateProjectManager(PackageURL purl, string destinationDirectory = ".")
         {
             ConstructProjectManager? projectManager = _projectManagers.GetValueOrDefault(purl.Type);
 
@@ -147,7 +147,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         /// <param name="overrideManagers"> If provided, will set the project manager dictionary instead of using the defaults.</param>
         /// <param name="destinationDirectory">The new destination directory, if provided.</param>
         /// <returns>A new <see cref="BaseProjectManager"/> implementation.</returns>
-        public static BaseProjectManager? ConstructPackageManager(PackageURL packageUrl, IHttpClientFactory? httpClientFactory = null, Dictionary<string, ConstructProjectManager>? overrideManagers = null, string destinationDirectory = ".")
+        public static IBaseProjectManager? ConstructPackageManager(PackageURL packageUrl, IHttpClientFactory? httpClientFactory = null, Dictionary<string, ConstructProjectManager>? overrideManagers = null, string destinationDirectory = ".")
         {
             if (overrideManagers != null && overrideManagers.Any())
             {

--- a/src/oss-diff/DiffTool.cs
+++ b/src/oss-diff/DiffTool.cs
@@ -20,6 +20,7 @@ using SarifResult = Microsoft.CodeAnalysis.Sarif.Result;
 
 namespace Microsoft.CST.OpenSource.DiffTool
 {
+    using Contracts;
     using Microsoft.CST.OpenSource.Helpers;
     using Microsoft.CST.OpenSource.PackageManagers;
     using PackageUrl;
@@ -120,7 +121,7 @@ namespace Microsoft.CST.OpenSource.DiffTool
             try
             {
                 PackageURL purl1 = new PackageURL(options.Targets.First());
-                BaseProjectManager? manager = ProjectManagerFactory.CreateProjectManager(purl1, options.DownloadDirectory ?? Path.GetTempPath());
+                IBaseProjectManager? manager = ProjectManagerFactory.CreateProjectManager(purl1, options.DownloadDirectory ?? Path.GetTempPath());
 
                 if (manager is not null)
                 {
@@ -154,7 +155,7 @@ namespace Microsoft.CST.OpenSource.DiffTool
             try
             {
                 PackageURL purl2 = new PackageURL(options.Targets.Last());
-                BaseProjectManager? manager2 = ProjectManagerFactory.CreateProjectManager(purl2, options.DownloadDirectory ?? Path.GetTempPath());
+                IBaseProjectManager? manager2 = ProjectManagerFactory.CreateProjectManager(purl2, options.DownloadDirectory ?? Path.GetTempPath());
 
                 if (manager2 is not null)
                 {

--- a/src/oss-find-squats-lib/FindPackageSquats.cs
+++ b/src/oss-find-squats-lib/FindPackageSquats.cs
@@ -2,6 +2,7 @@
 
 namespace Microsoft.CST.OpenSource.FindSquats
 {
+    using Contracts;
     using ExtensionMethods;
     using Microsoft.CST.OpenSource;
     using Microsoft.CST.OpenSource.Exceptions;
@@ -19,7 +20,7 @@ namespace Microsoft.CST.OpenSource.FindSquats
         /// </summary>
         public PackageURL PackageUrl { get; }
 
-        public BaseProjectManager? ProjectManager { get;  }
+        public IBaseProjectManager? ProjectManager { get;  }
 
         public FindPackageSquats(ProjectManagerFactory projectManagerFactory, PackageURL packageUrl)
             : base(projectManagerFactory)

--- a/src/oss-find-squats-lib/MutateExtension.cs
+++ b/src/oss-find-squats-lib/MutateExtension.cs
@@ -2,6 +2,7 @@
 
 namespace Microsoft.CST.OpenSource.FindSquats.ExtensionMethods
 {
+    using Contracts;
     using Extensions;
     using Microsoft.CST.OpenSource.FindSquats.Mutators;
     using Microsoft.CST.OpenSource.PackageManagers;
@@ -94,7 +95,7 @@ namespace Microsoft.CST.OpenSource.FindSquats.ExtensionMethods
         /// </summary>
         /// <param name="manager"></param>
         /// <returns>An IEnumerable of the recommended IMutators.</returns>
-        public static IEnumerable<IMutator> GetDefaultMutators(this BaseProjectManager manager) => manager switch
+        public static IEnumerable<IMutator> GetDefaultMutators(this IBaseProjectManager manager) => manager switch
         {
             NuGetProjectManager => NugetMutators,
             NPMProjectManager => NpmMutators,
@@ -110,7 +111,7 @@ namespace Microsoft.CST.OpenSource.FindSquats.ExtensionMethods
         /// <param name="purl">The Target package to check for squats.</param>
         /// <param name="options">The options for enumerating squats.</param>
         /// <returns>An <see cref="IDictionary{T, V}"/> where the key is the mutated name, and the value is a <see cref="IList{Mutation}"/> representing each candidate squat.</returns>
-        public static IDictionary<string, IList<Mutation>>? EnumerateSquatCandidates(this BaseProjectManager manager, PackageURL purl, MutateOptions? options = null)
+        public static IDictionary<string, IList<Mutation>>? EnumerateSquatCandidates(this IBaseProjectManager manager, PackageURL purl, MutateOptions? options = null)
         {
             return manager.EnumerateSquatCandidates(purl, manager.GetDefaultMutators(), options);
         }
@@ -124,7 +125,7 @@ namespace Microsoft.CST.OpenSource.FindSquats.ExtensionMethods
         /// <param name="mutators">The mutators to use. Will ignore the default set of mutators.</param>
         /// <param name="options">The options for enumerating squats.</param>
         /// <returns>An <see cref="IDictionary{T, V}"/> where the key is the mutated name, and the value is a <see cref="IList{Mutation}"/> representing each candidate squat.</returns>
-        public static IDictionary<string, IList<Mutation>>? EnumerateSquatCandidates(this BaseProjectManager manager, PackageURL purl, IEnumerable<IMutator> mutators, MutateOptions? options = null)
+        public static IDictionary<string, IList<Mutation>>? EnumerateSquatCandidates(this IBaseProjectManager manager, PackageURL purl, IEnumerable<IMutator> mutators, MutateOptions? options = null)
         {
             if (purl.Name is null || purl.Type is null)
             {
@@ -164,7 +165,7 @@ namespace Microsoft.CST.OpenSource.FindSquats.ExtensionMethods
         /// <param name="candidateMutations">The <see cref="IList{Mutation}"/> representing each squatting candidate.</param>
         /// <param name="options">The options for enumerating through existing squats.</param>
         /// <returns>An <see cref="IAsyncEnumerable{FindPackageSquatResult}"/> with the packages that exist which match one of the <paramref name="candidateMutations"/>.</returns>
-        public static async IAsyncEnumerable<FindPackageSquatResult> EnumerateExistingSquatsAsync(this BaseProjectManager manager, PackageURL purl, IDictionary<string, IList<Mutation>>? candidateMutations, MutateOptions? options = null)
+        public static async IAsyncEnumerable<FindPackageSquatResult> EnumerateExistingSquatsAsync(this IBaseProjectManager manager, PackageURL purl, IDictionary<string, IList<Mutation>>? candidateMutations, MutateOptions? options = null)
         {
             if (purl.Name is null || purl.Type is null)
             {

--- a/src/oss-health/HealthMetrics.cs
+++ b/src/oss-health/HealthMetrics.cs
@@ -13,6 +13,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.CST.OpenSource.Health
 {
+    using Contracts;
     using PackageUrl;
 
     public class HealthMetrics
@@ -43,7 +44,7 @@ namespace Microsoft.CST.OpenSource.Health
 
         public List<Result> toSarif()
         {
-            BaseProjectManager? projectManager = ProjectManagerFactory.ConstructPackageManager(purl, null);
+            IBaseProjectManager? projectManager = ProjectManagerFactory.ConstructPackageManager(purl, null);
 
             if (projectManager == null)
             {

--- a/src/oss-health/HealthTool.cs
+++ b/src/oss-health/HealthTool.cs
@@ -11,6 +11,7 @@ using static Microsoft.CST.OpenSource.Shared.OutputBuilderFactory;
 
 namespace Microsoft.CST.OpenSource
 {
+    using Contracts;
     using Microsoft.CST.OpenSource.PackageManagers;
     using PackageUrl;
 
@@ -26,7 +27,7 @@ namespace Microsoft.CST.OpenSource
         }
         public async Task<HealthMetrics?> CheckHealth(PackageURL purl)
         {
-            BaseProjectManager? packageManager = ProjectManagerFactory.CreateProjectManager(purl);
+            IBaseProjectManager? packageManager = ProjectManagerFactory.CreateProjectManager(purl);
 
             if (packageManager != null)
             {

--- a/src/oss-tests/DownloadTests.cs
+++ b/src/oss-tests/DownloadTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.CST.OpenSource.Tests
 {
+    using Contracts;
     using PackageManagers;
     using PackageUrl;
     using System.Collections.Generic;
@@ -151,7 +152,7 @@ namespace Microsoft.CST.OpenSource.Tests
         public async Task Wildcard_Download_Version_Succeeds(string packageUrl, string targetFilename)
         {
             PackageURL purl = new(packageUrl);
-            BaseProjectManager? manager = new ProjectManagerFactory().CreateProjectManager(purl);
+            IBaseProjectManager? manager = new ProjectManagerFactory().CreateProjectManager(purl);
             IEnumerable<string> versions = await manager?.EnumerateVersionsAsync(purl) ?? throw new InvalidOperationException();
             await TestDownload(packageUrl, targetFilename, versions.Count());
         }

--- a/src/oss-tests/FindSquatsTests.cs
+++ b/src/oss-tests/FindSquatsTests.cs
@@ -101,7 +101,7 @@ namespace Microsoft.CST.OpenSource.Tests
             PackageURL purl = new(packageUrl);
             if (purl.Name is not null && purl.Type is not null)
             {
-                BaseProjectManager? manager = ProjectManagerFactory.ConstructPackageManager(purl, null);
+                IBaseProjectManager? manager = ProjectManagerFactory.ConstructPackageManager(purl, null);
                 if (manager is not null)
                 {
                     foreach ((string _, IList<Mutation> mutations) in manager.EnumerateSquatCandidates(purl)!)
@@ -132,7 +132,7 @@ namespace Microsoft.CST.OpenSource.Tests
             PackageURL purl = new(packageUrl);
             if (purl.Name is not null && purl.Type is not null)
             {
-                BaseProjectManager? manager = ProjectManagerFactory.ConstructPackageManager(purl, null);
+                IBaseProjectManager? manager = ProjectManagerFactory.ConstructPackageManager(purl, null);
                 if (manager is not null)
                 {
                     foreach ((string _, IList<Mutation> mutations) in manager.EnumerateSquatCandidates(purl, options: mutateOptions)!)
@@ -167,7 +167,7 @@ namespace Microsoft.CST.OpenSource.Tests
             PackageURL purl = new(packageUrl);
             if (purl.Name is not null && purl.Type is not null)
             {
-                BaseProjectManager? manager = ProjectManagerFactory.ConstructPackageManager(purl, null);
+                IBaseProjectManager? manager = ProjectManagerFactory.ConstructPackageManager(purl, null);
                 if (manager is not null)
                 {
                     foreach ((string _, IList<Mutation> mutations) in manager.EnumerateSquatCandidates(purl)!)
@@ -192,7 +192,7 @@ namespace Microsoft.CST.OpenSource.Tests
             PackageURL purl = new(packageUrl);
             if (purl.Name is not null && purl.Type is not null)
             {
-                BaseProjectManager? manager = ProjectManagerFactory.ConstructPackageManager(purl, null);
+                IBaseProjectManager? manager = ProjectManagerFactory.ConstructPackageManager(purl, null);
                 if (manager is not null)
                 {
                     foreach ((string _, IList<Mutation> mutations) in manager.EnumerateSquatCandidates(purl)!)
@@ -221,7 +221,7 @@ namespace Microsoft.CST.OpenSource.Tests
             PackageURL purl = new(packageUrl);
             if (purl.Name is not null && purl.Type is not null)
             {
-                BaseProjectManager? manager = ProjectManagerFactory.ConstructPackageManager(purl, null);
+                IBaseProjectManager? manager = ProjectManagerFactory.ConstructPackageManager(purl, null);
                 if (manager is not null)
                 {
                     foreach ((string mutation, IList<Mutation> mutations) in manager.EnumerateSquatCandidates(purl)!)
@@ -266,7 +266,7 @@ namespace Microsoft.CST.OpenSource.Tests
             PackageURL purl = new(packageUrl);
             if (purl.Name is not null && purl.Type is not null)
             {
-                BaseProjectManager? manager = ProjectManagerFactory.ConstructPackageManager(purl, null);
+                IBaseProjectManager? manager = ProjectManagerFactory.ConstructPackageManager(purl, null);
                 if (manager is not null)
                 {
                     var originalMutations = manager.EnumerateSquatCandidates(purl);
@@ -321,7 +321,7 @@ namespace Microsoft.CST.OpenSource.Tests
             PackageURL purl = new(packageUrl);
             if (purl.Name is not null && purl.Type is not null)
             {
-                BaseProjectManager? manager = ProjectManagerFactory.ConstructPackageManager(purl, null);
+                IBaseProjectManager? manager = ProjectManagerFactory.ConstructPackageManager(purl, null);
                 if (manager is not null)
                 {
                     foreach ((string mutationPurlString, IList<Mutation> mutations) in manager.EnumerateSquatCandidates(purl)!)
@@ -354,7 +354,7 @@ namespace Microsoft.CST.OpenSource.Tests
             PackageURL purl = new(packageUrl);
             if (purl.Name is not null && purl.Type is not null)
             {
-                BaseProjectManager? manager = ProjectManagerFactory.ConstructPackageManager(purl, null);
+                IBaseProjectManager? manager = ProjectManagerFactory.ConstructPackageManager(purl, null);
                 if (manager is not null)
                 {
                     foreach (IMutator mutator in manager.GetDefaultMutators())
@@ -375,7 +375,7 @@ namespace Microsoft.CST.OpenSource.Tests
             PackageURL purl = new(packageUrl);
             if (purl.Name is not null && purl.Type is not null)
             {
-                BaseProjectManager? manager = ProjectManagerFactory.ConstructPackageManager(purl, null);
+                IBaseProjectManager? manager = ProjectManagerFactory.ConstructPackageManager(purl, null);
                 if (manager is not null)
                 {
                     foreach ((string mutationPurlString, _) in manager.EnumerateSquatCandidates(purl)!)

--- a/src/oss-tests/ProjectManagerTests/ProjectManagerFactoryTests.cs
+++ b/src/oss-tests/ProjectManagerTests/ProjectManagerFactoryTests.cs
@@ -2,6 +2,7 @@
 
 namespace Microsoft.CST.OpenSource.Tests.ProjectManagerTests;
 
+using Contracts;
 using PackageActions;
 using PackageManagers;
 using PackageUrl;
@@ -82,10 +83,10 @@ public class ProjectManagerFactoryTests
         AssertFactoryCreatesCorrect(projectManagerFactory);
 
         // Assert that the overrides worked by checking the TopLevelExtractionDirectory was changed.
-        BaseProjectManager? nuGetProjectManager = projectManagerFactory.CreateProjectManager(new PackageURL("pkg:nuget/foo"));
+        IBaseProjectManager? nuGetProjectManager = projectManagerFactory.CreateProjectManager(new PackageURL("pkg:nuget/foo"));
         Assert.AreEqual("nugetTestDirectory", nuGetProjectManager?.TopLevelExtractionDirectory);
         
-        BaseProjectManager? npmProjectManager = projectManagerFactory.CreateProjectManager(new PackageURL("pkg:npm/foo"));
+        IBaseProjectManager? npmProjectManager = projectManagerFactory.CreateProjectManager(new PackageURL("pkg:npm/foo"));
         Assert.AreEqual("npmTestDirectory", npmProjectManager?.TopLevelExtractionDirectory);
     }
     
@@ -145,8 +146,8 @@ public class ProjectManagerFactoryTests
         foreach ((string purlType, ProjectManagerFactory.ConstructProjectManager ctor) in _managerOverrides)
         {
             PackageURL packageUrl = new($"pkg:{purlType}/foo");
-            BaseProjectManager? expectedManager = ctor.Invoke();
-            BaseProjectManager? manager = projectManagerFactory.CreateProjectManager(packageUrl);
+            IBaseProjectManager? expectedManager = ctor.Invoke();
+            IBaseProjectManager? manager = projectManagerFactory.CreateProjectManager(packageUrl);
             Assert.AreEqual(expectedManager?.ManagerType, manager?.ManagerType);
             Assert.AreEqual(expectedManager?.GetType(), manager?.GetType());
         }

--- a/src/oss-tests/SharedTests.cs
+++ b/src/oss-tests/SharedTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.CST.OpenSource.Tests
 {
+    using Contracts;
     using Model;
     using PackageManagers;
     using PackageUrl;
@@ -36,7 +37,7 @@ namespace Microsoft.CST.OpenSource.Tests
         public async Task MetadataToFromJsonSucceeds(string packageUrlString)
         {
             PackageURL packageUrl = new(packageUrlString);
-            BaseProjectManager? projectManager = ProjectManagerFactory.ConstructPackageManager(packageUrl);
+            IBaseProjectManager? projectManager = ProjectManagerFactory.ConstructPackageManager(packageUrl);
 
             if (projectManager == null)
             {


### PR DESCRIPTION
As part of #416 , I neglected to make `IProjectManagerFactory` return `IBaseProjectManager` such that mocked instances of `IBaseProjectManager` could be returned to users of `IProjectManagerFactory`.

This change corrects that omission, and updates all uses of `ProjectManagerFactory` to receive `IBaseProjectManager` instead.