### PR TITLE
Lock moq version to 4.18.2

### DIFF
--- a/src/oss-tests/FindSourceTests.cs
+++ b/src/oss-tests/FindSourceTests.cs
@@ -90,7 +90,7 @@ namespace Microsoft.CST.OpenSource.Tests
         [DataRow("pkg:pypi/moment", "pkg:github/zachwill/moment")]
         [DataRow("pkg:nuget/Newtonsoft.Json", "pkg:github/jamesnk/newtonsoft.json")]
         [DataRow("pkg:pypi/django", "pkg:github/django/django")]
-        [DataRow("pkg:pypi/pylint", "pkg:github/pycqa/pylint")]
+        [DataRow("pkg:pypi/pylint", "pkg:github/pylint-dev/pylint")]
         [DataRow("pkg:pypi/arrow", "pkg:github/arrow-py/arrow")]
         public async Task FindSource_Success(string purl, string targetResult)
         {

--- a/src/oss-tests/oss-tests.csproj
+++ b/src/oss-tests/oss-tests.csproj
@@ -19,7 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="Moq" Version="[4.18.2]" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />


### PR DESCRIPTION
Per #441, interim commit to lock moq version to 4.18.2 until we decide on a path forward.