### PR TITLE
Escape @s in namespaces in OSS-Health Tool

### DIFF
--- a/src/Shared.CLI/OSSGadget.cs
+++ b/src/Shared.CLI/OSSGadget.cs
@@ -11,6 +11,7 @@ namespace Microsoft.CST.OpenSource
     using System.IO;
     using System.Linq;
     using System.Reflection;
+    using System.Text.RegularExpressions;
     using static Microsoft.CST.OpenSource.Shared.OutputBuilderFactory;
 
     public class OSSGadget : OssGadgetLib
@@ -201,6 +202,23 @@ The package-url specifier is described at https://github.com/package-url/purl-sp
         private static List<string> GetCommonSupportedHelpTextLines()
         {
             return GetCommonSupportedHelpText().Split(Environment.NewLine).ToList<string>();
+        }
+
+        private static Regex detectUnencodedNamespace = new Regex("pkg:[^/]+/(@)[^/]+/[^/]+");
+        /// <summary>
+        /// This method converts an @ specified in a PackageURL namespace to %40 to comply with the PackageURL specification.
+        /// This is only intended for use from CLI context where the input is provided by an interactive user to the application to reduce confusion.
+        /// </summary>
+        /// <returns>The PackageURL with @ converted to %40 if it appears in as the first character in the namespace specification.</returns>
+        protected static string EscapeAtSymbolInNameSpace(string originalPackageUrlString)
+        {
+            MatchCollection matches = detectUnencodedNamespace.Matches(originalPackageUrlString);
+            if (matches.Any())
+            {
+                var indexOfAt = matches.First().Groups[1].Index;
+                return originalPackageUrlString[0..indexOfAt] + "%40" + originalPackageUrlString[(indexOfAt +1)..];
+            }
+            return originalPackageUrlString;
         }
     }
 }

--- a/src/oss-download/DownloadTool.cs
+++ b/src/oss-download/DownloadTool.cs
@@ -89,8 +89,6 @@ namespace Microsoft.CST.OpenSource
                 return (int)(await downloadTool.RunAsync(opts.Value));
             }
         }
-
-        private Regex detectUnencodedNamespace = new Regex("pkg:[^/]+/(@)[^/]+/[^/]+");
         
         private async Task<ErrorCode> RunAsync(Options options)
         {
@@ -103,14 +101,8 @@ namespace Microsoft.CST.OpenSource
                         // PackageURL requires the @ in a namespace declaration to be escaped
                         // We find if the namespace contains an @ in the namespace
                         // And replace it with %40
-                        string? mutableIterationTarget = target;
-                        MatchCollection matches = detectUnencodedNamespace.Matches(target);
-                        if (matches.Any())
-                        {
-                            var indexOfAt = matches.First().Groups[1].Index;
-                            mutableIterationTarget = target[0..indexOfAt] + "%40" + target[(indexOfAt +1)..];
-                        }
-                        PackageURL? purl = new PackageURL(mutableIterationTarget);
+                        string escapedNameSpaceTarget = EscapeAtSymbolInNameSpace(target);
+                        PackageURL? purl = new PackageURL(escapedNameSpaceTarget);
                         string downloadDirectory = options.DownloadDirectory == "." ? System.IO.Directory.GetCurrentDirectory() : options.DownloadDirectory;
                         bool useCache = options.UseCache;
                         PackageDownloader? packageDownloader = new PackageDownloader(purl, ProjectManagerFactory, downloadDirectory, useCache);

--- a/src/oss-health/HealthTool.cs
+++ b/src/oss-health/HealthTool.cs
@@ -14,6 +14,8 @@ namespace Microsoft.CST.OpenSource
     using Contracts;
     using Microsoft.CST.OpenSource.PackageManagers;
     using PackageUrl;
+    using System.Linq;
+    using System.Text.RegularExpressions;
 
     public class HealthTool : OSSGadget
     {
@@ -113,6 +115,7 @@ namespace Microsoft.CST.OpenSource
             }
         }
 
+
         private async Task RunAsync(Options options)
         {
             // select output destination and format
@@ -120,11 +123,15 @@ namespace Microsoft.CST.OpenSource
             IOutputBuilder outputBuilder = SelectFormat(options.Format ?? OutputFormat.text.ToString());
             if (options.Targets is IList<string> targetList && targetList.Count > 0)
             {
-                foreach (string? target in targetList)
+                foreach (string target in targetList)
                 {
                     try
                     {
-                        PackageURL? purl = new PackageURL(target);
+                        // PackageURL requires the @ in a namespace declaration to be escaped
+                        // We find if the namespace contains an @ in the namespace
+                        // And replace it with %40
+                        string escapedNameSpaceTarget = EscapeAtSymbolInNameSpace(target);
+                        PackageURL? purl = new PackageURL(escapedNameSpaceTarget);
                         HealthMetrics? healthMetrics = CheckHealth(purl).Result;
                         if (healthMetrics == null)
                         {


### PR DESCRIPTION
Small refactor to move the escape method to a helper method on the OSSGadget base class so ti can be called from any CLI as needed.