### PR TITLE
Fix Npm Project Manager's Download Version Async respecting namespaces

### DIFF
--- a/src/Shared/PackageManagers/NPMProjectManager.cs
+++ b/src/Shared/PackageManagers/NPMProjectManager.cs
@@ -103,7 +103,10 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             try
             {
                 HttpClient httpClient = CreateHttpClient();
-                JsonDocument doc = await GetJsonCache(httpClient, $"{ENV_NPM_API_ENDPOINT}/{packageName}");
+                string uri = string.IsNullOrEmpty(purl?.Namespace)
+                    ? $"{ENV_NPM_API_ENDPOINT}/{packageName}"
+                    : $"{ENV_NPM_API_ENDPOINT}/{purl.Namespace}/{packageName}";
+                JsonDocument doc = await GetJsonCache(httpClient, uri);
                 string? tarball = doc.RootElement.GetProperty("versions").GetProperty(packageVersion).GetProperty("dist").GetProperty("tarball").GetString();
                 HttpResponseMessage result = await httpClient.GetAsync(tarball);
                 result.EnsureSuccessStatusCode();

--- a/src/oss-download/DownloadTool.cs
+++ b/src/oss-download/DownloadTool.cs
@@ -100,6 +100,9 @@ namespace Microsoft.CST.OpenSource
                 {
                     try
                     {
+                        // PackageURL requires the @ in a namespace declaration to be escaped
+                        // We find if the namespace contains an @ in the namespace
+                        // And replace it with %40
                         string? mutableIterationTarget = target;
                         MatchCollection matches = detectUnencodedNamespace.Matches(target);
                         if (matches.Any())


### PR DESCRIPTION
Also fix #420 - auto escape namespaces with @ in the first character of a namespace in the oss-download cli.