### PR TITLE
Add optional timeouts for project managers

### DIFF
--- a/src/Shared/Contracts/IBaseProjectManager.cs
+++ b/src/Shared/Contracts/IBaseProjectManager.cs
@@ -20,6 +20,8 @@ public interface IBaseProjectManager
     /// <seealso href="https://www.github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst"/>
     public string ManagerType { get; }
 
+    public TimeSpan? Timeout { get; }
+
     /// <summary>
     /// Per-object option container.
     /// </summary>

--- a/src/Shared/Contracts/IProjectManagerFactory.cs
+++ b/src/Shared/Contracts/IProjectManagerFactory.cs
@@ -4,6 +4,7 @@ namespace Microsoft.CST.OpenSource.Contracts;
 
 using PackageManagers;
 using PackageUrl;
+using System;
 
 public interface IProjectManagerFactory
 {
@@ -12,6 +13,7 @@ public interface IProjectManagerFactory
     /// </summary>
     /// <param name="purl">The <see cref="PackageURL"/> for the package to create the project manager for.</param>
     /// <param name="destinationDirectory">The new destination directory, if provided.</param>
+    /// <param name="timeout">The <see cref="TimeSpan"/> to wait before the request times out.</param>
     /// <returns>The implementation of <see cref="BaseProjectManager"/> for this <paramref name="purl"/>'s type.</returns>
-    IBaseProjectManager? CreateProjectManager(PackageURL purl, string destinationDirectory = ".");
+    IBaseProjectManager? CreateProjectManager(PackageURL purl, string destinationDirectory = ".", TimeSpan? timeout = null);
 }

--- a/src/Shared/PackageManagers/BaseProjectManager.cs
+++ b/src/Shared/PackageManagers/BaseProjectManager.cs
@@ -25,18 +25,21 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         /// <inheritdoc />
         public abstract string ManagerType { get; }
 
+        private TimeSpan? _timeout;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="BaseProjectManager"/> class.
         /// </summary>
-        public BaseProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory = ".")
+        public BaseProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory = ".", TimeSpan? timeout = null)
         {
             EnvironmentHelper.OverrideEnvironmentVariables(this);
             Options = new Dictionary<string, object>();
             TopLevelExtractionDirectory = destinationDirectory;
             HttpClientFactory = httpClientFactory;
+            _timeout = timeout;
         }
 
-        public BaseProjectManager(string destinationDirectory = ".") : this(new DefaultHttpClientFactory(), destinationDirectory)
+        public BaseProjectManager(string destinationDirectory = ".", TimeSpan? timeout = null) : this(new DefaultHttpClientFactory(), destinationDirectory, timeout)
         {
         }
 
@@ -524,7 +527,12 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
         protected HttpClient CreateHttpClient()
         {
-            return HttpClientFactory.CreateClient(GetType().Name);
+            HttpClient client = HttpClientFactory.CreateClient(GetType().Name);
+            if (_timeout.HasValue)
+            {
+                client.Timeout = _timeout.Value;
+            }
+            return client;
         }
     }
 }

--- a/src/Shared/PackageManagers/BaseProjectManager.cs
+++ b/src/Shared/PackageManagers/BaseProjectManager.cs
@@ -25,7 +25,8 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         /// <inheritdoc />
         public abstract string ManagerType { get; }
 
-        private TimeSpan? _timeout;
+        /// <inheritdoc/>
+        public TimeSpan? Timeout { get; } = null;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BaseProjectManager"/> class.
@@ -36,7 +37,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             Options = new Dictionary<string, object>();
             TopLevelExtractionDirectory = destinationDirectory;
             HttpClientFactory = httpClientFactory;
-            _timeout = timeout;
+            Timeout = timeout;
         }
 
         public BaseProjectManager(string destinationDirectory = ".", TimeSpan? timeout = null) : this(new DefaultHttpClientFactory(), destinationDirectory, timeout)
@@ -528,9 +529,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         protected HttpClient CreateHttpClient()
         {
             HttpClient client = HttpClientFactory.CreateClient(GetType().Name);
-            if (_timeout.HasValue)
+            if (Timeout.HasValue)
             {
-                client.Timeout = _timeout.Value;
+                client.Timeout = Timeout.Value;
             }
             return client;
         }

--- a/src/Shared/PackageManagers/CPANProjectManager.cs
+++ b/src/Shared/PackageManagers/CPANProjectManager.cs
@@ -34,11 +34,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public string ENV_CPAN_API_ENDPOINT { get; set; } = "https://fastapi.metacpan.org";
 
-        public CPANProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory) : base(httpClientFactory, destinationDirectory)
+        public CPANProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory, TimeSpan? timeout = null) : base(httpClientFactory, destinationDirectory, timeout)
         {
         }
 
-        public CPANProjectManager(string destinationDirectory) : base(destinationDirectory)
+        public CPANProjectManager(string destinationDirectory, TimeSpan? timeout = null) : base(destinationDirectory, timeout)
         {
         }
 

