### PR TITLE
Switch to newly created service connection

### DIFF
--- a/Pipelines/core-pipeline.yml
+++ b/Pipelines/core-pipeline.yml
@@ -268,7 +268,7 @@ stages:
     - task: GitHubRelease@1
       displayName: Release to GitHub
       inputs:
-        gitHubConnection: 'OSSGadget'
+        gitHubConnection: 'OSSGadget_gfs'
         repositoryName: 'microsoft/OSSGadget'
         action: 'create'
         target: '$(Build.SourceVersion)'


### PR DESCRIPTION
We are hitting errors when trying to publish github releases, try switching to a newly created service connection.