### PR TITLE
Fix Dependabot's Version update

### DIFF
--- a/src/Shared.CLI/Shared.CLI.csproj
+++ b/src/Shared.CLI/Shared.CLI.csproj
@@ -49,7 +49,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
     <PackageReference Include="NLog" Version="5.0.4" />
     <PackageReference Include="NLog.Schema" Version="5.0.4" />
-    <PackageReference Include="NuGet.Versioning" Version="6.3.1" />
+    <PackageReference Include="NuGet.Versioning" Version="6.6.1" />
     <PackageReference Include="Octokit" Version="4.0.1" />
     <PackageReference Include="Sarif.Sdk" Version="3.1.0" />
     <PackageReference Include="SemanticVersioning" Version="2.0.2" />

--- a/src/Shared/Shared.Lib.csproj
+++ b/src/Shared/Shared.Lib.csproj
@@ -42,8 +42,8 @@
         <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.10" />
         <PackageReference Include="NLog" Version="5.0.4" />
         <PackageReference Include="NLog.Schema" Version="5.0.4" />
-        <PackageReference Include="NuGet.Packaging" Version="6.3.1" />
-        <PackageReference Include="NuGet.Protocol" Version="6.3.3" />
+        <PackageReference Include="NuGet.Packaging" Version="6.6.1" />
+        <PackageReference Include="NuGet.Protocol" Version="6.6.1" />
         <PackageReference Include="Octokit" Version="4.0.1" />
         <PackageReference Include="packageurl-dotnet" Version="1.3.0" />
         <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />


### PR DESCRIPTION
Earlier today I merged a Dependabot PR which created version conflicts. This attempts to properly update all the Nuget packages to the latest version so they match again.