--- a/src/Shared/PackageManagers/CRANProjectManager.cs
+++ b/src/Shared/PackageManagers/CRANProjectManager.cs
@@ -26,11 +26,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public string ENV_CRAN_ENDPOINT { get; set; } = "https://cran.r-project.org";
 
-        public CRANProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory) : base(httpClientFactory, destinationDirectory)
+        public CRANProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory, TimeSpan? timeout = null) : base(httpClientFactory, destinationDirectory, timeout)
         {
         }
 
-        public CRANProjectManager(string destinationDirectory) : base(destinationDirectory)
+        public CRANProjectManager(string destinationDirectory, TimeSpan? timeout = null) : base(destinationDirectory, timeout)
         {
         }
 

--- a/src/Shared/PackageManagers/CargoProjectManager.cs
+++ b/src/Shared/PackageManagers/CargoProjectManager.cs
@@ -42,8 +42,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         public CargoProjectManager(
             string directory,
             IManagerPackageActions<IManagerPackageVersionMetadata>? actions = null,
-            IHttpClientFactory? httpClientFactory = null)
-            : base(actions ?? new NoOpPackageActions(), httpClientFactory ?? new DefaultHttpClientFactory(), directory)
+            IHttpClientFactory? httpClientFactory = null,
+            TimeSpan? timeout = null)
+            : base(actions ?? new NoOpPackageActions(), httpClientFactory ?? new DefaultHttpClientFactory(), directory, timeout)
         {
         }
 

--- a/src/Shared/PackageManagers/CocoapodsProjectManager.cs
+++ b/src/Shared/PackageManagers/CocoapodsProjectManager.cs
@@ -17,6 +17,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
     using System.Security.Cryptography;
     using System.Text;
     using System.Text.RegularExpressions;
+    using System.Threading;
     using System.Threading.Tasks;
 
     internal class CocoapodsProjectManager : BaseProjectManager
@@ -38,11 +39,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public string ENV_COCOAPODS_METADATA_ENDPOINT { get; set; } = "https://cocoapods.org";
 
-        public CocoapodsProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory) : base(httpClientFactory, destinationDirectory)
+        public CocoapodsProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory, TimeSpan? timeout = null) : base(httpClientFactory, destinationDirectory, timeout)
         {
         }
 
-        public CocoapodsProjectManager(string destinationDirectory) : base(destinationDirectory)
+        public CocoapodsProjectManager(string destinationDirectory, TimeSpan? timeout = null) : base(destinationDirectory, timeout)
         {
         }
 

--- a/src/Shared/PackageManagers/ComposerProjectManager.cs
+++ b/src/Shared/PackageManagers/ComposerProjectManager.cs
@@ -26,11 +26,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public string ENV_COMPOSER_ENDPOINT { get; set; } = "https://repo.packagist.org";
 
-        public ComposerProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory) : base(httpClientFactory, destinationDirectory)
+        public ComposerProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory, TimeSpan? timeout = null) : base(httpClientFactory, destinationDirectory, timeout)
         {
         }
 
-        public ComposerProjectManager(string destinationDirectory) : base(destinationDirectory)
+        public ComposerProjectManager(string destinationDirectory, TimeSpan? timeout = null) : base(destinationDirectory, timeout)
         {
         }
 

--- a/src/Shared/PackageManagers/CondaProjectManager.cs
+++ b/src/Shared/PackageManagers/CondaProjectManager.cs
@@ -33,8 +33,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         public CondaProjectManager(
             string directory,
             IManagerPackageActions<IManagerPackageVersionMetadata>? actions = null,
-            IHttpClientFactory? httpClientFactory = null)
-            : base(actions ?? new NoOpPackageActions(), httpClientFactory ?? new DefaultHttpClientFactory(), directory)
+            IHttpClientFactory? httpClientFactory = null,
+            TimeSpan? timeout = null)
+            : base(actions ?? new NoOpPackageActions(), httpClientFactory ?? new DefaultHttpClientFactory(), directory, timeout)
         {
         }
 

--- a/src/Shared/PackageManagers/GemProjectManager.cs
+++ b/src/Shared/PackageManagers/GemProjectManager.cs
@@ -27,11 +27,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         public string ENV_RUBYGEMS_ENDPOINT { get; set; } = "https://rubygems.org";
         public string ENV_RUBYGEMS_ENDPOINT_API { get; set; } = "https://api.rubygems.org";
 
-        public GemProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory) : base(httpClientFactory, destinationDirectory)
+        public GemProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory, TimeSpan? timeout = null) : base(httpClientFactory, destinationDirectory, timeout)
         {
         }
 
-        public GemProjectManager(string destinationDirectory) : base(destinationDirectory)
+        public GemProjectManager(string destinationDirectory, TimeSpan? timeout = null) : base(destinationDirectory, timeout)
         {
         }
 

