### PR TITLE
Improved "GetPublishedAtUtcAsync" method efficiency

### DIFF
--- a/src/Shared/PackageManagers/BaseProjectManager.cs
+++ b/src/Shared/PackageManagers/BaseProjectManager.cs
@@ -436,7 +436,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         }
 
         /// <inheritdoc />
-        public async Task<DateTime?> GetPublishedAtUtcAsync(PackageURL purl, bool useCache = true)
+        public virtual async Task<DateTime?> GetPublishedAtUtcAsync(PackageURL purl, bool useCache = true)
         {
             Check.NotNull(nameof(purl.Version), purl.Version);
             DateTime? uploadTime = (await GetPackageMetadataAsync(purl, useCache))?.UploadTime?.ToUniversalTime();

--- a/src/Shared/PackageManagers/BaseProjectManager.cs
+++ b/src/Shared/PackageManagers/BaseProjectManager.cs
@@ -261,8 +261,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                     MemoryCacheEntryOptions? mce = new() 
                     {
                         Size = contentLength,
-                        SlidingExpiration = TimeSpan.FromMinutes(30),
-                        AbsoluteExpiration = DateTimeOffset.UtcNow.AddHours(6),
+                        AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(30),
                     };
                     DataCache.Set<JsonDocument>(uri, doc, mce);
                 }
@@ -458,7 +457,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         protected static readonly MemoryCache DataCache = new(
             new MemoryCacheOptions
             {
-                SizeLimit = 1024 * 1024 * 800
+                SizeLimit = 1024 * 1024 * 100
             }
         );
 

--- a/src/Shared/PackageManagers/PyPIProjectManager.cs
+++ b/src/Shared/PackageManagers/PyPIProjectManager.cs
@@ -448,7 +448,15 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                 {
                     string? urlStr = OssUtilities.GetJSONPropertyStringIfExists(url, "url");
                     string? uploadTimeStr = OssUtilities.GetJSONPropertyStringIfExists(url, "upload_time");
-                    uploadTime = uploadTimeStr != null ? DateTime.Parse(uploadTimeStr).ToUniversalTime() : null;
+                    if (uploadTimeStr != null)
+                    {
+                        DateTime newUploadTime = DateTime.Parse(uploadTimeStr).ToUniversalTime();
+                        // Used to set the minimum upload time for all associated files for this version to get the publish time.
+                        if (uploadTime == null || uploadTime > newUploadTime)
+                        {
+                            uploadTime = newUploadTime;
+                        }
+                    }
                 }
             }
 

--- a/src/oss-tests/ProjectManagerTests/PyPIProjectManagerTests.cs
+++ b/src/oss-tests/ProjectManagerTests/PyPIProjectManagerTests.cs
@@ -161,9 +161,9 @@ namespace Microsoft.CST.OpenSource.Tests.ProjectManagerTests
         }
 
         [DataTestMethod]
-        [DataRow("pkg:pypi/pandas@1.4.2", "2022-04-02T17:37:04")]
-        [DataRow("pkg:pypi/plotly@5.7.0", "2022-04-05T23:26:12")]
-        [DataRow("pkg:pypi/requests@2.27.1", "2022-01-05T23:40:51")]
+        [DataRow("pkg:pypi/pandas@1.4.2", "2022-04-02T10:37:04")]
+        [DataRow("pkg:pypi/plotly@5.7.0", "2022-04-05T16:26:12")]
+        [DataRow("pkg:pypi/requests@2.27.1", "2022-01-05T15:40:51")]
         public async Task GetPublishedAtUtcSucceeds(string purlString, string? expectedTime = null)
         {
             PackageURL purl = new(purlString);
@@ -175,7 +175,7 @@ namespace Microsoft.CST.OpenSource.Tests.ProjectManagerTests
             }
             else
             {
-                Assert.AreEqual(DateTime.Parse(expectedTime), time);
+                Assert.AreEqual(DateTime.Parse(expectedTime).ToUniversalTime(), time);
             }
         }
 

--- a/src/oss-tests/ProjectManagerTests/PyPIProjectManagerTests.cs
+++ b/src/oss-tests/ProjectManagerTests/PyPIProjectManagerTests.cs
@@ -161,9 +161,9 @@ namespace Microsoft.CST.OpenSource.Tests.ProjectManagerTests
         }
 
         [DataTestMethod]
-        [DataRow("pkg:pypi/pandas@1.4.2", "2022-04-02T10:37:04")]
-        [DataRow("pkg:pypi/plotly@5.7.0", "2022-04-05T16:26:12")]
-        [DataRow("pkg:pypi/requests@2.27.1", "2022-01-05T15:40:51")]
+        [DataRow("pkg:pypi/pandas@1.4.2", "2022-04-02T10:32:27")]
+        [DataRow("pkg:pypi/plotly@5.7.0", "2022-04-05T16:26:03")]
+        [DataRow("pkg:pypi/requests@2.27.1", "2022-01-05T15:40:49")]
         public async Task GetPublishedAtUtcSucceeds(string purlString, string? expectedTime = null)
         {
             PackageURL purl = new(purlString);

--- a/src/oss-tests/ProjectManagerTests/PyPIProjectManagerTests.cs
+++ b/src/oss-tests/ProjectManagerTests/PyPIProjectManagerTests.cs
@@ -161,6 +161,25 @@ namespace Microsoft.CST.OpenSource.Tests.ProjectManagerTests
         }
 
         [DataTestMethod]
+        [DataRow("pkg:pypi/pandas@1.4.2", "2022-04-02T17:37:04")]
+        [DataRow("pkg:pypi/plotly@5.7.0", "2022-04-05T23:26:12")]
+        [DataRow("pkg:pypi/requests@2.27.1", "2022-01-05T23:40:51")]
+        public async Task GetPublishedAtUtcSucceeds(string purlString, string? expectedTime = null)
+        {
+            PackageURL purl = new(purlString);
+            DateTime? time = await _projectManager.GetPublishedAtUtcAsync(purl, useCache: false);
+
+            if (expectedTime == null)
+            {
+                Assert.IsNull(time);
+            }
+            else
+            {
+                Assert.AreEqual(DateTime.Parse(expectedTime), time);
+            }
+        }
+
+        [DataTestMethod]
         [DataRow("pkg:pypi/pandas", true)]
         [DataRow("pkg:pypi/plotly@3.7.1", true)]
         [DataRow("pkg:pypi/notarealpackage", false)]


### PR DESCRIPTION
Current implementation of "GetPublishedAtUtcAsync" is fetching all the metadata for a given package version, which is causing significant delay. To improve the latency, optimized "GetPublishedAtUtcAsync" method to fetch the uploadtime alone. 