### PR TITLE
Updated packageurl-dotnet library.

### DIFF
--- a/src/Shared/Shared.Lib.csproj
+++ b/src/Shared/Shared.Lib.csproj
@@ -45,7 +45,7 @@
         <PackageReference Include="NuGet.Packaging" Version="6.3.1" />
         <PackageReference Include="NuGet.Protocol" Version="6.3.1" />
         <PackageReference Include="Octokit" Version="4.0.1" />
-        <PackageReference Include="packageurl-dotnet" Version="1.2.0" />
+        <PackageReference Include="packageurl-dotnet" Version="1.3.0" />
         <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
         <PackageReference Include="Sarif.Sdk" Version="3.1.0" />
         <PackageReference Include="SemanticVersioning" Version="2.0.2" />

--- a/src/oss-find-squats-lib/Mutators/IMutator.cs
+++ b/src/oss-find-squats-lib/Mutators/IMutator.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CST.OpenSource.FindSquats.Mutators
                 if (hasNamespace)
                 {
                     yield return new Mutation(
-                        mutated: arg.CreateWithNewNames(arg.Name, HttpUtility.UrlEncode(mutation.Mutated)).ToString(),
+                        mutated: arg.CreateWithNewNames(arg.Name, mutation.Mutated).ToString(),
                         original: arg.ToString(),
                         reason: mutation.Reason,
                         mutator: mutation.Mutator);
@@ -59,7 +59,7 @@ namespace Microsoft.CST.OpenSource.FindSquats.Mutators
                 else
                 {
                     yield return new Mutation(
-                        mutated: arg.CreateWithNewNames(HttpUtility.UrlEncode(mutation.Mutated), arg.Namespace).ToString(),
+                        mutated: arg.CreateWithNewNames(mutation.Mutated, arg.Namespace).ToString(),
                         original: arg.ToString(),
                         reason: mutation.Reason,
                         mutator: mutation.Mutator);


### PR DESCRIPTION
I have updated the package-url dotnet library to handle the special characters in the purl components (name, namespace, version, subpath and qualifiers) as per the PURL spec. As part of that change, the PackageUrl now accepts unencoded PURL components and it takes care of encoding/unencoding them when parsing/generating the PURL.  Here is the[ PR](https://github.com/package-url/packageurl-dotnet/pull/23) that has these changes.

I have updated the OSSGadget to use the new dotnet PURL library, as per the new updates, PackageURL constructor now accepts unencoded Purl components as arguments.