--- a/src/Shared/PackageManagers/GitHubProjectManager.cs
+++ b/src/Shared/PackageManagers/GitHubProjectManager.cs
@@ -28,11 +28,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         private const string DEFAULT_GITHUB_ENDPOINT = "https://github.com";
         public string ENV_GITHUB_ENDPOINT { get; set; } = DEFAULT_GITHUB_ENDPOINT;
 
-        public GitHubProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory) : base(httpClientFactory, destinationDirectory)
+        public GitHubProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory, TimeSpan? timeout = null) : base(httpClientFactory, destinationDirectory, timeout)
         {
         }
 
-        public GitHubProjectManager(string destinationDirectory) : base(destinationDirectory)
+        public GitHubProjectManager(string destinationDirectory, TimeSpan? timeout = null) : base(destinationDirectory, timeout)
         {
         }
 

--- a/src/Shared/PackageManagers/GolangProjectManager.cs
+++ b/src/Shared/PackageManagers/GolangProjectManager.cs
@@ -37,8 +37,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         public GolangProjectManager(
             string directory,
             IManagerPackageActions<IManagerPackageVersionMetadata>? actions = null,
-            IHttpClientFactory? httpClientFactory = null)
-            : base(actions ?? new NoOpPackageActions(), httpClientFactory ?? new DefaultHttpClientFactory(), directory)
+            IHttpClientFactory? httpClientFactory = null,
+            TimeSpan? timeout = null)
+            : base(actions ?? new NoOpPackageActions(), httpClientFactory ?? new DefaultHttpClientFactory(), directory, timeout)
         {
         }
 

--- a/src/Shared/PackageManagers/HackageProjectManager.cs
+++ b/src/Shared/PackageManagers/HackageProjectManager.cs
@@ -26,11 +26,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public string ENV_HACKAGE_ENDPOINT { get; set; } = "https://hackage.haskell.org";
 
-        public HackageProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory) : base(httpClientFactory, destinationDirectory)
+        public HackageProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory, TimeSpan? timeout = null) : base(httpClientFactory, destinationDirectory, timeout)
         {
         }
 
-        public HackageProjectManager(string destinationDirectory) : base(destinationDirectory)
+        public HackageProjectManager(string destinationDirectory, TimeSpan? timeout = null) : base(destinationDirectory, timeout)
         {
         }
 

--- a/src/Shared/PackageManagers/MavenProjectManager.cs
+++ b/src/Shared/PackageManagers/MavenProjectManager.cs
@@ -33,8 +33,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         public MavenProjectManager(
             string directory,
             IManagerPackageActions<IManagerPackageVersionMetadata>? actions = null,
-            IHttpClientFactory? httpClientFactory = null)
-            : base(actions ?? new NoOpPackageActions(), httpClientFactory ?? new DefaultHttpClientFactory(), directory)
+            IHttpClientFactory? httpClientFactory = null,
+            TimeSpan? timeout = null)
+            : base(actions ?? new NoOpPackageActions(), httpClientFactory ?? new DefaultHttpClientFactory(), directory, timeout)
         {
         }
 

--- a/src/Shared/PackageManagers/NPMProjectManager.cs
+++ b/src/Shared/PackageManagers/NPMProjectManager.cs
@@ -130,6 +130,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                     downloadedPaths.Add(extractionPath);
                 }
             }
+            catch (TaskCanceledException ex)
+            {
+                Logger.Debug(ex, "Downloading NPM package timed out: {0}", ex.Message);
+                throw;
+            }
             catch (Exception ex)
             {
                 Logger.Debug(ex, "Error downloading NPM package: {0}", ex.Message);

--- a/src/Shared/PackageManagers/NPMProjectManager.cs
+++ b/src/Shared/PackageManagers/NPMProjectManager.cs
@@ -43,8 +43,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         public NPMProjectManager(
             string directory,
             IManagerPackageActions<IManagerPackageVersionMetadata>? actions = null,
-            IHttpClientFactory? httpClientFactory = null)
-            : base(actions ?? new NoOpPackageActions(), httpClientFactory ?? new DefaultHttpClientFactory(), directory)
+            IHttpClientFactory? httpClientFactory = null,
+            TimeSpan? timeout = null)
+            : base(actions ?? new NoOpPackageActions(), httpClientFactory ?? new DefaultHttpClientFactory(), directory, timeout)
         {
         }
 

--- a/src/Shared/PackageManagers/NuGetProjectManager.cs
+++ b/src/Shared/PackageManagers/NuGetProjectManager.cs
@@ -46,8 +46,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         public NuGetProjectManager(
             string directory,
             IManagerPackageActions<NuGetPackageVersionMetadata>? actions = null,
-            IHttpClientFactory? httpClientFactory = null)
-            : base(actions ?? new NuGetPackageActions(), httpClientFactory ?? new DefaultHttpClientFactory(), directory)
+            IHttpClientFactory? httpClientFactory = null,
+            TimeSpan? timeout = null)
+            : base(actions ?? new NuGetPackageActions(), httpClientFactory ?? new DefaultHttpClientFactory(), directory, timeout)
         {
             GetRegistrationEndpointAsync().Wait();
         }

