### PR TITLE
Change the way of excerpts line to be splited

### DIFF
--- a/src/oss-detect-backdoor/DetectBackdoorTool.cs
+++ b/src/oss-detect-backdoor/DetectBackdoorTool.cs
@@ -121,7 +121,7 @@ namespace Microsoft.CST.OpenSource
                         Console.WriteLine("  Severity: " + Cyan(match.Severity.ToString()) + ", Confidence: " + Cyan(match.Confidence.ToString()));
                         Console.WriteLine("  Filename: " + Yellow(filename));
                         Console.WriteLine("   Pattern: " + Green(match.MatchingPattern.Pattern));
-                        foreach (string? line in match.Excerpt.Split(new[] {"\r", "\n", "\r\n"}, StringSplitOptions.None))
+                        foreach (string? line in match.Excerpt.Split(Environment.NewLine, StringSplitOptions.None))
                         {
                             string? s = line;
                             if (s.Length > 100)

--- a/src/oss-detect-backdoor/DetectBackdoorTool.cs
+++ b/src/oss-detect-backdoor/DetectBackdoorTool.cs
@@ -121,7 +121,7 @@ namespace Microsoft.CST.OpenSource
                         Console.WriteLine("  Severity: " + Cyan(match.Severity.ToString()) + ", Confidence: " + Cyan(match.Confidence.ToString()));
                         Console.WriteLine("  Filename: " + Yellow(filename));
                         Console.WriteLine("   Pattern: " + Green(match.MatchingPattern.Pattern));
-                        foreach (string? line in match.Excerpt.Split(Environment.NewLine, StringSplitOptions.None))
+                        foreach (string? line in match.Excerpt.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None))
                         {
                             string? s = line;
                             if (s.Length > 100)


### PR DESCRIPTION
Use Environment.NewLine to replace new[] { "\r", "\n", "\r\n" }. The latter can result in peculiar line breaks in certain code files, such as introducing additional blank lines in Python source code.