--- a/src/Shared/PackageManagers/ProjectManagerFactory.cs
+++ b/src/Shared/PackageManagers/ProjectManagerFactory.cs
@@ -17,13 +17,14 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         /// </summary>
         /// <remarks>The only runtime parameter we need is the destination directory. Everything else can be defined in the constructor call itself.</remarks>
         /// <param name="destinationDirectory">The destination that any files should be saved to when downloading from this ProjectManager, defaults to the runtime directory.</param>
+        /// <param name="timeout">The <see cref="TimeSpan"/> to wait before the request times out.</param>
         /// <returns>An implementation of the <see cref="BaseProjectManager"/> class, or null if unable to construct.</returns>
         /// <example>
         /// destinationDirectory =>
         /// new NPMProjectManager(httpClientFactory, destinationDirectory)
         /// </example>
         /// <seealso cref="ProjectManagerFactory.GetDefaultManagers">Example implementations in GetDefaultManagers(IHttpClientFactory?)</seealso>
-        public delegate BaseProjectManager? ConstructProjectManager(string destinationDirectory = ".");
+        public delegate BaseProjectManager? ConstructProjectManager(string destinationDirectory = ".", TimeSpan? timeout = null);
 
         /// <summary>
         /// The dictionary of project managers.
@@ -61,82 +62,82 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             return new Dictionary<string, ConstructProjectManager>(StringComparer.InvariantCultureIgnoreCase)
             {
                 {
-                    CargoProjectManager.Type, destinationDirectory =>
-                        new CargoProjectManager(destinationDirectory, new NoOpPackageActions(), httpClientFactory)
+                    CargoProjectManager.Type, (destinationDirectory, timeout) =>
+                        new CargoProjectManager(destinationDirectory, new NoOpPackageActions(), httpClientFactory, timeout)
                 },
                 {
-                    CocoapodsProjectManager.Type, destinationDirectory =>
-                        new CocoapodsProjectManager(httpClientFactory, destinationDirectory)
+                    CocoapodsProjectManager.Type, (destinationDirectory, timeout) =>
+                        new CocoapodsProjectManager(httpClientFactory, destinationDirectory, timeout)
                 },
                 {
-                    ComposerProjectManager.Type, destinationDirectory =>
-                        new ComposerProjectManager(httpClientFactory, destinationDirectory)
+                    ComposerProjectManager.Type, (destinationDirectory, timeout) =>
+                        new ComposerProjectManager(httpClientFactory, destinationDirectory, timeout)
                 },
                 {
-                    CondaProjectManager.Type, destinationDirectory =>
-                        new CondaProjectManager(destinationDirectory, new NoOpPackageActions(), httpClientFactory)
+                    CondaProjectManager.Type, (destinationDirectory, timeout) =>
+                        new CondaProjectManager(destinationDirectory, new NoOpPackageActions(), httpClientFactory, timeout)
                 },
                 {
-                    CPANProjectManager.Type, destinationDirectory =>
-                        new CPANProjectManager(httpClientFactory, destinationDirectory)
+                    CPANProjectManager.Type, (destinationDirectory, timeout) =>
+                        new CPANProjectManager(httpClientFactory, destinationDirectory, timeout)
                 },
                 {
-                    CRANProjectManager.Type, destinationDirectory =>
-                        new CRANProjectManager(httpClientFactory, destinationDirectory)
+                    CRANProjectManager.Type, (destinationDirectory, timeout) =>
+                        new CRANProjectManager(httpClientFactory, destinationDirectory, timeout)
                 },
                 {
-                    GemProjectManager.Type, destinationDirectory =>
-                        new GemProjectManager(httpClientFactory, destinationDirectory)
+                    GemProjectManager.Type, (destinationDirectory, timeout) =>
+                        new GemProjectManager(httpClientFactory, destinationDirectory, timeout)
                 },
                 {
-                    GitHubProjectManager.Type, destinationDirectory =>
-                        new GitHubProjectManager(httpClientFactory, destinationDirectory)
+                    GitHubProjectManager.Type, (destinationDirectory, timeout) =>
+                        new GitHubProjectManager(httpClientFactory, destinationDirectory, timeout)
                 },
                 {
-                    GolangProjectManager.Type, destinationDirectory =>
-                        new GolangProjectManager(destinationDirectory, new NoOpPackageActions(), httpClientFactory)
+                    GolangProjectManager.Type, (destinationDirectory, timeout) =>
+                        new GolangProjectManager(destinationDirectory, new NoOpPackageActions(), httpClientFactory, timeout)
                 },
                 {
-                    HackageProjectManager.Type, destinationDirectory =>
-                        new HackageProjectManager(httpClientFactory, destinationDirectory)
+                    HackageProjectManager.Type, (destinationDirectory, timeout) =>
+                        new HackageProjectManager(httpClientFactory, destinationDirectory, timeout)
                 },
                 {
-                    MavenProjectManager.Type, destinationDirectory =>
-                        new MavenProjectManager(destinationDirectory, new NoOpPackageActions(), httpClientFactory)
+                    MavenProjectManager.Type, (destinationDirectory, timeout) =>
+                        new MavenProjectManager(destinationDirectory, new NoOpPackageActions(), httpClientFactory, timeout)
                 },
                 {
-                    NPMProjectManager.Type, destinationDirectory =>
-                        new NPMProjectManager(destinationDirectory, new NoOpPackageActions(), httpClientFactory)
+                    NPMProjectManager.Type, (destinationDirectory, timeout) =>
+                        new NPMProjectManager(destinationDirectory, new NoOpPackageActions(), httpClientFactory, timeout)
                 },
                 {
-                    NuGetProjectManager.Type, destinationDirectory =>
-                        new NuGetProjectManager(destinationDirectory, new NuGetPackageActions(), httpClientFactory) // Add the NuGetPackageActions to the NuGetProjectManager.
+                    NuGetProjectManager.Type, (destinationDirectory, timeout) =>
+                        new NuGetProjectManager(destinationDirectory, new NuGetPackageActions(), httpClientFactory, timeout) // Add the NuGetPackageActions to the NuGetProjectManager.
                 },
                 {
-                    PyPIProjectManager.Type, destinationDirectory =>
-                        new PyPIProjectManager(destinationDirectory, new NoOpPackageActions(), httpClientFactory)
+                    PyPIProjectManager.Type, (destinationDirectory, timeout) =>
+                        new PyPIProjectManager(destinationDirectory, new NoOpPackageActions(), httpClientFactory, timeout)
                 },
                 {
-                    UbuntuProjectManager.Type, destinationDirectory =>
-                        new UbuntuProjectManager(httpClientFactory, destinationDirectory)
+                    UbuntuProjectManager.Type, (destinationDirectory, timeout) =>
+                        new UbuntuProjectManager(httpClientFactory, destinationDirectory, timeout)
                 },
                 {
-                    URLProjectManager.Type, destinationDirectory =>
-                        new URLProjectManager(httpClientFactory, destinationDirectory)
+                    URLProjectManager.Type, (destinationDirectory, timeout) =>
+                        new URLProjectManager(httpClientFactory, destinationDirectory, timeout)
                 },
                 {
-                    VSMProjectManager.Type, destinationDirectory =>
-                        new VSMProjectManager(httpClientFactory, destinationDirectory)
+                    VSMProjectManager.Type, (destinationDirectory, timeout) =>
+                        new VSMProjectManager(httpClientFactory, destinationDirectory, timeout)
                 },
             };
         }
 
         /// <inheritdoc />
-        public IBaseProjectManager? CreateProjectManager(PackageURL purl, string destinationDirectory = ".")
+        public IBaseProjectManager? CreateProjectManager(PackageURL purl, string destinationDirectory = ".", TimeSpan? timeout = null)
         {
             ConstructProjectManager? projectManager = _projectManagers.GetValueOrDefault(purl.Type);
 
-            return projectManager?.Invoke(destinationDirectory);
+            return projectManager?.Invoke(destinationDirectory, timeout);
         }
 
         /// <summary>

--- a/src/Shared/PackageManagers/PyPIProjectManager.cs
+++ b/src/Shared/PackageManagers/PyPIProjectManager.cs
@@ -37,8 +37,9 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         public PyPIProjectManager(
             string directory,
             IManagerPackageActions<IManagerPackageVersionMetadata>? actions = null,
-            IHttpClientFactory? httpClientFactory = null)
-            : base(actions ?? new NoOpPackageActions(), httpClientFactory ?? new DefaultHttpClientFactory(), directory)
+            IHttpClientFactory? httpClientFactory = null,
+            TimeSpan? timeout = null)
+            : base(actions ?? new NoOpPackageActions(), httpClientFactory ?? new DefaultHttpClientFactory(), directory, timeout)
         {
         }
 

--- a/src/Shared/PackageManagers/TypedManager.cs
+++ b/src/Shared/PackageManagers/TypedManager.cs
@@ -35,7 +35,7 @@ public abstract class TypedManager<T, TArtifactUriType> : BaseProjectManager, IT
     /// </summary>
     protected readonly IManagerPackageActions<T> Actions;
 
-    protected TypedManager(IManagerPackageActions<T> actions, IHttpClientFactory httpClientFactory, string directory) : base(httpClientFactory, directory)
+    protected TypedManager(IManagerPackageActions<T> actions, IHttpClientFactory httpClientFactory, string directory, TimeSpan? timeout = null) : base(httpClientFactory, directory, timeout)
     {
         Actions = actions;
     }

--- a/src/Shared/PackageManagers/URLProjectManager.cs
+++ b/src/Shared/PackageManagers/URLProjectManager.cs
@@ -20,11 +20,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
         public override string ManagerType => Type;
 
-        public URLProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory) : base(httpClientFactory, destinationDirectory)
+        public URLProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory, TimeSpan? timeout = null) : base(httpClientFactory, destinationDirectory, timeout)
         {
         }
 
-        public URLProjectManager(string destinationDirectory) : base(destinationDirectory)
+        public URLProjectManager(string destinationDirectory, TimeSpan? timeout = null) : base(destinationDirectory, timeout)
         {
         }
 

--- a/src/Shared/PackageManagers/UbuntuProjectManager.cs
+++ b/src/Shared/PackageManagers/UbuntuProjectManager.cs
@@ -34,11 +34,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public string ENV_UBUNTU_POOL_NAMES { get; set; } = "main,universe,multiverse,restricted";
 
-        public UbuntuProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory) : base(httpClientFactory, destinationDirectory)
+        public UbuntuProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory, TimeSpan? timeout = null) : base(httpClientFactory, destinationDirectory, timeout)
         {
         }
 
-        public UbuntuProjectManager(string destinationDirectory) : base(destinationDirectory)
+        public UbuntuProjectManager(string destinationDirectory, TimeSpan? timeout = null) : base(destinationDirectory, timeout)
         {
         }
 

--- a/src/Shared/PackageManagers/VSMProjectManager.cs
+++ b/src/Shared/PackageManagers/VSMProjectManager.cs
@@ -28,11 +28,11 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Modified through reflection.")]
         public string ENV_VS_MARKETPLACE_ENDPOINT { get; set; } = "https://marketplace.visualstudio.com";
 
-        public VSMProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory) : base(httpClientFactory, destinationDirectory)
+        public VSMProjectManager(IHttpClientFactory httpClientFactory, string destinationDirectory, TimeSpan? timeout = null) : base(httpClientFactory, destinationDirectory, timeout)
         {
         }
 
-        public VSMProjectManager(string destinationDirectory) : base(destinationDirectory)
+        public VSMProjectManager(string destinationDirectory, TimeSpan? timeout = null) : base(destinationDirectory, timeout)
         {
         }
 

--- a/src/oss-tests/FindSquatsTests.cs
+++ b/src/oss-tests/FindSquatsTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CST.OpenSource.Tests
 
             // Override the NuGet constructor to add the mocked NuGetPackageActions.
             managerOverrides[NuGetProjectManager.Type] =
-                _ => new NuGetProjectManager(".", nugetPackageActions, httpClientFactory);
+                (destinationDirectory, timeout) => new NuGetProjectManager(".", nugetPackageActions, httpClientFactory);
             
             ProjectManagerFactory projectManagerFactory = new(managerOverrides);
             FindSquatsTool fst = new(projectManagerFactory);
@@ -554,8 +554,8 @@ namespace Microsoft.CST.OpenSource.Tests
             IManagerPackageActions<NuGetPackageVersionMetadata> packageActions = PackageActionsHelper<NuGetPackageVersionMetadata>.SetupPackageActions(newtonsoft, validSquats: squattingPackages) ?? throw new InvalidOperationException();
             Dictionary<string, ProjectManagerFactory.ConstructProjectManager> overrideDict = ProjectManagerFactory.GetDefaultManagers(httpClientFactory);
 
-            overrideDict[NuGetProjectManager.Type] = directory =>
-                new NuGetProjectManager(directory, packageActions, httpClientFactory);
+            overrideDict[NuGetProjectManager.Type] = (destinationDirectory, timeout) =>
+                new NuGetProjectManager(destinationDirectory, packageActions, httpClientFactory);
             
             FindPackageSquats findPackageSquats = new(new ProjectManagerFactory(overrideDict), newtonsoft);
 
@@ -589,8 +589,8 @@ namespace Microsoft.CST.OpenSource.Tests
             IManagerPackageActions<NuGetPackageVersionMetadata> packageActions = PackageActionsHelper<NuGetPackageVersionMetadata>.SetupPackageActions(requests, validSquats: squattingPackages) ?? throw new InvalidOperationException();
             Dictionary<string, ProjectManagerFactory.ConstructProjectManager> overrideDict = ProjectManagerFactory.GetDefaultManagers(httpClientFactory);
 
-            overrideDict[NuGetProjectManager.Type] = directory =>
-                new NuGetProjectManager(directory, packageActions, httpClientFactory);
+            overrideDict[NuGetProjectManager.Type] = (destinationDirectory, timeout) =>
+                new NuGetProjectManager(destinationDirectory, packageActions, httpClientFactory);
             
             FindPackageSquats findPackageSquats = new(new ProjectManagerFactory(overrideDict), requests);
 

--- a/src/oss-tests/ProjectManagerTests/CondaProjectManagerTests.cs
+++ b/src/oss-tests/ProjectManagerTests/CondaProjectManagerTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CST.OpenSource.Tests.ProjectManagerTests
             Mock<IHttpClientFactory> mockFactory = new();
             _httpFactory = mockFactory.Object;
 
-            _projectManager = new Mock<CondaProjectManager>(".", new NoOpPackageActions(), _httpFactory) { CallBase = true };
+            _projectManager = new Mock<CondaProjectManager>(".", new NoOpPackageActions(), _httpFactory, null) { CallBase = true };
         }
 
         [DataTestMethod]

--- a/src/oss-tests/ProjectManagerTests/GolangProjectManagerTests.cs
+++ b/src/oss-tests/ProjectManagerTests/GolangProjectManagerTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CST.OpenSource.Tests.ProjectManagerTests
             mockFactory.Setup(_ => _.CreateClient(It.IsAny<string>())).Returns(mockHttp.ToHttpClient());
             _httpFactory = mockFactory.Object;
 
-            _projectManager = new Mock<GolangProjectManager>(".", new NoOpPackageActions(), _httpFactory) { CallBase = true };
+            _projectManager = new Mock<GolangProjectManager>(".", new NoOpPackageActions(), _httpFactory, null) { CallBase = true };
         }
 
         [DataTestMethod]

--- a/src/oss-tests/ProjectManagerTests/MavenProjectManagerTests.cs
+++ b/src/oss-tests/ProjectManagerTests/MavenProjectManagerTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CST.OpenSource.Tests.ProjectManagerTests
             mockFactory.Setup(_ => _.CreateClient(It.IsAny<string>())).Returns(mockHttp.ToHttpClient());
             _httpFactory = mockFactory.Object;
 
-            _projectManager = new Mock<MavenProjectManager>(".", new NoOpPackageActions(), _httpFactory) { CallBase = true };
+            _projectManager = new Mock<MavenProjectManager>(".", new NoOpPackageActions(), _httpFactory, null) { CallBase = true };
         }
 
         [DataTestMethod]

--- a/src/oss-tests/ProjectManagerTests/NPMProjectManagerTests.cs
+++ b/src/oss-tests/ProjectManagerTests/NPMProjectManagerTests.cs
@@ -127,7 +127,7 @@ namespace Microsoft.CST.OpenSource.Tests.ProjectManagerTests
             mockFactory.Setup(_ => _.CreateClient(It.IsAny<string>())).Returns(mockHttp.ToHttpClient());
             _httpFactory = mockFactory.Object;
 
-            _projectManager = new Mock<NPMProjectManager>(".", new NoOpPackageActions(), _httpFactory) { CallBase = true };
+            _projectManager = new Mock<NPMProjectManager>(".", new NoOpPackageActions(), _httpFactory, null) { CallBase = true };
         }
 
         [DataTestMethod]
@@ -290,6 +290,8 @@ namespace Microsoft.CST.OpenSource.Tests.ProjectManagerTests
         public async Task PackageVersionPulledAsync(string purlString, bool expectedPulled = true)
         {
             PackageURL purl = new(purlString);
+
+            var project = _projectManager;
             
             string? content = await _projectManager.Object.GetMetadataAsync(purl);
 

--- a/src/oss-tests/ProjectManagerTests/ProjectManagerFactoryTests.cs
+++ b/src/oss-tests/ProjectManagerTests/ProjectManagerFactoryTests.cs
@@ -53,7 +53,7 @@ public class ProjectManagerFactoryTests
 
         AssertFactoryCreatesCorrect(projectManagerFactory);
     }
-    
+
     /// <summary>
     /// Test adding a new manager to the dictionary, not overriding an existing one.
     /// </summary>
@@ -66,7 +66,7 @@ public class ProjectManagerFactoryTests
 
         AssertFactoryCreatesCorrect(projectManagerFactory);
     }
-    
+
     /// <summary>
     /// Test overriding the nuget and npm entries as well as their destination directories in the dictionary.
     /// </summary>
@@ -85,11 +85,11 @@ public class ProjectManagerFactoryTests
         // Assert that the overrides worked by checking the TopLevelExtractionDirectory was changed.
         IBaseProjectManager? nuGetProjectManager = projectManagerFactory.CreateProjectManager(new PackageURL("pkg:nuget/foo"));
         Assert.AreEqual("nugetTestDirectory", nuGetProjectManager?.TopLevelExtractionDirectory);
-        
+
         IBaseProjectManager? npmProjectManager = projectManagerFactory.CreateProjectManager(new PackageURL("pkg:npm/foo"));
         Assert.AreEqual("npmTestDirectory", npmProjectManager?.TopLevelExtractionDirectory);
     }
-    
+
     /// <summary>
     /// Test changing an entry in the dictionary of constructors to construct a manager of a different type.
     /// </summary>
@@ -97,12 +97,12 @@ public class ProjectManagerFactoryTests
     public void ChangeProjectManagerSucceeds()
     {
         _managerOverrides[NuGetProjectManager.Type] = (destinationDirectory, timeout) => new NPMProjectManager(destinationDirectory, null, _httpClientFactory); // Override the default entry for nuget and set it as another NPMProjectManager.
-        
+
         ProjectManagerFactory projectManagerFactory = new(_managerOverrides);
 
         AssertFactoryCreatesCorrect(projectManagerFactory);
     }
-    
+
     /// <summary>
     /// Test removing an entry from the default dictionary of project manager constructors.
     /// </summary>
@@ -112,11 +112,11 @@ public class ProjectManagerFactoryTests
         Assert.IsTrue(_managerOverrides.Remove(NuGetProjectManager.Type));
 
         ProjectManagerFactory projectManagerFactory = new(_managerOverrides);
-        
+
         PackageURL packageUrl = new("pkg:nuget/foo");
         Assert.IsNull(projectManagerFactory.CreateProjectManager(packageUrl));
     }
-    
+
     /// <summary>
     /// Test removing all project managers from the dictionary of project manager constructors.
     /// </summary>
@@ -127,14 +127,34 @@ public class ProjectManagerFactoryTests
         _managerOverrides.Clear();
 
         ProjectManagerFactory projectManagerFactory = new(_managerOverrides);
-        
+
         AssertFactoryCreatesCorrect(projectManagerFactory);
-        
+
         foreach (PackageURL packageUrl in ProjectManagerFactory.GetDefaultManagers(_httpClientFactory).Keys
                      .Select(purlType => new PackageURL($"pkg:{purlType}/foo")))
         {
             Assert.IsNull(projectManagerFactory.CreateProjectManager(packageUrl));
         }
+    }
+
+    /// <summary>
+    /// Test that timeout is set if a value is passed.
+    /// </summary>
+    [TestMethod]
+    public void CreateProjectManagerSetsTimeOutCorrectly()
+    {
+        // Arrange
+        ProjectManagerFactory projectManagerFactory = new();
+        TimeSpan testTimeout = TimeSpan.FromMilliseconds(100);
+        PackageURL testPackageUrl = new("pkg:npm/foo");
+
+        // Act
+        IBaseProjectManager? testProjectManager = projectManagerFactory.CreateProjectManager(testPackageUrl, ".", testTimeout);
+        IBaseProjectManager? testProjectManagerWithoutTimeout = projectManagerFactory.CreateProjectManager(testPackageUrl, ".");
+
+        // Assert
+        Assert.AreEqual(testTimeout, testProjectManager?.Timeout);
+        Assert.IsNull(testProjectManagerWithoutTimeout?.Timeout);
     }
 
     /// <summary>

--- a/src/oss-tests/ProjectManagerTests/ProjectManagerFactoryTests.cs
+++ b/src/oss-tests/ProjectManagerTests/ProjectManagerFactoryTests.cs
@@ -60,7 +60,7 @@ public class ProjectManagerFactoryTests
     [TestMethod]
     public void AddTestManagerSucceeds()
     {
-        _managerOverrides["test"] = directory => new NuGetProjectManager(directory, null, _httpClientFactory); // Create a test type with the NuGetProjectManager.
+        _managerOverrides["test"] = (destinationDirectory, timeout) => new NuGetProjectManager(destinationDirectory, null, _httpClientFactory); // Create a test type with the NuGetProjectManager.
 
         ProjectManagerFactory projectManagerFactory = new(_managerOverrides);
 
@@ -74,9 +74,9 @@ public class ProjectManagerFactoryTests
     public void OverrideManagerSucceeds()
     {
         _managerOverrides[NuGetProjectManager.Type] =
-            _ => new NuGetProjectManager("nugetTestDirectory", null, _httpClientFactory); // Override the default entry for nuget, and override the destinationDirectory.
+            (destinationDirectory, timeout) => new NuGetProjectManager("nugetTestDirectory", null, _httpClientFactory); // Override the default entry for nuget, and override the destinationDirectory.
         _managerOverrides[NPMProjectManager.Type] =
-            _ => new NPMProjectManager("npmTestDirectory", null, _httpClientFactory); // Override the default entry for npm, and override the destinationDirectory.
+            (destinationDirectory, timeout) => new NPMProjectManager("npmTestDirectory", null, _httpClientFactory); // Override the default entry for npm, and override the destinationDirectory.
 
         ProjectManagerFactory projectManagerFactory = new(_managerOverrides);
 
@@ -96,7 +96,7 @@ public class ProjectManagerFactoryTests
     [TestMethod]
     public void ChangeProjectManagerSucceeds()
     {
-        _managerOverrides[NuGetProjectManager.Type] = directory => new NPMProjectManager(directory, null, _httpClientFactory); // Override the default entry for nuget and set it as another NPMProjectManager.
+        _managerOverrides[NuGetProjectManager.Type] = (destinationDirectory, timeout) => new NPMProjectManager(destinationDirectory, null, _httpClientFactory); // Override the default entry for nuget and set it as another NPMProjectManager.
         
         ProjectManagerFactory projectManagerFactory = new(_managerOverrides);
 


### PR DESCRIPTION
On a previous incident occurring due to a disruption in npmjs.org, there were very long response times (~60s) that ultimately came back with 503 responses. This impacted Terrapin's latencies and availability. This change allows users to specify timeouts when they use OSSGadget's project managers when they call `CreateProjectManager`