### PR TITLE
Add changes to support upstream to maven google repo

### DIFF
--- a/src/Shared/Model/Enums/MavenSupportedUpstream.cs
+++ b/src/Shared/Model/Enums/MavenSupportedUpstream.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.CST.OpenSource.Model.Enums;
+
+/// <summary>
+/// Maven upstream repositories supported by Terrapin.
+/// </summary>
+public enum MavenSupportedUpstream
+{
+    /// <summary>
+    /// https://repo1.maven.org/maven2
+    /// </summary>
+    MavenCentralRepository = 0,
+
+    /// <summary>
+    /// https://dl.google.com/android/maven2
+    /// </summary>
+    GoogleMavenRepository,
+}
+
+/// <summary>
+/// Extension methods for <see cref="MavenSupportedUpstream"/>.
+/// </summary>
+public static class MavenSupportedUpstreamExtensions
+{
+    /// <summary>
+    /// Gets the registry URI for the maven upstream repository.
+    /// </summary>
+    /// <param name="mavenUpstream">The <see cref="MavenSupportedUpstream"/>.</param>
+    public static string GetRepositoryUrl(this MavenSupportedUpstream mavenUpstream) => mavenUpstream switch
+    {
+        MavenSupportedUpstream.MavenCentralRepository => "https://repo1.maven.org/maven2",
+        MavenSupportedUpstream.GoogleMavenRepository => "https://maven.google.com/web/index.html#",
+        _ => throw new ArgumentOutOfRangeException(nameof(mavenUpstream), mavenUpstream, null),
+    };
+
+    /// <summary>
+    /// Returns the <see cref="MavenSupportedUpstream"/> associated with a given string.
+    /// </summary>
+    /// <param name="mavenUpstream"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentOutOfRangeException"></exception>
+    public static MavenSupportedUpstream GetMavenSupportedUpstream(this string mavenUpstream) => mavenUpstream switch
+    {
+        "MavenCentralRepository" => MavenSupportedUpstream.MavenCentralRepository,
+        "https://repo1.maven.org/maven2" => MavenSupportedUpstream.MavenCentralRepository,
+        "GoogleMavenRepository" => MavenSupportedUpstream.GoogleMavenRepository,
+        "https://dl.google.com/android/maven2" => MavenSupportedUpstream.GoogleMavenRepository,
+        _ => throw new ArgumentOutOfRangeException(nameof(mavenUpstream), mavenUpstream, null),
+    };
+}

--- a/src/Shared/PackageManagers/MavenProjectManager.cs
+++ b/src/Shared/PackageManagers/MavenProjectManager.cs
@@ -4,17 +4,22 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 {
     using AngleSharp.Html.Parser;
     using Helpers;
+    using Microsoft.CodeAnalysis.Sarif;
     using Microsoft.CST.OpenSource.Contracts;
     using Microsoft.CST.OpenSource.Extensions;
     using Microsoft.CST.OpenSource.Model;
+    using Microsoft.CST.OpenSource.Model.Enums;
     using Microsoft.CST.OpenSource.PackageActions;
+    using Newtonsoft.Json;
     using PackageUrl;
+    using PuppeteerSharp;
     using System;
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
     using System.Net;
     using System.Net.Http;
+    using System.Text.RegularExpressions;
     using System.Threading.Tasks;
 
     public class MavenProjectManager : TypedManager<IManagerPackageVersionMetadata, MavenProjectManager.MavenArtifactType>
@@ -27,8 +32,8 @@ namespace Microsoft.CST.OpenSource.PackageManagers
 
         public override string ManagerType => Type;
 
-        public const string DEFAULT_MAVEN_ENDPOINT = "https://repo1.maven.org/maven2";
-        public string ENV_MAVEN_ENDPOINT { get; set; } = DEFAULT_MAVEN_ENDPOINT;
+        public const MavenSupportedUpstream DEFAULT_MAVEN_ENDPOINT = MavenSupportedUpstream.MavenCentralRepository;
+        public MavenSupportedUpstream ENV_MAVEN_ENDPOINT { get; set; } = DEFAULT_MAVEN_ENDPOINT;
 
         public MavenProjectManager(
             string directory,
@@ -42,27 +47,58 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         /// <inheritdoc />
         public override async IAsyncEnumerable<ArtifactUri<MavenArtifactType>> GetArtifactDownloadUrisAsync(PackageURL purl, bool useCache = true)
         {
-            string? packageNamespace = Check.NotNull(nameof(purl.Namespace), purl?.Namespace).Replace('.', '/');
             string? packageName = Check.NotNull(nameof(purl.Name), purl?.Name);
             string? packageVersion = Check.NotNull(nameof(purl.Version), purl?.Version);
-            string feedUrl = (purl?.Qualifiers?["repository_url"] ?? ENV_MAVEN_ENDPOINT).EnsureTrailingSlash();
+            string feedUrl = purl?.Qualifiers?["repository_url"] ?? ENV_MAVEN_ENDPOINT.GetRepositoryUrl();
+            MavenSupportedUpstream upstream = feedUrl.GetMavenSupportedUpstream();
 
-            HttpClient httpClient = CreateHttpClient();
-            string baseUrl = $"{feedUrl}{packageNamespace}/{packageName}/{packageVersion}/";
-            string? html = await GetHttpStringCache(httpClient, baseUrl, useCache);
-            if (string.IsNullOrEmpty(html))
+            if (upstream == MavenSupportedUpstream.MavenCentralRepository)
             {
-                throw new InvalidOperationException();
+                string? packageNamespace = Check.NotNull(nameof(purl.Namespace), purl?.Namespace).Replace('.', '/');
+                var baseUrl = $"{upstream.GetRepositoryUrl().EnsureTrailingSlash()}{packageNamespace}/{packageName}/{packageVersion}/";
+
+                HttpClient httpClient = CreateHttpClient();
+                string? html = await GetHttpStringCache(httpClient, baseUrl, useCache);
+                if (string.IsNullOrEmpty(html))
+                {
+                    throw new InvalidOperationException();
+                }
+
+                HtmlParser parser = new();
+                AngleSharp.Html.Dom.IHtmlDocument document = await parser.ParseDocumentAsync(html);
+
+                foreach (string fileName in document.QuerySelectorAll("a").Select(link => link.GetAttribute("href").ToString()))
+                {
+                    if (fileName == "../") continue;
+
+                    MavenArtifactType artifactType = GetMavenArtifactType(fileName);
+                    yield return new ArtifactUri<MavenArtifactType>(artifactType, baseUrl + fileName);
+                }
             }
-
-            HtmlParser parser = new();
-            AngleSharp.Html.Dom.IHtmlDocument document = await parser.ParseDocumentAsync(html);
-            foreach (string fileName in document.QuerySelectorAll("a").Select(link => link.GetAttribute("href").ToString()))
+            else if (upstream == MavenSupportedUpstream.GoogleMavenRepository)
             {
-                if (fileName == "../") continue;
+                string packageNamespace = purl.Namespace;
+                var packageVersionUrl = $"{upstream.GetRepositoryUrl()}{packageNamespace}:{packageName}:{purl.Version}";
 
-                MavenArtifactType artifactType = GetMavenArtifactType(fileName);
-                yield return new ArtifactUri<MavenArtifactType>(artifactType, baseUrl + fileName);
+                // Google Maven Repository's webpage has dynamic content
+                var browserFetcher = new BrowserFetcher();
+                await browserFetcher.DownloadAsync();
+                var browser = await Puppeteer.LaunchAsync(new LaunchOptions { HeadlessMode = HeadlessMode.True });
+                var page = await browser.NewPageAsync();
+                await page.GoToAsync(packageVersionUrl, WaitUntilNavigation.DOMContentLoaded);
+
+                await page.WaitForSelectorAsync("tr");
+                var trElement = await page.XPathAsync("//tr[td[contains(text(), 'Artifact(s)')]]");
+                var anchors = await trElement.ElementAt(0).QuerySelectorAllAsync("a");
+
+                foreach (var anchor in anchors)
+                {
+                    var hrefValue = await (await anchor.GetPropertyAsync("href")).JsonValueAsync<string>();
+                    MavenArtifactType artifactType = GetMavenArtifactType(hrefValue);
+                    yield return new ArtifactUri<MavenArtifactType>(artifactType, hrefValue);
+                }
+
+                await browser.CloseAsync();
             }
         }
 
@@ -90,12 +126,12 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             if (string.IsNullOrWhiteSpace(packageNamespace) || string.IsNullOrWhiteSpace(packageName) ||
                 string.IsNullOrWhiteSpace(packageVersion))
             {
-                Logger.Warn("Unable to download [{0} {1} {2}]. Both must be defined.", packageNamespace, packageName, packageVersion);
+                Logger.Warn("Unable to download [{0} {1} {2}]. All must be defined.", packageNamespace, packageName, packageVersion);
                 return downloadedPaths;
             }
 
             IEnumerable<ArtifactUri<MavenArtifactType>> artifacts = (await GetArtifactDownloadUrisAsync(purl, useCache: cached).ToListAsync())
-                .Where(artifact => artifact.Type is MavenArtifactType.Jar or MavenArtifactType.SourcesJar or MavenArtifactType.JavadocJar);
+                .Where(artifact => artifact.Type is MavenArtifactType.Jar or MavenArtifactType.SourcesJar or MavenArtifactType.JavadocJar or MavenArtifactType.Aar);
             foreach (ArtifactUri<MavenArtifactType> artifact in artifacts)
             {
                 try
@@ -142,12 +178,25 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                 Logger.Trace("Provided PackageURL was null.");
                 return false;
             }
-            string packageNamespace = purl.Namespace.Replace('.', '/');
             string packageName = purl.Name;
-            string feedUrl = (purl?.Qualifiers?["repository_url"] ?? ENV_MAVEN_ENDPOINT).EnsureTrailingSlash();
+            string feedUrl = purl?.Qualifiers?["repository_url"] ?? ENV_MAVEN_ENDPOINT.GetRepositoryUrl();
+            MavenSupportedUpstream upstream = feedUrl.GetMavenSupportedUpstream();
+
             HttpClient httpClient = CreateHttpClient();
 
-            return await CheckHttpCacheForPackage(httpClient, $"{feedUrl}{packageNamespace}/{packageName}/maven-metadata.xml", useCache);
+            string packageRepositoryCheckUri = string.Empty;
+            if (upstream == MavenSupportedUpstream.MavenCentralRepository)
+            {
+                string packageNamespace = purl.Namespace.Replace('.', '/');
+                packageRepositoryCheckUri = $"{upstream.GetRepositoryUrl().EnsureTrailingSlash()}{packageNamespace}/{packageName}/maven-metadata.xml";
+            }
+            else if (upstream == MavenSupportedUpstream.GoogleMavenRepository)
+            {
+                string packageNamespace = purl.Namespace;
+                packageRepositoryCheckUri = $"{upstream.GetRepositoryUrl()}{packageNamespace}:{packageName}";
+            }
+
+            return await CheckHttpCacheForPackage(httpClient, packageRepositoryCheckUri, useCache);
         }
 
         /// <inheritdoc />
@@ -160,35 +209,77 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             }
             try
             {
-                string packageNamespace = purl.Namespace.Replace('.', '/');
                 string packageName = purl.Name;
-                string feedUrl = (purl?.Qualifiers?["repository_url"] ?? ENV_MAVEN_ENDPOINT).EnsureTrailingSlash();
+                string feedUrl = purl?.Qualifiers?["repository_url"] ?? ENV_MAVEN_ENDPOINT.GetRepositoryUrl();
+                MavenSupportedUpstream upstream = feedUrl.GetMavenSupportedUpstream();
+
                 HttpClient httpClient = CreateHttpClient();
 
-                string? content = await GetHttpStringCache(httpClient, $"{feedUrl}{packageNamespace}/{packageName}/", useCache);
+                string baseUrl = string.Empty;
+                if (upstream == MavenSupportedUpstream.MavenCentralRepository)
+                {
+                    string packageNamespace = purl.Namespace.Replace('.', '/');
+                    baseUrl = $"{upstream.GetRepositoryUrl().EnsureTrailingSlash()}{packageNamespace}/{packageName}/";
+                }
+                else if (upstream == MavenSupportedUpstream.GoogleMavenRepository)
+                {
+                    string packageNamespace = purl.Namespace;
+                    baseUrl = $"{upstream.GetRepositoryUrl()}{packageNamespace}:{packageName}";
+                }
+
+                string? content = await GetHttpStringCache(httpClient, baseUrl, useCache);
+
                 List<string> versionList = new();
                 if (string.IsNullOrWhiteSpace(content))
                 {
                     return new List<string>();
                 }
-                
-                // Parse the html file.
-                HtmlParser parser = new();
-                AngleSharp.Html.Dom.IHtmlDocument document = await parser.ParseDocumentAsync(content);
-                
-                // Break the version content down into its individual lines. Includes the parent directory and xml + hash files.
-                IEnumerable<string> htmlEntries = document.QuerySelector("#contents").QuerySelectorAll("a").Select(a => a.TextContent);
 
-                foreach (string htmlEntry in htmlEntries)
+                if (upstream == MavenSupportedUpstream.MavenCentralRepository)
                 {
-                    // Get the version.
-                    if (htmlEntry.EndsWith('/') && !htmlEntry.Equals("../"))
+                    // Parse the html file.
+                    HtmlParser parser = new();
+                    AngleSharp.Html.Dom.IHtmlDocument document = await parser.ParseDocumentAsync(content);
+
+                    // Break the version content down into its individual lines. Includes the parent directory and xml + hash files.
+                    IEnumerable<string> htmlEntries = document.QuerySelector("#contents").QuerySelectorAll("a").Select(a => a.TextContent);
+
+                    foreach (string htmlEntry in htmlEntries)
                     {
-                        var versionStr = htmlEntry.TrimEnd(htmlEntry[^1]);
+                        // Get the version.
+                        if (htmlEntry.EndsWith('/') && !htmlEntry.Equals("../"))
+                        {
+                            var versionStr = htmlEntry.TrimEnd(htmlEntry[^1]);
+                            Logger.Debug("Identified {0} version {1}.", packageName, versionStr);
+                            versionList.Add(versionStr);
+                        }
+                    }
+                }
+                else if (upstream == MavenSupportedUpstream.GoogleMavenRepository)
+                {
+                    // Google Maven Repository's webpage has dynamic content
+                    var browserFetcher = new BrowserFetcher();
+                    await browserFetcher.DownloadAsync();
+                    var browser = await Puppeteer.LaunchAsync(new LaunchOptions { HeadlessMode = HeadlessMode.True });
+                    var page = await browser.NewPageAsync();
+                    await page.GoToAsync(baseUrl, WaitUntilNavigation.DOMContentLoaded);
+
+                    await page.WaitForSelectorAsync(".artifact-child-item");
+                    var htmlEntries = await page.QuerySelectorAllAsync(".artifact-child-item");
+
+                    // Get the version.
+                    foreach (var htmlEntry in htmlEntries)
+                    {
+                        var span = await htmlEntry.QuerySelectorAsync("span");
+                        var versionStr = await (await span.GetPropertyAsync("textContent")).JsonValueAsync<string>();
                         Logger.Debug("Identified {0} version {1}.", packageName, versionStr);
                         versionList.Add(versionStr);
                     }
+
+                    await browser.CloseAsync();
+                    return versionList.Distinct();
                 }
+
                 return SortVersions(versionList.Distinct());
             }
             catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
@@ -213,12 +304,25 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             }
             try
             {
-                string packageNamespace = purl.Namespace.Replace('.', '/');
                 string packageName = purl.Name;
-                string feedUrl = (purl?.Qualifiers?["repository_url"] ?? ENV_MAVEN_ENDPOINT).EnsureTrailingSlash();
+                string feedUrl = purl?.Qualifiers?["repository_url"] ?? ENV_MAVEN_ENDPOINT.GetRepositoryUrl();
+                MavenSupportedUpstream upstream = feedUrl.GetMavenSupportedUpstream();
+
                 HttpClient httpClient = CreateHttpClient();
 
-                string? content = await GetHttpStringCache(httpClient, $"{feedUrl}{packageNamespace}/{packageName}/{purl.Version}/", useCache);
+                string packageRepositoryCheckUri = string.Empty;
+                if (upstream == MavenSupportedUpstream.MavenCentralRepository)
+                {
+                    string packageNamespace = purl.Namespace.Replace('.', '/');
+                    packageRepositoryCheckUri = $"{upstream.GetRepositoryUrl().EnsureTrailingSlash()}{packageNamespace}/{packageName}/{purl.Version}/";
+                }
+                else if (upstream == MavenSupportedUpstream.GoogleMavenRepository)
+                {
+                    string packageNamespace = purl.Namespace;
+                    packageRepositoryCheckUri = $"{upstream.GetRepositoryUrl()}{packageNamespace}:{packageName}:{purl.Version}";
+                }
+
+                string? content = await GetHttpStringCache(httpClient, packageRepositoryCheckUri, useCache);
                 if (string.IsNullOrWhiteSpace(content))
                 {
                     return false;
@@ -243,23 +347,44 @@ namespace Microsoft.CST.OpenSource.PackageManagers
         {
             try
             {
-                string? packageNamespace = purl?.Namespace?.Replace('.', '/');
                 string? packageName = purl?.Name;
-                string feedUrl = (purl?.Qualifiers?["repository_url"] ?? ENV_MAVEN_ENDPOINT).EnsureTrailingSlash();
+                string feedUrl = purl?.Qualifiers?["repository_url"] ?? ENV_MAVEN_ENDPOINT.GetRepositoryUrl();
+                MavenSupportedUpstream upstream = feedUrl.GetMavenSupportedUpstream();
+
                 HttpClient httpClient = CreateHttpClient();
+
+                string version;
                 if (purl?.Version == null)
                 {
-                    foreach (string? version in await EnumerateVersionsAsync(purl, useCache))
+                    // if no version is specified, use the earliest version available
+                    var versions = await EnumerateVersionsAsync(purl, useCache);
+                    if (!versions.Any())
                     {
-                        return await GetHttpStringCache(httpClient, $"{feedUrl}{packageNamespace}/{packageName}/{version}/{packageName}-{version}.pom", useCache);
+                        throw new Exception("No version specified and unable to enumerate.");
                     }
-                    throw new Exception("No version specified and unable to enumerate.");
+
+                    version = versions.ElementAt(0);
                 }
                 else
                 {
-                    string version = purl.Version;
-                    return await GetHttpStringCache(httpClient, $"{feedUrl}{packageNamespace}/{packageName}/{version}/{packageName}-{version}.pom", useCache);
+                    version = purl.Version;
                 }
+
+                if (upstream == MavenSupportedUpstream.MavenCentralRepository)
+                {
+                    string? packageNamespace = purl?.Namespace?.Replace('.', '/');
+                    return await GetHttpStringCache(httpClient, $"{upstream.GetRepositoryUrl().EnsureTrailingSlash()}{packageNamespace}/{packageName}/{version}/{packageName}-{version}.pom", useCache);
+                }
+                else if (upstream == MavenSupportedUpstream.GoogleMavenRepository)
+                {
+                    string packageNamespace = purl.Namespace;
+                    var packageVersionUrl = $"{upstream.GetRepositoryUrl()}{packageNamespace}:{packageName}:{version}";
+
+                    var metadata = await GoogleMavenRepositoryMetadataParserHelperAsync(packageVersionUrl);
+                    return JsonConvert.SerializeObject(metadata);
+                }
+
+                throw new Exception($"Unable to obtain metadata for {purl}.");
             }
             catch (Exception ex)
             {
@@ -276,7 +401,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             PackageMetadata metadata = new();
             metadata.Name = purl.GetFullName();
             metadata.PackageVersion = purl?.Version;
-            metadata.PackageManagerUri = (purl?.Qualifiers?["repository_url"] ?? ENV_MAVEN_ENDPOINT).EnsureTrailingSlash();
+            metadata.PackageManagerUri = (purl?.Qualifiers?["repository_url"] ?? ENV_MAVEN_ENDPOINT.GetRepositoryUrl()).EnsureTrailingSlash();
             metadata.Platform = "Maven";
             metadata.Language = "Java";
 
@@ -285,14 +410,92 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             return metadata;
         }
 
-        public override Uri GetPackageAbsoluteUri(PackageURL purl)
+        public override Uri? GetPackageAbsoluteUri(PackageURL purl)
         {
-            string? packageNamespace = purl?.Namespace?.Replace('.', '/');
             string? packageName = purl?.Name;
-            string feedUrl = (purl?.Qualifiers?["repository_url"] ?? ENV_MAVEN_ENDPOINT).EnsureTrailingSlash();
+            string feedUrl = purl?.Qualifiers?["repository_url"] ?? ENV_MAVEN_ENDPOINT.GetRepositoryUrl();
+            MavenSupportedUpstream upstream = feedUrl.GetMavenSupportedUpstream();
 
-            return new Uri($"{feedUrl}{packageNamespace}/{packageName}");
+            if (upstream == MavenSupportedUpstream.MavenCentralRepository)
+            {
+                string? packageNamespace = purl?.Namespace?.Replace('.', '/');
+                return new Uri($"{upstream.GetRepositoryUrl().EnsureTrailingSlash()}{packageNamespace}/{packageName}");
+            }
+            else if (upstream == MavenSupportedUpstream.GoogleMavenRepository)
+            {
+                string packageNamespace = purl.Namespace;
+                return new Uri($"{upstream.GetRepositoryUrl()}{packageNamespace}/{packageName}");
+            }
+
+            Logger.Warn($"Unable to get package absolute URI for {purl}.");
+            return null;
         }
+
+        internal async Task<Dictionary<string,string>> GoogleMavenRepositoryMetadataParserHelperAsync(string url)
+        {
+            var metadata = new Dictionary<string,string>();
+            
+            // Google Maven Repository's webpage has dynamic content. Scrape available metadata on the webpage.
+            var browserFetcher = new BrowserFetcher();
+            await browserFetcher.DownloadAsync();
+            var browser = await Puppeteer.LaunchAsync(new LaunchOptions { HeadlessMode = HeadlessMode.True });
+            var page = await browser.NewPageAsync();
+            await page.GoToAsync(url, WaitUntilNavigation.DOMContentLoaded);
+
+            await page.WaitForSelectorAsync("tr");
+            var fields = await page.QuerySelectorAllAsync("tr");
+
+            foreach (var field in fields)
+            {
+                var tds = await field.QuerySelectorAllAsync("td");
+
+                string key = string.Empty;
+                string value = string.Empty;
+                foreach (var td in tds)
+                {
+                    var className = await page.EvaluateFunctionAsync<string>("el => el.className", td);
+                    if (className.Contains("gav-pom-key"))
+                    {
+                        key = await(await td.GetPropertyAsync("textContent")).JsonValueAsync<string>();
+                    }
+                    else
+                    {
+                        // only include link- or text-based metadata
+                        var datas = (await td.QuerySelectorAllAsync("a")).IsEmptyEnumerable() ? await td.QuerySelectorAllAsync("span") :
+                            await td.QuerySelectorAllAsync("a");
+
+                        foreach (var data in datas)
+                        {
+                            if (data != null)
+                            {
+                                var rawValue = await(await data.GetPropertyAsync("textContent") ?? await data.GetPropertyAsync("href"))
+                                    .JsonValueAsync<string>();
+
+                                // format: remove newlines and excessive spaces and punctuation
+                                rawValue = Regex.Replace(rawValue, @"\s{2,}", "");
+                                rawValue = Regex.Replace(rawValue, @"\r\n|,", "");
+                                rawValue = Regex.Replace(rawValue, @"\r\n|\n", "");
+
+                                // append available artifact types as comma-separated string
+                                if (value == string.Empty)
+                                {
+                                    value = rawValue;
+                                }
+                                else
+                                {
+                                    value += $", {rawValue}";
+                                }
+                            }
+                        }
+                    }
+                }
+                metadata.Add(key, value);
+            }
+
+            await browser.CloseAsync();
+            return metadata;
+        }
+
 
         public enum MavenArtifactType
         {
@@ -303,6 +506,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             SourcesJar,
             TestsJar,
             TestSourcesJar,
+            Aar,
         }
 
         private static MavenArtifactType GetMavenArtifactType(string fileName)
@@ -315,48 +519,80 @@ namespace Microsoft.CST.OpenSource.PackageManagers
                 case string _ when fileName.EndsWith(".pom"): return MavenArtifactType.Pom;
                 case string _ when fileName.EndsWith("-javadoc.jar"): return MavenArtifactType.JavadocJar;
                 case string _ when fileName.EndsWith(".jar"): return MavenArtifactType.Jar;
+                case string _ when fileName.EndsWith(".aar"): return MavenArtifactType.Aar;
                 default: return MavenArtifactType.Unknown;
             }
         }
 
-        private async Task<DateTime?> GetPackagePublishDateAsync(PackageURL purl, bool useCache = true)
+        public async Task<DateTime?> GetPackagePublishDateAsync(PackageURL purl, bool useCache = true)
         {
-            string? packageNamespace = Check.NotNull(nameof(purl.Namespace), purl?.Namespace).Replace('.', '/');
             string? packageName = Check.NotNull(nameof(purl.Name), purl?.Name);
             string? packageVersion = Check.NotNull(nameof(purl.Version), purl?.Version);
-            string feedUrl = (purl?.Qualifiers?["repository_url"] ?? ENV_MAVEN_ENDPOINT).EnsureTrailingSlash();
+            string feedUrl = purl?.Qualifiers?["repository_url"] ?? ENV_MAVEN_ENDPOINT.GetRepositoryUrl();
+            MavenSupportedUpstream upstream = feedUrl.GetMavenSupportedUpstream();
 
             HttpClient httpClient = CreateHttpClient();
-            string baseUrl = $"{feedUrl}{packageNamespace}/{packageName}/";
-            string? html = await GetHttpStringCache(httpClient, baseUrl, useCache);
-            if (string.IsNullOrEmpty(html))
+
+            if (upstream == MavenSupportedUpstream.MavenCentralRepository)
             {
-                throw new InvalidOperationException();
+                string? packageNamespace = Check.NotNull(nameof(purl.Namespace), purl?.Namespace).Replace('.', '/');
+                var baseUrl = $"{upstream.GetRepositoryUrl().EnsureTrailingSlash()}{packageNamespace}/{packageName}/";
+
+                string? html = await GetHttpStringCache(httpClient, baseUrl, useCache);
+                if (string.IsNullOrEmpty(html))
+                {
+                    throw new InvalidOperationException();
+                }
+
+                HtmlParser parser = new();
+                AngleSharp.Html.Dom.IHtmlDocument document = await parser.ParseDocumentAsync(html);
+
+                // Break the version content down into its individual lines, and then find the one that represents the
+                // intended version.
+                string? versionContent = document.QuerySelector("#contents").TextContent
+                    .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+                    .SingleOrDefault(versionText => versionText.StartsWith($"{packageVersion}/"));
+
+                if (versionContent == null)
+                {
+                    return null;
+                }
+
+                // Split the version content into its individual parts.
+                // [0] - The version
+                // [1] - The date it was published
+                // [2] - The time it waas published
+                // [3] - The download count
+                string[] versionParts = versionContent.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                if (DateTime.TryParse($"{versionParts[1]} {versionParts[2]}", out DateTime publishDateTime))
+                {
+                    return publishDateTime;
+                }
             }
-
-            HtmlParser parser = new();
-            AngleSharp.Html.Dom.IHtmlDocument document = await parser.ParseDocumentAsync(html);
-
-            // Break the version content down into its individual lines, and then find the one that represents the
-            // intended version.
-            string? versionContent = document.QuerySelector("#contents").TextContent
-                .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
-                .SingleOrDefault(versionText => versionText.StartsWith($"{packageVersion}/"));
-
-            if (versionContent == null)
+            else if (upstream == MavenSupportedUpstream.GoogleMavenRepository)
             {
-                return null;
-            }
+                string packageNamespace = purl.Namespace;
+                var packageVersionUrl = $"{upstream.GetRepositoryUrl()}{packageNamespace}:{packageName}:{packageVersion}";
 
-            // Split the version content into its individual parts.
-            // [0] - The version
-            // [1] - The date it was published
-            // [2] - The time it waas published
-            // [3] - The download count
-            string[] versionParts = versionContent.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-            if (DateTime.TryParse($"{versionParts[1]} {versionParts[2]}", out DateTime publishDateTime))
-            {
-                return publishDateTime;
+                // Google Maven Repository's webpage has dynamic content
+                var browserFetcher = new BrowserFetcher();
+                await browserFetcher.DownloadAsync();
+                var browser = await Puppeteer.LaunchAsync(new LaunchOptions { Headless = true });
+                var page = await browser.NewPageAsync();
+                await page.GoToAsync(packageVersionUrl);
+
+                // Google Maven Repository offers a "Last Updated Date", which will be considered as the publish timestamp.
+                await page.WaitForSelectorAsync("tr");
+                var trElement = await page.XPathAsync("//tr[td[contains(text(), 'Last Updated Date')]]");
+                var content = await trElement.ElementAt(0).QuerySelectorAsync("span");
+                var lastUpdatedDate = await content.EvaluateFunctionAsync<string>("el => el.textContent");
+
+                await browser.CloseAsync();
+
+                if (DateTime.TryParse($"{lastUpdatedDate}", out DateTime publishDateTime))
+                {
+                    return publishDateTime;
+                }
             }
 
             return null;

--- a/src/Shared/Shared.Lib.csproj
+++ b/src/Shared/Shared.Lib.csproj
@@ -47,6 +47,7 @@
         <PackageReference Include="Octokit" Version="13.0.1" />
         <PackageReference Include="packageurl-dotnet" Version="1.3.0" />
         <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
+        <PackageReference Include="PuppeteerSharp" Version="20.1.3" />
         <PackageReference Include="Sarif.Sdk" Version="4.5.4" />
         <PackageReference Include="SemanticVersioning" Version="2.0.2" />
         <PackageReference Include="System.Console" Version="4.3.1" />

--- a/src/oss-tests/ProjectManagerTests/MavenProjectManagerTests.cs
+++ b/src/oss-tests/ProjectManagerTests/MavenProjectManagerTests.cs
@@ -3,9 +3,9 @@
 namespace Microsoft.CST.OpenSource.Tests.ProjectManagerTests
 {
     using Microsoft.CST.OpenSource.Extensions;
+    using Microsoft.CST.OpenSource.Model.Enums;
     using Model;
     using Moq;
-    using Octokit;
     using oss;
     using PackageActions;
     using PackageManagers;
@@ -35,6 +35,10 @@ namespace Microsoft.CST.OpenSource.Tests.ProjectManagerTests
             { "https://repo1.maven.org/maven2/com/microsoft/fluentui/fluentui_listitem/", Resources.maven_microsoft_fluentui_listitem_all_html },
             { "https://repo1.maven.org/maven2/com/microsoft/fluentui/fluentui_listitem/maven-metadata.xml", Resources.maven_microsoft_fluentui_listitem_metadata_xml },
             { "https://repo1.maven.org/maven2/com/microsoft/fluentui/fluentui_listitem/0.0.8/fluentui_listitem-0.0.8.pom", Resources.maven_fluentui_listitem_0_0_8_pom },
+            { "https://maven.google.com/web/index.html#android.arch.core:core:1.0.0-alpha3", Resources.maven_core_1_0_0_alpha3_html },
+            { "https://maven.google.com/web/index.html#android.arch.core:core", Resources.maven_core_all_html },
+            { "https://maven.google.com/web/index.html#androidx.appcompat:appcompat:1.7.0-rc01", Resources.maven_appcompat_1_7_0_rc01_html },
+            { "https://maven.google.com/web/index.html#androidx.appcompat:appcompat", Resources.maven_appcompat_all_html },
         }.ToImmutableDictionary();
 
         public MavenProjectManagerTests()
@@ -55,27 +59,42 @@ namespace Microsoft.CST.OpenSource.Tests.ProjectManagerTests
         }
 
         [DataTestMethod]
-        [DataRow("pkg:maven/ant/ant@1.6?repository_url=https://repo1.maven.org/maven2", "https://repo1.maven.org/maven2/ant/ant/1.6/")]
-        public async Task GetArtifactDownloadUrisSucceeds_Async(string purlString, string expectedUriPrefix)
+        [DataRow("pkg:maven/ant/ant@1.6?repository_url=https://repo1.maven.org/maven2", MavenSupportedUpstream.MavenCentralRepository, "https://repo1.maven.org/maven2/ant/ant/1.6/")]
+        [DataRow("pkg:maven/android.arch.core/core@1.0.0-alpha3?repository_url=https://dl.google.com/android/maven2", MavenSupportedUpstream.GoogleMavenRepository, "https://dl.google.com/android/maven2/android/arch/core/core/1.0.0-alpha3/")]
+        [DataRow("pkg:maven/androidx.appcompat/appcompat@1.7.0-rc01?repository_url=https://dl.google.com/android/maven2", MavenSupportedUpstream.GoogleMavenRepository, "https://dl.google.com/android/maven2/androidx/appcompat/appcompat/1.7.0-rc01/")]
+        public async Task GetArtifactDownloadUrisSucceeds_Async(string purlString, MavenSupportedUpstream upstream, string expectedUriPrefix)
         {
             PackageURL purl = new(purlString);
             List<ArtifactUri<MavenProjectManager.MavenArtifactType>> uris = await _projectManager.Object.GetArtifactDownloadUrisAsync(purl).ToListAsync();
 
-            Assert.IsNotNull(uris.SingleOrDefault(artifact => artifact.Type == MavenProjectManager.MavenArtifactType.Jar
+            if (upstream == MavenSupportedUpstream.MavenCentralRepository)
+            {
+                Assert.IsNotNull(uris.SingleOrDefault(artifact => artifact.Type == MavenProjectManager.MavenArtifactType.Jar
                 && artifact.Uri == new System.Uri(expectedUriPrefix + $"{purl.Name}-{purl.Version}.jar")));
-            Assert.IsNotNull(uris.SingleOrDefault(artifact => artifact.Type == MavenProjectManager.MavenArtifactType.SourcesJar
-                && artifact.Uri == new System.Uri(expectedUriPrefix + $"{purl.Name}-{purl.Version}-sources.jar")));
-            Assert.IsNotNull(uris.SingleOrDefault(artifact => artifact.Type == MavenProjectManager.MavenArtifactType.Pom
-                && artifact.Uri == new System.Uri(expectedUriPrefix + $"{purl.Name}-{purl.Version}.pom")));
+                Assert.IsNotNull(uris.SingleOrDefault(artifact => artifact.Type == MavenProjectManager.MavenArtifactType.SourcesJar
+                    && artifact.Uri == new System.Uri(expectedUriPrefix + $"{purl.Name}-{purl.Version}-sources.jar")));
+                Assert.IsNotNull(uris.SingleOrDefault(artifact => artifact.Type == MavenProjectManager.MavenArtifactType.Pom
+                    && artifact.Uri == new System.Uri(expectedUriPrefix + $"{purl.Name}-{purl.Version}.pom")));
+            }
+            else if (upstream  == MavenSupportedUpstream.GoogleMavenRepository)
+            {
+                
+                Assert.IsNotNull(uris.SingleOrDefault(artifact => artifact.Type == MavenProjectManager.MavenArtifactType.Aar
+                    && artifact.Uri == new System.Uri(expectedUriPrefix + $"{purl.Name}-{purl.Version}.aar")));
+                Assert.IsNotNull(uris.SingleOrDefault(artifact => artifact.Type == MavenProjectManager.MavenArtifactType.Pom
+                    && artifact.Uri == new System.Uri(expectedUriPrefix + $"{purl.Name}-{purl.Version}.pom")));
+            }
         }
 
         [DataTestMethod]
         [DataRow("pkg:maven/ant/ant@1.6?repository_url=https://repo1.maven.org/maven2")] // Normal package
+        [DataRow("pkg:maven/android.arch.core/core@1.0.0-alpha3?repository_url=https://dl.google.com/android/maven2")]
+        [DataRow("pkg:maven/androidx.appcompat/appcompat@1.7.0-rc01?repository_url=https://dl.google.com/android/maven2")]
         public async Task MetadataSucceeds(string purlString)
         {
             PackageURL purl = new(purlString);
             PackageMetadata? metadata = await _projectManager.Object.GetPackageMetadataAsync(purl, useCache: false);
-
+            
             Assert.IsNotNull(metadata);
             Assert.AreEqual(purl.GetFullName(), metadata.Name);
             Assert.AreEqual(purl.Version, metadata.PackageVersion);
@@ -85,6 +104,8 @@ namespace Microsoft.CST.OpenSource.Tests.ProjectManagerTests
         [DataTestMethod]
         [DataRow("pkg:maven/ant/ant@1.6", 13, "1.7.0")]
         [DataRow("pkg:maven/com.microsoft.fluentui/fluentui_listitem@0.0.8", 21, "0.1.6")]
+        [DataRow("pkg:maven/android.arch.core/core@1.0.0-alpha3?repository_url=https://dl.google.com/android/maven2", 3, "1.0.0-alpha3")]
+        [DataRow("pkg:maven/androidx.appcompat/appcompat@1.7.0-rc01?repository_url=https://dl.google.com/android/maven2", 56, "1.7.0")]
         public async Task EnumerateVersionsSucceeds(string purlString, int count, string latestVersion)
         {
             PackageURL purl = new(purlString);
@@ -97,11 +118,59 @@ namespace Microsoft.CST.OpenSource.Tests.ProjectManagerTests
         [DataTestMethod]
         [DataRow("pkg:maven/ant/ant@1.6")]
         [DataRow("pkg:maven/com.microsoft.fluentui/fluentui_listitem@0.0.8")]
+        [DataRow("pkg:maven/android.arch.core/core@1.0.0-alpha3?repository_url=https://dl.google.com/android/maven2")]
+        [DataRow("pkg:maven/androidx.appcompat/appcompat@1.7.0-rc01?repository_url=https://dl.google.com/android/maven2")]
         public async Task PackageVersionExistsAsyncSucceeds(string purlString)
         {
             PackageURL purl = new(purlString);
 
             Assert.IsTrue(await _projectManager.Object.PackageVersionExistsAsync(purl, useCache: false));
+        }
+
+        [DataTestMethod]
+        [DataRow("https://maven.google.com/web/index.html#android.arch.core:core:1.0.0-alpha3")]
+        [DataRow("https://maven.google.com/web/index.html#androidx.appcompat:appcompat:1.7.0-rc01")]
+        public async Task GoogleMavenRepositoryMetadataParserSucceeds(string url)
+        {
+            var metadata = await _projectManager.Object.GoogleMavenRepositoryMetadataParserHelperAsync(url);
+
+            if (url.Contains("android.arch.core"))
+            {
+                var expectedResult = new Dictionary<string, string>
+                {
+                    { "Project", "https://developer.android.com/topic/libraries/architecture/index.html" },
+                    { "Artifact(s)", "aar, pom" },
+                    { "Developer(s)", "The Android Open Source Project" },
+                    { "License(s)", "The Apache Software License Version 2.0" },
+                    { "Group ID", "android.arch.core" },
+                    { "Artifact ID", "core" },
+                    { "Version", "1.0.0-alpha3" },
+                    { "Gradle Groovy DSL", "" },
+                    { "Gradle Kotlin DSL", "" },
+                    { "Last Updated Date", "9/20/2019" }
+                };
+                CollectionAssert.AreEquivalent(metadata, expectedResult);
+            }
+            else if (url.Contains("androidx.appcompat"))
+            {
+                var expectedResult = new Dictionary<string, string>
+                {
+                    { "Name", "AppCompat" },
+                    { "Description", "Provides backwards-compatible implementations of UI-related Android SDK functionality including dark mode and Material theming." },
+                    { "Project", "https://developer.android.com/jetpack/androidx/releases/appcompat#1.7.0-rc01" },
+                    { "Artifact(s)", "source, gpg (source), appcompat-1.7.0-rc01-versionMetadata.json, gpg (appcompat-1.7.0-rc01-versionMetadata.json), aar, gpg (aar), gradle-module-metadata, gpg (gradle-module-metadata), pom, gpg (appcompat-1.7.0-rc01.pom)" },
+                    { "Developer(s)", "The Android Open Source Project" },
+                    { "License(s)", "The Apache Software License Version 2.0" },
+                    { "Group ID", "androidx.appcompat" },
+                    { "Artifact ID", "appcompat" },
+                    { "Version", "1.7.0-rc01" },
+                    { "Gradle Groovy DSL", "" },
+                    { "Gradle Kotlin DSL", "" },
+                    { "Last Updated Date", "5/14/2024" },
+                    { "Organization", "The Android Open Source Project" }
+                };
+                CollectionAssert.AreEquivalent(metadata, expectedResult);
+            }
         }
 
         private static void MockHttpFetchResponse(

--- a/src/oss-tests/Properties/Resources.Designer.cs
+++ b/src/oss-tests/Properties/Resources.Designer.cs
@@ -10,8 +10,8 @@
 
 namespace oss {
     using System;
-    
-    
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -309,6 +309,84 @@ namespace oss {
         internal static string maven_ant_metadata_xml {
             get {
                 return ResourceManager.GetString("maven_ant_metadata_xml", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;!DOCTYPE html&gt;
+        ///&lt;html lang=&quot;en&quot;&gt;
+        ///&lt;head&gt;
+        ///    &lt;style&gt;
+        ///        @charset &quot;UTF-8&quot;;
+        ///
+        ///        [ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak, .ng-hide:not(.ng-hide-animate) {
+        ///            display: none !important;
+        ///        }
+        ///
+        ///        ng\:form {
+        ///            display: block;
+        ///        }
+        ///
+        ///        .ng-animate-shim {
+        ///            visibility: hidden;
+        ///        }
+        ///
+        ///        .ng-anchor {
+        ///            position: absolute;
+        ///        }
+        ///    &lt;/style&gt;
+        ///    &lt;script nonce=&quot;&quot;&gt;
+        ///    if (window [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string maven_core_1_0_0_alpha3_html {
+            get {
+                return ResourceManager.GetString("maven_core_1.0.0_alpha3_html", resourceCulture);
+            }
+        }
+
+        internal static string maven_appcompat_1_7_0_rc01_html {
+            get {
+                return ResourceManager.GetString("maven_appcompat_1.7.0_rc01_html", resourceCulture);
+            }
+        }
+
+        internal static string maven_appcompat_all_html
+        {
+            get
+            {
+                return ResourceManager.GetString("maven_appcompat_all_html", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;!DOCTYPE html&gt;
+        ///&lt;html lang=&quot;en&quot;&gt;
+        ///&lt;head&gt;
+        ///    &lt;style&gt;
+        ///        @charset &quot;UTF-8&quot;;
+        ///
+        ///        [ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak, .ng-hide:not(.ng-hide-animate) {
+        ///            display: none !important;
+        ///        }
+        ///
+        ///        ng\:form {
+        ///            display: block;
+        ///        }
+        ///
+        ///        .ng-animate-shim {
+        ///            visibility: hidden;
+        ///        }
+        ///
+        ///        .ng-anchor {
+        ///            position: absolute;
+        ///        }
+        ///    &lt;/style&gt;
+        ///    &lt;script nonce=&quot;&quot;&gt;
+        ///        if (wi [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string maven_core_all_html {
+            get {
+                return ResourceManager.GetString("maven_core_all_html", resourceCulture);
             }
         }
         

--- a/src/oss-tests/Properties/Resources.resx
+++ b/src/oss-tests/Properties/Resources.resx
@@ -217,6 +217,18 @@
   <data name="maven_ant_1.6_pom" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\TestData\Maven\maven_ant_1.6.pom;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="maven_core_1.0.0_alpha3_html" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\TestData\Maven\maven_core_1.0.0_alpha3.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="maven_core_all_html" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\TestData\Maven\maven_core_all.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="maven_appcompat_1.7.0_rc01_html" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\TestData\Maven\maven_appcompat_1.7.0_rc01.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="maven_appcompat_all_html" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\TestData\Maven\maven_appcompat_all.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>   
   <data name="maven_microsoft_fluentui_listitem_0.0.8_html" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\TestData\Maven\maven_microsoft_fluentui_listitem_0.0.8.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>

--- a/src/oss-tests/TestData/Maven/maven_appcompat_1.7.0_rc01.html
+++ b/src/oss-tests/TestData/Maven/maven_appcompat_1.7.0_rc01.html
@@ -1,0 +1,3087 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <style>
+        @charset "UTF-8";
+
+        [ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak, .ng-hide:not(.ng-hide-animate) {
+            display: none !important;
+        }
+
+        ng\:form {
+            display: block;
+        }
+
+        .ng-animate-shim {
+            visibility: hidden;
+        }
+
+        .ng-anchor {
+            position: absolute;
+        }
+    </style>
+    <script nonce="">
+        if (window.location.search.substring(1) !== "full=true") { // do not redirect if querystring is ?full=true
+            if (navigator.userAgent.match(/i(Phone|Pad)|Android|Blackberry|WebOs/i)) { // detect mobile browser
+                window.location.replace("m_index.html"); // redirect if mobile browser detected
+            }
+        }
+    </script>
+
+    <title>Google's Maven Repository</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" type="image/x-icon" href="favicon.ico">
+    <!-- Stylesheets -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Material+Icons|Material+Icons+Outlined|Material+Icons+Two+Tone|Material+Icons+Round|Material+Icons+Sharp" nonce="">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:400,500|Roboto+Mono|Roboto:300,400,500,700" nonce="">
+    <link rel="stylesheet" href="css/common_styles.css" nonce="">
+    <link rel="stylesheet" href="css/styles.css" nonce="">
+    <!-- Scripts -->
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.8.0/angular.min.js" nonce=""></script>
+    <script src="js/gmaven-index.js" nonce=""></script>
+</head>
+
+<body ng-app="MavenIndex" ng-controller="MavenIndexController as index" class="ng-scope">
+    <div class="flex-container flex-column full-height">
+        <!-- Material Design App Bar -->
+        <header>
+            <div class="app-bar">
+                <div class="app-bar-title">Google's Maven Repository</div>
+                <!-- Search box for filtering the artifact tree -->
+                <div class="search-box-container">
+                    <div class="search-box flex-container">
+                        <label class="flex-item">
+                            <input class="search-box-input ng-pristine ng-valid ng-empty ng-touched" ng-model="searchTerm" ng-change="setFilter(searchTerm)" placeholder="Search for an artifact...">
+                        </label>
+                        <i class="search-box-icon material-icons ng-binding" ng-click="clearFilter()" ng-keypress="$event.which === 13 &amp;&amp; clearFilter()" ng-class="{'clickable-icon': searchTerm.length}" tabindex="0">
+                            search
+                        </i>
+                    </div>
+                </div>
+                <div class="app-bar-icon-container">
+                    <!-- ngIf: false -->
+                </div>
+            </div>
+            <div class="nav-bar">
+                <div class="nav-bar-bread-crumb" ng-click="clearFilter()">Home</div>
+                <!-- ngIf: selectedGroupNode --><i class="nav-bar-bread-crumb-divider material-icons ng-scope" ng-if="selectedGroupNode">arrow_forward_ios</i><!-- end ngIf: selectedGroupNode -->
+                <!-- ngIf: selectedGroupNode --><div class="nav-bar-bread-crumb-path-element ng-binding ng-scope" ng-if="selectedGroupNode" ng-click="selectedGroupNode.select()">
+                    androidx.appcompat
+                </div><!-- end ngIf: selectedGroupNode -->
+                <!-- ngIf: selectedArtifactNode --><i class="nav-bar-bread-crumb-divider material-icons ng-scope" ng-if="selectedArtifactNode">keyboard_arrow_right</i><!-- end ngIf: selectedArtifactNode -->
+                <!-- ngIf: selectedArtifactNode --><div class="nav-bar-bread-crumb-path-element ng-binding ng-scope" ng-if="selectedArtifactNode" ng-click="selectedArtifactNode.select()">
+                    appcompat
+                </div><!-- end ngIf: selectedArtifactNode -->
+                <!-- ngIf: selectedVersionNode --><i class="nav-bar-bread-crumb-divider material-icons ng-scope" ng-if="selectedVersionNode">keyboard_arrow_right</i><!-- end ngIf: selectedVersionNode -->
+                <!-- ngIf: selectedVersionNode --><div class="nav-bar-bread-crumb-path-element ng-binding ng-scope" ng-if="selectedVersionNode" ng-click="selectedVersionNode.select()">
+                    1.7.0-rc01
+                </div><!-- end ngIf: selectedVersionNode -->
+            </div>
+        </header>
+        <!-- Container for the overview/details content panels -->
+        <div class="flex-container flex-item min-height">
+            <!-- Details - Right hand content panel -->
+            <main class="flex-container flex-item main">
+                <div class="flex-item">
+                    <!-- Welcome message - only show when no selection in overview tree exists -->
+                    <!-- ngIf: !selectedNode -->
+                    <!-- Artifact details - show all the different artifact versions (children) when an artifact is selected -->
+                    <!-- ngIf: selectedNode.subnode && selectedNode.subnode.length -->
+                    <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                    <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                    <!-- ngRepeat: child in selectedNode.subnode -->
+                    <!-- Version details - show the POM file information for the selected group-artifact-version coordinate -->
+                    <!-- ngIf: selectedNode && selectedNode.model --><div ng-if="selectedNode &amp;&amp; selectedNode.model" class="ng-scope">
+                        <div class="content-header ng-binding">
+                            androidx.appcompat:appcompat:1.7.0-rc01
+                        </div><table class="gav-pom-table">
+                            <thead>
+
+                            </thead>
+                            <tbody>
+                                <!-- ngRepeat: item in selectedNode.model -->
+                                <tr ng-repeat="item in selectedNode.model" class="ng-scope">
+                                    <td class="gav-pom-key ng-binding">Name</td>
+                                    <td ng-switch="item.type" class="gav-pom-value">
+                                        <!-- ngSwitchWhen: text --><span ng-switch-when="text" class="ng-binding ng-scope">AppCompat</span><!-- end ngSwitchWhen: -->
+                                        <!-- ngSwitchWhen: link -->
+                                        <!-- ngSwitchWhen: artifacts -->
+                                        <!-- ngSwitchWhen: code -->
+                                    </td>
+                                </tr><!-- end ngRepeat: item in selectedNode.model -->
+                                <tr ng-repeat="item in selectedNode.model" class="ng-scope">
+                                    <td class="gav-pom-key ng-binding">Description</td>
+                                    <td ng-switch="item.type" class="gav-pom-value">
+                                        <!-- ngSwitchWhen: text --><span ng-switch-when="text" class="ng-binding ng-scope">Provides backwards-compatible implementations of UI-related Android SDK functionality, including dark mode and Material theming.</span><!-- end ngSwitchWhen: -->
+                                        <!-- ngSwitchWhen: link -->
+                                        <!-- ngSwitchWhen: artifacts -->
+                                        <!-- ngSwitchWhen: code -->
+                                    </td>
+                                </tr><!-- end ngRepeat: item in selectedNode.model -->
+                                <tr ng-repeat="item in selectedNode.model" class="ng-scope">
+                                    <td class="gav-pom-key ng-binding">Project</td>
+                                    <td ng-switch="item.type" class="gav-pom-value">
+                                        <!-- ngSwitchWhen: text -->
+                                        <!-- ngSwitchWhen: link --><a ng-switch-when="link" href="https://developer.android.com/jetpack/androidx/releases/appcompat#1.7.0-rc01" target="_blank" class="ng-binding ng-scope">
+                                            https://developer.android.com/jetpack/androidx/releases/appcompat#1.7.0-rc01
+                                        </a><!-- end ngSwitchWhen: -->
+                                        <!-- ngSwitchWhen: artifacts -->
+                                        <!-- ngSwitchWhen: code -->
+                                    </td>
+                                </tr><!-- end ngRepeat: item in selectedNode.model -->
+                                <tr ng-repeat="item in selectedNode.model" class="ng-scope">
+                                    <td class="gav-pom-key ng-binding">Artifact(s)</td>
+                                    <td ng-switch="item.type" class="gav-pom-value">
+                                        <!-- ngSwitchWhen: text -->
+                                        <!-- ngSwitchWhen: link -->
+                                        <!-- ngSwitchWhen: artifacts --><!-- ngRepeat: artifact in item.value --><span ng-switch-when="artifacts" ng-repeat="artifact in item.value" class="ng-scope">
+                                            <a href="https://dl.google.com/android/maven2/androidx/appcompat/appcompat/1.7.0-rc01/appcompat-1.7.0-rc01-sources.jar" class="ng-binding">source</a><!-- ngIf: !$last --><span ng-if="!$last" class="ng-scope">,&nbsp;</span><!-- end ngIf: !$last -->
+                                        </span><!-- end ngRepeat: artifact in item.value --><span ng-switch-when="artifacts" ng-repeat="artifact in item.value" class="ng-scope">
+                                            <a href="https://dl.google.com/android/maven2/androidx/appcompat/appcompat/1.7.0-rc01/appcompat-1.7.0-rc01-sources.jar.asc" class="ng-binding">gpg (source)</a><!-- ngIf: !$last --><span ng-if="!$last" class="ng-scope">,&nbsp;</span><!-- end ngIf: !$last -->
+                                        </span><!-- end ngRepeat: artifact in item.value --><span ng-switch-when="artifacts" ng-repeat="artifact in item.value" class="ng-scope">
+                                            <a href="https://dl.google.com/android/maven2/androidx/appcompat/appcompat/1.7.0-rc01/appcompat-1.7.0-rc01-versionMetadata.json" class="ng-binding">appcompat-1.7.0-rc01-versionMetadata.json</a><!-- ngIf: !$last --><span ng-if="!$last" class="ng-scope">,&nbsp;</span><!-- end ngIf: !$last -->
+                                        </span><!-- end ngRepeat: artifact in item.value --><span ng-switch-when="artifacts" ng-repeat="artifact in item.value" class="ng-scope">
+                                            <a href="https://dl.google.com/android/maven2/androidx/appcompat/appcompat/1.7.0-rc01/appcompat-1.7.0-rc01-versionMetadata.json.asc" class="ng-binding">gpg (appcompat-1.7.0-rc01-versionMetadata.json)</a><!-- ngIf: !$last --><span ng-if="!$last" class="ng-scope">,&nbsp;</span><!-- end ngIf: !$last -->
+                                        </span><!-- end ngRepeat: artifact in item.value --><span ng-switch-when="artifacts" ng-repeat="artifact in item.value" class="ng-scope">
+                                            <a href="https://dl.google.com/android/maven2/androidx/appcompat/appcompat/1.7.0-rc01/appcompat-1.7.0-rc01.aar" class="ng-binding">aar</a><!-- ngIf: !$last --><span ng-if="!$last" class="ng-scope">,&nbsp;</span><!-- end ngIf: !$last -->
+                                        </span><!-- end ngRepeat: artifact in item.value --><span ng-switch-when="artifacts" ng-repeat="artifact in item.value" class="ng-scope">
+                                            <a href="https://dl.google.com/android/maven2/androidx/appcompat/appcompat/1.7.0-rc01/appcompat-1.7.0-rc01.aar.asc" class="ng-binding">gpg (aar)</a><!-- ngIf: !$last --><span ng-if="!$last" class="ng-scope">,&nbsp;</span><!-- end ngIf: !$last -->
+                                        </span><!-- end ngRepeat: artifact in item.value --><span ng-switch-when="artifacts" ng-repeat="artifact in item.value" class="ng-scope">
+                                            <a href="https://dl.google.com/android/maven2/androidx/appcompat/appcompat/1.7.0-rc01/appcompat-1.7.0-rc01.module" class="ng-binding">gradle-module-metadata</a><!-- ngIf: !$last --><span ng-if="!$last" class="ng-scope">,&nbsp;</span><!-- end ngIf: !$last -->
+                                        </span><!-- end ngRepeat: artifact in item.value --><span ng-switch-when="artifacts" ng-repeat="artifact in item.value" class="ng-scope">
+                                            <a href="https://dl.google.com/android/maven2/androidx/appcompat/appcompat/1.7.0-rc01/appcompat-1.7.0-rc01.module.asc" class="ng-binding">gpg (gradle-module-metadata)</a><!-- ngIf: !$last --><span ng-if="!$last" class="ng-scope">,&nbsp;</span><!-- end ngIf: !$last -->
+                                        </span><!-- end ngRepeat: artifact in item.value --><span ng-switch-when="artifacts" ng-repeat="artifact in item.value" class="ng-scope">
+                                            <a href="https://dl.google.com/android/maven2/androidx/appcompat/appcompat/1.7.0-rc01/appcompat-1.7.0-rc01.pom" class="ng-binding">pom</a><!-- ngIf: !$last --><span ng-if="!$last" class="ng-scope">,&nbsp;</span><!-- end ngIf: !$last -->
+                                        </span><!-- end ngRepeat: artifact in item.value --><span ng-switch-when="artifacts" ng-repeat="artifact in item.value" class="ng-scope">
+                                            <a href="https://dl.google.com/android/maven2/androidx/appcompat/appcompat/1.7.0-rc01/appcompat-1.7.0-rc01.pom.asc" class="ng-binding">gpg (appcompat-1.7.0-rc01.pom)</a><!-- ngIf: !$last -->
+                                        </span><!-- end ngRepeat: artifact in item.value --><!-- end ngSwitchWhen: -->
+                                        <!-- ngSwitchWhen: code -->
+                                    </td>
+                                </tr><!-- end ngRepeat: item in selectedNode.model -->
+                                <tr ng-repeat="item in selectedNode.model" class="ng-scope">
+                                    <td class="gav-pom-key ng-binding">Developer(s)</td>
+                                    <td ng-switch="item.type" class="gav-pom-value">
+                                        <!-- ngSwitchWhen: text --><span ng-switch-when="text" class="ng-binding ng-scope">The Android Open Source Project</span><!-- end ngSwitchWhen: -->
+                                        <!-- ngSwitchWhen: link -->
+                                        <!-- ngSwitchWhen: artifacts -->
+                                        <!-- ngSwitchWhen: code -->
+                                    </td>
+                                </tr><!-- end ngRepeat: item in selectedNode.model -->
+                                <tr ng-repeat="item in selectedNode.model" class="ng-scope">
+                                    <td class="gav-pom-key ng-binding">License(s)</td>
+                                    <td ng-switch="item.type" class="gav-pom-value">
+                                        <!-- ngSwitchWhen: text -->
+                                        <!-- ngSwitchWhen: link --><a ng-switch-when="link" href="http://www.apache.org/licenses/LICENSE-2.0.txt" target="_blank" class="ng-binding ng-scope">
+                                            The Apache Software License, Version 2.0
+                                        </a><!-- end ngSwitchWhen: -->
+                                        <!-- ngSwitchWhen: artifacts -->
+                                        <!-- ngSwitchWhen: code -->
+                                    </td>
+                                </tr><!-- end ngRepeat: item in selectedNode.model -->
+                                <tr ng-repeat="item in selectedNode.model" class="ng-scope">
+                                    <td class="gav-pom-key ng-binding">Group ID</td>
+                                    <td ng-switch="item.type" class="gav-pom-value">
+                                        <!-- ngSwitchWhen: text --><span ng-switch-when="text" class="ng-binding ng-scope">androidx.appcompat</span><!-- end ngSwitchWhen: -->
+                                        <!-- ngSwitchWhen: link -->
+                                        <!-- ngSwitchWhen: artifacts -->
+                                        <!-- ngSwitchWhen: code -->
+                                    </td>
+                                </tr><!-- end ngRepeat: item in selectedNode.model -->
+                                <tr ng-repeat="item in selectedNode.model" class="ng-scope">
+                                    <td class="gav-pom-key ng-binding">Artifact ID</td>
+                                    <td ng-switch="item.type" class="gav-pom-value">
+                                        <!-- ngSwitchWhen: text --><span ng-switch-when="text" class="ng-binding ng-scope">appcompat</span><!-- end ngSwitchWhen: -->
+                                        <!-- ngSwitchWhen: link -->
+                                        <!-- ngSwitchWhen: artifacts -->
+                                        <!-- ngSwitchWhen: code -->
+                                    </td>
+                                </tr><!-- end ngRepeat: item in selectedNode.model -->
+                                <tr ng-repeat="item in selectedNode.model" class="ng-scope">
+                                    <td class="gav-pom-key ng-binding">Version</td>
+                                    <td ng-switch="item.type" class="gav-pom-value">
+                                        <!-- ngSwitchWhen: text --><span ng-switch-when="text" class="ng-binding ng-scope">1.7.0-rc01</span><!-- end ngSwitchWhen: -->
+                                        <!-- ngSwitchWhen: link -->
+                                        <!-- ngSwitchWhen: artifacts -->
+                                        <!-- ngSwitchWhen: code -->
+                                    </td>
+                                </tr><!-- end ngRepeat: item in selectedNode.model -->
+                                <tr ng-repeat="item in selectedNode.model" class="ng-scope">
+                                    <td class="gav-pom-key ng-binding">Gradle Groovy DSL</td>
+                                    <td ng-switch="item.type" class="gav-pom-value">
+                                        <!-- ngSwitchWhen: text -->
+                                        <!-- ngSwitchWhen: link -->
+                                        <!-- ngSwitchWhen: artifacts -->
+                                        <!-- ngSwitchWhen: code --><div ng-switch-when="code" class="gav-pom-value-copyable ng-scope" title="Click to copy" ng-click="copyTextToClipboard(item.id)">
+                                            <div id="groovy-dsl" class="ng-binding">implementation 'androidx.appcompat:appcompat:1.7.0-rc01'</div>
+                                            <i class="material-icons small-icon">content_copy</i>
+                                        </div><!-- end ngSwitchWhen: -->
+                                    </td>
+                                </tr><!-- end ngRepeat: item in selectedNode.model -->
+                                <tr ng-repeat="item in selectedNode.model" class="ng-scope">
+                                    <td class="gav-pom-key ng-binding">Gradle Kotlin DSL</td>
+                                    <td ng-switch="item.type" class="gav-pom-value">
+                                        <!-- ngSwitchWhen: text -->
+                                        <!-- ngSwitchWhen: link -->
+                                        <!-- ngSwitchWhen: artifacts -->
+                                        <!-- ngSwitchWhen: code --><div ng-switch-when="code" class="gav-pom-value-copyable ng-scope" title="Click to copy" ng-click="copyTextToClipboard(item.id)">
+                                            <div id="kotlin-dsl" class="ng-binding">implementation("androidx.appcompat:appcompat:1.7.0-rc01")</div>
+                                            <i class="material-icons small-icon">content_copy</i>
+                                        </div><!-- end ngSwitchWhen: -->
+                                    </td>
+                                </tr><!-- end ngRepeat: item in selectedNode.model -->
+                                <tr ng-repeat="item in selectedNode.model" class="ng-scope">
+                                    <td class="gav-pom-key ng-binding">Last Updated Date</td>
+                                    <td ng-switch="item.type" class="gav-pom-value">
+                                        <!-- ngSwitchWhen: text --><span ng-switch-when="text" class="ng-binding ng-scope">5/14/2024</span><!-- end ngSwitchWhen: -->
+                                        <!-- ngSwitchWhen: link -->
+                                        <!-- ngSwitchWhen: artifacts -->
+                                        <!-- ngSwitchWhen: code -->
+                                    </td>
+                                </tr><!-- end ngRepeat: item in selectedNode.model -->
+                                <tr ng-repeat="item in selectedNode.model" class="ng-scope">
+                                    <td class="gav-pom-key ng-binding">Organization</td>
+                                    <td ng-switch="item.type" class="gav-pom-value">
+                                        <!-- ngSwitchWhen: text -->
+                                        <!-- ngSwitchWhen: link --><a ng-switch-when="link" target="_blank" class="ng-binding ng-scope">
+                                            The Android Open Source Project
+                                        </a><!-- end ngSwitchWhen: -->
+                                        <!-- ngSwitchWhen: artifacts -->
+                                        <!-- ngSwitchWhen: code -->
+                                    </td>
+                                </tr><!-- end ngRepeat: item in selectedNode.model -->
+                            </tbody>
+                        </table>
+                    </div><!-- end ngIf: selectedNode && selectedNode.model -->
+                </div>
+            </main>
+            <!-- Overview - Left hand navigation panel -->
+            <aside class="flex-column sidebar sidebar-left">
+                <!-- Group-Artifact-Version tree container -->
+                <div class="tree-container">
+                    <!-- ngIf: allHidden || displayTree.length==0 -->
+                    <!-- Group list -->
+                    <!-- ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child expand" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">android.arch.core</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded --><div style="margin-left:20px" ng-if="group.expanded" class="ng-scope">
+                            <!-- Artifact list -->
+                            <!-- ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">common</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child expand" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">core</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded --><div style="margin-left:28px" ng-if="artifact.expanded" class="ng-scope">
+
+                                    <!-- Versions list -->
+                                    <!-- ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha3
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha2
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha1
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode -->
+                                </div><!-- end ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">core-testing</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">runtime</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode -->
+                        </div><!-- end ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">android.arch.lifecycle</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">android.arch.navigation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">android.arch.paging</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">android.arch.persistence</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">android.arch.persistence.room</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">android.arch.work</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.activity</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.ads</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.annotation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child expand" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.appcompat</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded --><div style="margin-left:20px" ng-if="group.expanded" class="ng-scope">
+                            <!-- Artifact list -->
+                            <!-- ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child expand" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">appcompat</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded --><div style="margin-left:28px" ng-if="artifact.expanded" class="ng-scope">
+
+                                    <!-- Versions list -->
+                                    <!-- ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.7.0
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem selected" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding selected" ng-class="{'selected': version.selected}">
+                                                1.7.0-rc01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.7.0-beta01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.7.0-alpha03
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.7.0-alpha02
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.7.0-alpha01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.6.1
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.6.0
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.6.0-rc01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.6.0-beta01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.6.0-alpha05
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.6.0-alpha04
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.6.0-alpha03
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.6.0-alpha01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.5.1
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.5.0
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.5.0-rc01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.5.0-beta01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.5.0-alpha01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.4.2
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.4.1
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.4.0
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.4.0-rc01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.4.0-beta01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.4.0-alpha03
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.4.0-alpha02
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.4.0-alpha01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.3.1
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.3.0
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.3.0-rc01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.3.0-beta01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.3.0-alpha02
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.3.0-alpha01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.2.0
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.2.0-rc02
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.2.0-rc01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.2.0-beta01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.2.0-alpha03
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.2.0-alpha02
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.2.0-alpha01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.1.0
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.1.0-rc01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.1.0-beta01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.1.0-alpha05
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.1.0-alpha04
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.1.0-alpha03
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.1.0-alpha02
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.1.0-alpha01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.2
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.1
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-rc02
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-rc01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-beta01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha3
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha1
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode -->
+                                </div><!-- end ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">appcompat-resources</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode -->
+                        </div><!-- end ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.appsearch</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.arch.core</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.asynclayoutinflater</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.autofill</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.baselineprofile</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.baselineprofile.apptarget</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.baselineprofile.consumer</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.baselineprofile.producer</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.benchmark</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.biometric</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.bluetooth</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.browser</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.camera</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.camera.media3</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.camera.viewfinder</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.car</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.car.app</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.cardview</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.collection</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.compose</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.compose.animation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.compose.compiler</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.compose.foundation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.compose.material</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.compose.material3</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.compose.material3.adaptive</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.compose.runtime</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.compose.ui</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.concurrent</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.constraintlayout</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.contentpager</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.coordinatorlayout</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.core</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.core.uwb</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.credentials</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.credentials.registry</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.cursoradapter</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.customview</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.databinding</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.datastore</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.documentfile</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.draganddrop</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.drawerlayout</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.dynamicanimation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.emoji</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.emoji2</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.enterprise</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.exifinterface</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.fragment</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.games</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.gaming</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.glance</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.gradle</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.graphics</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.gridlayout</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.health</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.health.connect</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.heifwriter</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.hilt</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.ink</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.input</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.interpolator</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.javascriptengine</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.leanback</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.legacy</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.lifecycle</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.lint</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.loader</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.localbroadcastmanager</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.media</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.media2</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.media3</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.mediarouter</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.metrics</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.multidex</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.navigation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.navigation.safeargs</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.navigation.safeargs.kotlin</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.paging</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.palette</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.pdf</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.percentlayout</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.performance</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.preference</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.print</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.privacysandbox.activity</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.privacysandbox.ads</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.privacysandbox.library</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.privacysandbox.plugins</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.privacysandbox.sdkruntime</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.privacysandbox.tools</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.privacysandbox.ui</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.profileinstaller</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.recommendation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.recyclerview</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.remotecallback</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.resourceinspection</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.room</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.savedstate</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.security</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.sharetarget</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.slice</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.slidingpanelayout</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.sqlite</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.startup</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.swiperefreshlayout</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.test</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.test.espresso</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.test.espresso.idling</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.test.ext</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.test.janktesthelper</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.test.services</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.test.uiautomator</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.textclassifier</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.tracing</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.transition</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.tv</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.tvprovider</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.ui</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.vectordrawable</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.versionedparcelable</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.viewpager</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.viewpager2</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.wear</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.wear.compose</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.wear.protolayout</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.wear.tiles</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.wear.watchface</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.webkit</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.window</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.window.extensions.core</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.work</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.xr.arcore</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.xr.compose</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.xr.compose.material3</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.xr.runtime</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.xr.scenecore</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.ai-pack</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.application</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.art</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.asset-pack</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.asset-pack-bundle</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.billingclient</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.car.setupwizardlib</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.car.ui</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.compose.screenshot</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.databinding</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.designcompose</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.dynamic-feature</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.experimental.built-in-kotlin</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.fused-library</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.identity</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.installreferrer</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.internal.settings</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.java.tools.build</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.kotlin.multiplatform.library</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.legacy-kapt</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.library</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.lint</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.ndk.thirdparty</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.privacy-sandbox-sdk</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.reporting</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.security.autorepro</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.security.autorepro.apptest</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.security.autorepro.javahosttest</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.security.autorepro.ndktest</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.security.autorepro.submission</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.security.lint</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.settings</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.support</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.support.constraint</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.support.test</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.support.test.espresso</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.support.test.espresso.idling</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.support.test.janktesthelper</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.support.test.services</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.support.test.uiautomator</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.test</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.adblib</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.analytics-library</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.apkdeployer</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.apkparser</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.build</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.build.jetifier</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.chunkio</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.compose</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.ddms</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.emulator</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.external.com-intellij</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.external.org-jetbrains</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.fakeadbserver</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.internal.build.test</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.layoutlib</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.lint</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.metalava</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.pixelprobe</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.screenshot</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.smali</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.utp</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.volley</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.crashlytics.sdk.android</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ads.afsn</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ads.interactivemedia.v3</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ads.mediation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ai.client.generativeai</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ai.edge.aicore</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ai.edge.litert</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ai.edge.localagents</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ambient.crossdevice</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.ads</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.ads.consent</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.apps.common.testing.accessibility.framework</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.car.connectionservice</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.datatransport</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.engage</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.enterprise.connectedapps</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.exoplayer</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.fhir</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.flexbox</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.games</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.gms</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.gms.strict-version-matcher-plugin</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.instantapps</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.instantapps.thirdpartycompat</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.ads.mobile.sdk</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.car</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.cloud.telco.subgraph</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.enterprise.amapi</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.healthdata</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.identity.googleid</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.maps</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.mapsplatform.secrets-gradle-plugin</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.mapsplatform.transportation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.navigation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.places</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.play.games</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.sdkcoroutines</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.searchinapps</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.livesharing</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.material</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.mdoc</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.mediahome</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.meet</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.odml</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.play</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.recaptcha</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.support</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.things</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.tv</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.tv.tvpanelframework</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.ump</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.wearable</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.androidbrowserhelper</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ar</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ar.sceneform</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ar.sceneform.ux</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.assistant.appactions</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.assistant.suggestion</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.camerax.effects</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.chromeos</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.cose</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.d2c</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.devtools.ksp</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.fhir</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.firebase</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.firebase.appdistribution</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.firebase.crashlytics</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.firebase.firebase-perf</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.firebase.testlab</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.gms</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.gms.google-services</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.jacquard</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.mediapipe</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.mlkit</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.net.cronet</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.oboe</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.prefab</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.relay</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.test.platform</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.testing.platform</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">io.fabric.sdk.android</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">org.chromium.net</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">org.jetbrains.kotlin</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">org.multipaz</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">tools.base.build-system.debug</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">zipflinger</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree -->
+                </div>
+            </aside>
+        </div>
+        <!-- Bottom bar -->
+        <footer class="footer">
+            <div>
+                <span>Copyright <span class="material-icons" style="font-size: 8pt; vertical-align: baseline;">copyright</span> 2020 Google</span>
+            </div>
+        </footer>
+    </div>
+
+
+
+</body>
+</html>

--- a/src/oss-tests/TestData/Maven/maven_appcompat_all.html
+++ b/src/oss-tests/TestData/Maven/maven_appcompat_all.html
@@ -1,0 +1,3265 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <style>
+        @charset "UTF-8";
+
+        [ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak, .ng-hide:not(.ng-hide-animate) {
+            display: none !important;
+        }
+
+        ng\:form {
+            display: block;
+        }
+
+        .ng-animate-shim {
+            visibility: hidden;
+        }
+
+        .ng-anchor {
+            position: absolute;
+        }
+    </style>
+    <script nonce="">
+        if (window.location.search.substring(1) !== "full=true") { // do not redirect if querystring is ?full=true
+            if (navigator.userAgent.match(/i(Phone|Pad)|Android|Blackberry|WebOs/i)) { // detect mobile browser
+                window.location.replace("m_index.html"); // redirect if mobile browser detected
+            }
+        }
+    </script>
+
+    <title>Google's Maven Repository</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" type="image/x-icon" href="favicon.ico">
+    <!-- Stylesheets -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Material+Icons|Material+Icons+Outlined|Material+Icons+Two+Tone|Material+Icons+Round|Material+Icons+Sharp" nonce="">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:400,500|Roboto+Mono|Roboto:300,400,500,700" nonce="">
+    <link rel="stylesheet" href="css/common_styles.css" nonce="">
+    <link rel="stylesheet" href="css/styles.css" nonce="">
+    <!-- Scripts -->
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.8.0/angular.min.js" nonce=""></script>
+    <script src="js/gmaven-index.js" nonce=""></script>
+</head>
+
+<body ng-app="MavenIndex" ng-controller="MavenIndexController as index" class="ng-scope">
+    <div class="flex-container flex-column full-height">
+        <!-- Material Design App Bar -->
+        <header>
+            <div class="app-bar">
+                <div class="app-bar-title">Google's Maven Repository</div>
+                <!-- Search box for filtering the artifact tree -->
+                <div class="search-box-container">
+                    <div class="search-box flex-container">
+                        <label class="flex-item">
+                            <input class="search-box-input ng-pristine ng-valid ng-empty ng-touched" ng-model="searchTerm" ng-change="setFilter(searchTerm)" placeholder="Search for an artifact...">
+                        </label>
+                        <i class="search-box-icon material-icons ng-binding" ng-click="clearFilter()" ng-keypress="$event.which === 13 &amp;&amp; clearFilter()" ng-class="{'clickable-icon': searchTerm.length}" tabindex="0">
+                            search
+                        </i>
+                    </div>
+                </div>
+                <div class="app-bar-icon-container">
+                    <!-- ngIf: false -->
+                </div>
+            </div>
+            <div class="nav-bar">
+                <div class="nav-bar-bread-crumb" ng-click="clearFilter()">Home</div>
+                <!-- ngIf: selectedGroupNode --><i class="nav-bar-bread-crumb-divider material-icons ng-scope" ng-if="selectedGroupNode">arrow_forward_ios</i><!-- end ngIf: selectedGroupNode -->
+                <!-- ngIf: selectedGroupNode --><div class="nav-bar-bread-crumb-path-element ng-binding ng-scope" ng-if="selectedGroupNode" ng-click="selectedGroupNode.select()">
+                    androidx.appcompat
+                </div><!-- end ngIf: selectedGroupNode -->
+                <!-- ngIf: selectedArtifactNode --><i class="nav-bar-bread-crumb-divider material-icons ng-scope" ng-if="selectedArtifactNode">keyboard_arrow_right</i><!-- end ngIf: selectedArtifactNode -->
+                <!-- ngIf: selectedArtifactNode --><div class="nav-bar-bread-crumb-path-element ng-binding ng-scope" ng-if="selectedArtifactNode" ng-click="selectedArtifactNode.select()">
+                    appcompat
+                </div><!-- end ngIf: selectedArtifactNode -->
+                <!-- ngIf: selectedVersionNode -->
+                <!-- ngIf: selectedVersionNode -->
+            </div>
+        </header>
+        <!-- Container for the overview/details content panels -->
+        <div class="flex-container flex-item min-height">
+            <!-- Details - Right hand content panel -->
+            <main class="flex-container flex-item main">
+                <div class="flex-item">
+                    <!-- Welcome message - only show when no selection in overview tree exists -->
+                    <!-- ngIf: !selectedNode -->
+                    <!-- Artifact details - show all the different artifact versions (children) when an artifact is selected -->
+                    <!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div class="content-header ng-binding ng-scope" ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length">
+                        androidx.appcompat:appcompat
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length -->
+                    <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                    <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><div class="content-description ng-binding ng-scope" ng-if="selectedNode.constructor.name === 'ArtifactNode'">
+                        Versions (56)
+                    </div><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                    <!-- ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.7.0</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.7.0-rc01</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.7.0-beta01</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.7.0-alpha03</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.7.0-alpha02</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.7.0-alpha01</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.6.1</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.6.0</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.6.0-rc01</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.6.0-beta01</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.6.0-alpha05</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.6.0-alpha04</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.6.0-alpha03</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.6.0-alpha01</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.5.1</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.5.0</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.5.0-rc01</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.5.0-beta01</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.5.0-alpha01</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.4.2</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.4.1</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.4.0</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.4.0-rc01</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.4.0-beta01</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.4.0-alpha03</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.4.0-alpha02</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.4.0-alpha01</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.3.1</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.3.0</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.3.0-rc01</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.3.0-beta01</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.3.0-alpha02</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.3.0-alpha01</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.2.0</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.2.0-rc02</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.2.0-rc01</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.2.0-beta01</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.2.0-alpha03</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.2.0-alpha02</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.2.0-alpha01</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.1.0</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.1.0-rc01</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.1.0-beta01</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.1.0-alpha05</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.1.0-alpha04</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.1.0-alpha03</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.1.0-alpha02</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.1.0-alpha01</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.0.2</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.0.1</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.0.0</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.0.0-rc02</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.0.0-rc01</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.0.0-beta01</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.0.0-alpha3</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.0.0-alpha1</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode -->
+                    <!-- Version details - show the POM file information for the selected group-artifact-version coordinate -->
+                    <!-- ngIf: selectedNode && selectedNode.model -->
+                </div>
+            </main>
+            <!-- Overview - Left hand navigation panel -->
+            <aside class="flex-column sidebar sidebar-left">
+                <!-- Group-Artifact-Version tree container -->
+                <div class="tree-container">
+                    <!-- ngIf: allHidden || displayTree.length==0 -->
+                    <!-- Group list -->
+                    <!-- ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child expand" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">android.arch.core</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded --><div style="margin-left:20px" ng-if="group.expanded" class="ng-scope">
+                            <!-- Artifact list -->
+                            <!-- ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">common</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child expand" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">core</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded --><div style="margin-left:28px" ng-if="artifact.expanded" class="ng-scope">
+
+                                    <!-- Versions list -->
+                                    <!-- ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha3
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha2
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha1
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode -->
+                                </div><!-- end ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">core-testing</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">runtime</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode -->
+                        </div><!-- end ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">android.arch.lifecycle</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">android.arch.navigation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">android.arch.paging</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">android.arch.persistence</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">android.arch.persistence.room</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">android.arch.work</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.activity</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.ads</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.annotation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child expand" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.appcompat</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded --><div style="margin-left:20px" ng-if="group.expanded" class="ng-scope">
+                            <!-- Artifact list -->
+                            <!-- ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem selected" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child expand" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope selected" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">appcompat</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded --><div style="margin-left:28px" ng-if="artifact.expanded" class="ng-scope">
+
+                                    <!-- Versions list -->
+                                    <!-- ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.7.0
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.7.0-rc01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.7.0-beta01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.7.0-alpha03
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.7.0-alpha02
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.7.0-alpha01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.6.1
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.6.0
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.6.0-rc01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.6.0-beta01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.6.0-alpha05
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.6.0-alpha04
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.6.0-alpha03
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.6.0-alpha01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.5.1
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.5.0
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.5.0-rc01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.5.0-beta01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.5.0-alpha01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.4.2
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.4.1
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.4.0
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.4.0-rc01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.4.0-beta01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.4.0-alpha03
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.4.0-alpha02
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.4.0-alpha01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.3.1
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.3.0
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.3.0-rc01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.3.0-beta01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.3.0-alpha02
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.3.0-alpha01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.2.0
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.2.0-rc02
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.2.0-rc01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.2.0-beta01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.2.0-alpha03
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.2.0-alpha02
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.2.0-alpha01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.1.0
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.1.0-rc01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.1.0-beta01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.1.0-alpha05
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.1.0-alpha04
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.1.0-alpha03
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.1.0-alpha02
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.1.0-alpha01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.2
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.1
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-rc02
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-rc01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-beta01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha3
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha1
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode -->
+                                </div><!-- end ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">appcompat-resources</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode -->
+                        </div><!-- end ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.appsearch</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.arch.core</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.asynclayoutinflater</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.autofill</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.baselineprofile</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.baselineprofile.apptarget</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.baselineprofile.consumer</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.baselineprofile.producer</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.benchmark</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.biometric</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.bluetooth</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.browser</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.camera</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.camera.media3</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.camera.viewfinder</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.car</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.car.app</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.cardview</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.collection</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.compose</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.compose.animation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.compose.compiler</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.compose.foundation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.compose.material</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.compose.material3</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.compose.material3.adaptive</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.compose.runtime</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.compose.ui</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.concurrent</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.constraintlayout</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.contentpager</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.coordinatorlayout</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.core</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.core.uwb</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.credentials</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.credentials.registry</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.cursoradapter</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.customview</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.databinding</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.datastore</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.documentfile</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.draganddrop</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.drawerlayout</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.dynamicanimation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.emoji</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.emoji2</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.enterprise</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.exifinterface</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.fragment</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.games</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.gaming</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.glance</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.gradle</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.graphics</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.gridlayout</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.health</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.health.connect</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.heifwriter</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.hilt</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.ink</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.input</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.interpolator</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.javascriptengine</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.leanback</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.legacy</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.lifecycle</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.lint</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.loader</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.localbroadcastmanager</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.media</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.media2</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.media3</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.mediarouter</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.metrics</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.multidex</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.navigation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.navigation.safeargs</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.navigation.safeargs.kotlin</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.paging</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.palette</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.pdf</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.percentlayout</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.performance</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.preference</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.print</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.privacysandbox.activity</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.privacysandbox.ads</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.privacysandbox.library</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.privacysandbox.plugins</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.privacysandbox.sdkruntime</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.privacysandbox.tools</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.privacysandbox.ui</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.profileinstaller</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.recommendation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.recyclerview</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.remotecallback</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.resourceinspection</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.room</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.savedstate</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.security</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.sharetarget</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.slice</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.slidingpanelayout</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.sqlite</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.startup</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.swiperefreshlayout</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.test</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.test.espresso</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.test.espresso.idling</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.test.ext</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.test.janktesthelper</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.test.services</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.test.uiautomator</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.textclassifier</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.tracing</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.transition</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.tv</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.tvprovider</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.ui</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.vectordrawable</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.versionedparcelable</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.viewpager</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.viewpager2</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.wear</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.wear.compose</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.wear.protolayout</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.wear.tiles</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.wear.watchface</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.webkit</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.window</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.window.extensions.core</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.work</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.xr.arcore</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.xr.compose</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.xr.compose.material3</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.xr.runtime</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.xr.scenecore</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.ai-pack</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.application</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.art</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.asset-pack</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.asset-pack-bundle</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.billingclient</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.car.setupwizardlib</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.car.ui</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.compose.screenshot</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.databinding</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.designcompose</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.dynamic-feature</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.experimental.built-in-kotlin</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.fused-library</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.identity</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.installreferrer</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.internal.settings</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.java.tools.build</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.kotlin.multiplatform.library</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.legacy-kapt</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.library</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.lint</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.ndk.thirdparty</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.privacy-sandbox-sdk</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.reporting</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.security.autorepro</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.security.autorepro.apptest</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.security.autorepro.javahosttest</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.security.autorepro.ndktest</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.security.autorepro.submission</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.security.lint</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.settings</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.support</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.support.constraint</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.support.test</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.support.test.espresso</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.support.test.espresso.idling</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.support.test.janktesthelper</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.support.test.services</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.support.test.uiautomator</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.test</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.adblib</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.analytics-library</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.apkdeployer</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.apkparser</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.build</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.build.jetifier</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.chunkio</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.compose</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.ddms</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.emulator</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.external.com-intellij</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.external.org-jetbrains</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.fakeadbserver</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.internal.build.test</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.layoutlib</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.lint</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.metalava</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.pixelprobe</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.screenshot</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.smali</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.utp</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.volley</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.crashlytics.sdk.android</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ads.afsn</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ads.interactivemedia.v3</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ads.mediation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ai.client.generativeai</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ai.edge.aicore</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ai.edge.litert</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ai.edge.localagents</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ambient.crossdevice</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.ads</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.ads.consent</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.apps.common.testing.accessibility.framework</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.car.connectionservice</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.datatransport</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.engage</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.enterprise.connectedapps</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.exoplayer</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.fhir</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.flexbox</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.games</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.gms</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.gms.strict-version-matcher-plugin</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.instantapps</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.instantapps.thirdpartycompat</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.ads.mobile.sdk</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.car</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.cloud.telco.subgraph</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.enterprise.amapi</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.healthdata</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.identity.googleid</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.maps</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.mapsplatform.secrets-gradle-plugin</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.mapsplatform.transportation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.navigation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.places</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.play.games</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.sdkcoroutines</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.searchinapps</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.livesharing</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.material</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.mdoc</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.mediahome</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.meet</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.odml</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.play</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.recaptcha</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.support</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.things</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.tv</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.tv.tvpanelframework</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.ump</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.wearable</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.androidbrowserhelper</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ar</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ar.sceneform</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ar.sceneform.ux</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.assistant.appactions</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.assistant.suggestion</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.camerax.effects</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.chromeos</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.cose</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.d2c</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.devtools.ksp</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.fhir</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.firebase</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.firebase.appdistribution</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.firebase.crashlytics</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.firebase.firebase-perf</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.firebase.testlab</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.gms</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.gms.google-services</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.jacquard</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.mediapipe</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.mlkit</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.net.cronet</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.oboe</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.prefab</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.relay</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.test.platform</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.testing.platform</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">io.fabric.sdk.android</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">org.chromium.net</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">org.jetbrains.kotlin</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">org.multipaz</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">tools.base.build-system.debug</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">zipflinger</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree -->
+                </div>
+            </aside>
+        </div>
+        <!-- Bottom bar -->
+        <footer class="footer">
+            <div>
+                <span>Copyright <span class="material-icons" style="font-size: 8pt; vertical-align: baseline;">copyright</span> 2020 Google</span>
+            </div>
+        </footer>
+    </div>
+
+
+
+</body>
+</html>

--- a/src/oss-tests/TestData/Maven/maven_core_1.0.0_alpha3.html
+++ b/src/oss-tests/TestData/Maven/maven_core_1.0.0_alpha3.html
@@ -1,0 +1,2940 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <style>
+        @charset "UTF-8";
+
+        [ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak, .ng-hide:not(.ng-hide-animate) {
+            display: none !important;
+        }
+
+        ng\:form {
+            display: block;
+        }
+
+        .ng-animate-shim {
+            visibility: hidden;
+        }
+
+        .ng-anchor {
+            position: absolute;
+        }
+    </style>
+    <script nonce="">
+    if (window.location.search.substring(1) !== "full=true") { // do not redirect if querystring is ?full=true
+      if (navigator.userAgent.match(/i(Phone|Pad)|Android|Blackberry|WebOs/i)) { // detect mobile browser
+        window.location.replace("m_index.html"); // redirect if mobile browser detected
+      }
+    }
+    </script>
+
+    <title>Google's Maven Repository</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" type="image/x-icon" href="favicon.ico">
+    <!-- Stylesheets -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Material+Icons|Material+Icons+Outlined|Material+Icons+Two+Tone|Material+Icons+Round|Material+Icons+Sharp" nonce="">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:400,500|Roboto+Mono|Roboto:300,400,500,700" nonce="">
+    <link rel="stylesheet" href="css/common_styles.css" nonce="">
+    <link rel="stylesheet" href="css/styles.css" nonce="">
+    <!-- Scripts -->
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.8.0/angular.min.js" nonce=""></script>
+    <script src="js/gmaven-index.js" nonce=""></script>
+</head>
+
+<body ng-app="MavenIndex" ng-controller="MavenIndexController as index" class="ng-scope">
+    <div class="flex-container flex-column full-height">
+        <!-- Material Design App Bar -->
+        <header>
+            <div class="app-bar">
+                <div class="app-bar-title">Google's Maven Repository</div>
+                <!-- Search box for filtering the artifact tree -->
+                <div class="search-box-container">
+                    <div class="search-box flex-container">
+                        <label class="flex-item">
+                            <input class="search-box-input ng-pristine ng-valid ng-empty ng-touched" ng-model="searchTerm" ng-change="setFilter(searchTerm)" placeholder="Search for an artifact...">
+                        </label>
+                        <i class="search-box-icon material-icons ng-binding" ng-click="clearFilter()" ng-keypress="$event.which === 13 &amp;&amp; clearFilter()" ng-class="{'clickable-icon': searchTerm.length}" tabindex="0">
+                            search
+                        </i>
+                    </div>
+                </div>
+                <div class="app-bar-icon-container">
+                    <!-- ngIf: false -->
+                </div>
+            </div>
+            <div class="nav-bar">
+                <div class="nav-bar-bread-crumb" ng-click="clearFilter()">Home</div>
+                <!-- ngIf: selectedGroupNode --><i class="nav-bar-bread-crumb-divider material-icons ng-scope" ng-if="selectedGroupNode">arrow_forward_ios</i><!-- end ngIf: selectedGroupNode -->
+                <!-- ngIf: selectedGroupNode --><div class="nav-bar-bread-crumb-path-element ng-binding ng-scope" ng-if="selectedGroupNode" ng-click="selectedGroupNode.select()">
+                    android.arch.core
+                </div><!-- end ngIf: selectedGroupNode -->
+                <!-- ngIf: selectedArtifactNode --><i class="nav-bar-bread-crumb-divider material-icons ng-scope" ng-if="selectedArtifactNode">keyboard_arrow_right</i><!-- end ngIf: selectedArtifactNode -->
+                <!-- ngIf: selectedArtifactNode --><div class="nav-bar-bread-crumb-path-element ng-binding ng-scope" ng-if="selectedArtifactNode" ng-click="selectedArtifactNode.select()">
+                    core
+                </div><!-- end ngIf: selectedArtifactNode -->
+                <!-- ngIf: selectedVersionNode --><i class="nav-bar-bread-crumb-divider material-icons ng-scope" ng-if="selectedVersionNode">keyboard_arrow_right</i><!-- end ngIf: selectedVersionNode -->
+                <!-- ngIf: selectedVersionNode --><div class="nav-bar-bread-crumb-path-element ng-binding ng-scope" ng-if="selectedVersionNode" ng-click="selectedVersionNode.select()">
+                    1.0.0-alpha3
+                </div><!-- end ngIf: selectedVersionNode -->
+            </div>
+        </header>
+        <!-- Container for the overview/details content panels -->
+        <div class="flex-container flex-item min-height">
+            <!-- Details - Right hand content panel -->
+            <main class="flex-container flex-item main">
+                <div class="flex-item">
+                    <!-- Welcome message - only show when no selection in overview tree exists -->
+                    <!-- ngIf: !selectedNode -->
+                    <!-- Artifact details - show all the different artifact versions (children) when an artifact is selected -->
+                    <!-- ngIf: selectedNode.subnode && selectedNode.subnode.length -->
+                    <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                    <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                    <!-- ngRepeat: child in selectedNode.subnode -->
+                    <!-- Version details - show the POM file information for the selected group-artifact-version coordinate -->
+                    <!-- ngIf: selectedNode && selectedNode.model --><div ng-if="selectedNode &amp;&amp; selectedNode.model" class="ng-scope">
+                        <div class="content-header ng-binding">
+                            android.arch.core:core:1.0.0-alpha3
+                        </div><table class="gav-pom-table">
+                            <thead>
+
+                            </thead>
+                            <tbody>
+                                <!-- ngRepeat: item in selectedNode.model -->
+                                <tr ng-repeat="item in selectedNode.model" class="ng-scope">
+                                    <td class="gav-pom-key ng-binding">Project</td>
+                                    <td ng-switch="item.type" class="gav-pom-value">
+                                        <!-- ngSwitchWhen: text -->
+                                        <!-- ngSwitchWhen: link --><a ng-switch-when="link" href="https://developer.android.com/topic/libraries/architecture/index.html" target="_blank" class="ng-binding ng-scope">
+                                            https://developer.android.com/topic/libraries/architecture/index.html
+                                        </a><!-- end ngSwitchWhen: -->
+                                        <!-- ngSwitchWhen: artifacts -->
+                                        <!-- ngSwitchWhen: code -->
+                                    </td>
+                                </tr><!-- end ngRepeat: item in selectedNode.model -->
+                                <tr ng-repeat="item in selectedNode.model" class="ng-scope">
+                                    <td class="gav-pom-key ng-binding">Artifact(s)</td>
+                                    <td ng-switch="item.type" class="gav-pom-value">
+                                        <!-- ngSwitchWhen: text -->
+                                        <!-- ngSwitchWhen: link -->
+                                        <!-- ngSwitchWhen: artifacts --><!-- ngRepeat: artifact in item.value --><span ng-switch-when="artifacts" ng-repeat="artifact in item.value" class="ng-scope">
+                                            <a href="https://dl.google.com/android/maven2/android/arch/core/core/1.0.0-alpha3/core-1.0.0-alpha3.aar" class="ng-binding">aar</a><!-- ngIf: !$last --><span ng-if="!$last" class="ng-scope">,&nbsp;</span><!-- end ngIf: !$last -->
+                                        </span><!-- end ngRepeat: artifact in item.value --><span ng-switch-when="artifacts" ng-repeat="artifact in item.value" class="ng-scope">
+                                            <a href="https://dl.google.com/android/maven2/android/arch/core/core/1.0.0-alpha3/core-1.0.0-alpha3.pom" class="ng-binding">pom</a><!-- ngIf: !$last -->
+                                        </span><!-- end ngRepeat: artifact in item.value --><!-- end ngSwitchWhen: -->
+                                        <!-- ngSwitchWhen: code -->
+                                    </td>
+                                </tr><!-- end ngRepeat: item in selectedNode.model -->
+                                <tr ng-repeat="item in selectedNode.model" class="ng-scope">
+                                    <td class="gav-pom-key ng-binding">Developer(s)</td>
+                                    <td ng-switch="item.type" class="gav-pom-value">
+                                        <!-- ngSwitchWhen: text --><span ng-switch-when="text" class="ng-binding ng-scope">The Android Open Source Project</span><!-- end ngSwitchWhen: -->
+                                        <!-- ngSwitchWhen: link -->
+                                        <!-- ngSwitchWhen: artifacts -->
+                                        <!-- ngSwitchWhen: code -->
+                                    </td>
+                                </tr><!-- end ngRepeat: item in selectedNode.model -->
+                                <tr ng-repeat="item in selectedNode.model" class="ng-scope">
+                                    <td class="gav-pom-key ng-binding">License(s)</td>
+                                    <td ng-switch="item.type" class="gav-pom-value">
+                                        <!-- ngSwitchWhen: text -->
+                                        <!-- ngSwitchWhen: link --><a ng-switch-when="link" href="http://www.apache.org/licenses/LICENSE-2.0.txt" target="_blank" class="ng-binding ng-scope">
+                                            The Apache Software License, Version 2.0
+                                        </a><!-- end ngSwitchWhen: -->
+                                        <!-- ngSwitchWhen: artifacts -->
+                                        <!-- ngSwitchWhen: code -->
+                                    </td>
+                                </tr><!-- end ngRepeat: item in selectedNode.model -->
+                                <tr ng-repeat="item in selectedNode.model" class="ng-scope">
+                                    <td class="gav-pom-key ng-binding">Group ID</td>
+                                    <td ng-switch="item.type" class="gav-pom-value">
+                                        <!-- ngSwitchWhen: text --><span ng-switch-when="text" class="ng-binding ng-scope">android.arch.core</span><!-- end ngSwitchWhen: -->
+                                        <!-- ngSwitchWhen: link -->
+                                        <!-- ngSwitchWhen: artifacts -->
+                                        <!-- ngSwitchWhen: code -->
+                                    </td>
+                                </tr><!-- end ngRepeat: item in selectedNode.model -->
+                                <tr ng-repeat="item in selectedNode.model" class="ng-scope">
+                                    <td class="gav-pom-key ng-binding">Artifact ID</td>
+                                    <td ng-switch="item.type" class="gav-pom-value">
+                                        <!-- ngSwitchWhen: text --><span ng-switch-when="text" class="ng-binding ng-scope">core</span><!-- end ngSwitchWhen: -->
+                                        <!-- ngSwitchWhen: link -->
+                                        <!-- ngSwitchWhen: artifacts -->
+                                        <!-- ngSwitchWhen: code -->
+                                    </td>
+                                </tr><!-- end ngRepeat: item in selectedNode.model -->
+                                <tr ng-repeat="item in selectedNode.model" class="ng-scope">
+                                    <td class="gav-pom-key ng-binding">Version</td>
+                                    <td ng-switch="item.type" class="gav-pom-value">
+                                        <!-- ngSwitchWhen: text --><span ng-switch-when="text" class="ng-binding ng-scope">1.0.0-alpha3</span><!-- end ngSwitchWhen: -->
+                                        <!-- ngSwitchWhen: link -->
+                                        <!-- ngSwitchWhen: artifacts -->
+                                        <!-- ngSwitchWhen: code -->
+                                    </td>
+                                </tr><!-- end ngRepeat: item in selectedNode.model -->
+                                <tr ng-repeat="item in selectedNode.model" class="ng-scope">
+                                    <td class="gav-pom-key ng-binding">Gradle Groovy DSL</td>
+                                    <td ng-switch="item.type" class="gav-pom-value">
+                                        <!-- ngSwitchWhen: text -->
+                                        <!-- ngSwitchWhen: link -->
+                                        <!-- ngSwitchWhen: artifacts -->
+                                        <!-- ngSwitchWhen: code --><div ng-switch-when="code" class="gav-pom-value-copyable ng-scope" title="Click to copy" ng-click="copyTextToClipboard(item.id)">
+                                            <div id="groovy-dsl" class="ng-binding">implementation 'android.arch.core:core:1.0.0-alpha3'</div>
+                                            <i class="material-icons small-icon">content_copy</i>
+                                        </div><!-- end ngSwitchWhen: -->
+                                    </td>
+                                </tr><!-- end ngRepeat: item in selectedNode.model -->
+                                <tr ng-repeat="item in selectedNode.model" class="ng-scope">
+                                    <td class="gav-pom-key ng-binding">Gradle Kotlin DSL</td>
+                                    <td ng-switch="item.type" class="gav-pom-value">
+                                        <!-- ngSwitchWhen: text -->
+                                        <!-- ngSwitchWhen: link -->
+                                        <!-- ngSwitchWhen: artifacts -->
+                                        <!-- ngSwitchWhen: code --><div ng-switch-when="code" class="gav-pom-value-copyable ng-scope" title="Click to copy" ng-click="copyTextToClipboard(item.id)">
+                                            <div id="kotlin-dsl" class="ng-binding">implementation("android.arch.core:core:1.0.0-alpha3")</div>
+                                            <i class="material-icons small-icon">content_copy</i>
+                                        </div><!-- end ngSwitchWhen: -->
+                                    </td>
+                                </tr><!-- end ngRepeat: item in selectedNode.model -->
+                                <tr ng-repeat="item in selectedNode.model" class="ng-scope">
+                                    <td class="gav-pom-key ng-binding">Last Updated Date</td>
+                                    <td ng-switch="item.type" class="gav-pom-value">
+                                        <!-- ngSwitchWhen: text --><span ng-switch-when="text" class="ng-binding ng-scope">9/20/2019</span><!-- end ngSwitchWhen: -->
+                                        <!-- ngSwitchWhen: link -->
+                                        <!-- ngSwitchWhen: artifacts -->
+                                        <!-- ngSwitchWhen: code -->
+                                    </td>
+                                </tr><!-- end ngRepeat: item in selectedNode.model -->
+                            </tbody>
+                        </table>
+                    </div><!-- end ngIf: selectedNode && selectedNode.model -->
+                </div>
+            </main>
+            <!-- Overview - Left hand navigation panel -->
+            <aside class="flex-column sidebar sidebar-left">
+                <!-- Group-Artifact-Version tree container -->
+                <div class="tree-container">
+                    <!-- ngIf: allHidden || displayTree.length==0 -->
+                    <!-- Group list -->
+                    <!-- ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child expand" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">android.arch.core</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded --><div style="margin-left:20px" ng-if="group.expanded" class="ng-scope">
+                            <!-- Artifact list -->
+                            <!-- ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child expand" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">common</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded --><div style="margin-left:28px" ng-if="artifact.expanded" class="ng-scope">
+
+                                    <!-- Versions list -->
+                                    <!-- ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.1.1
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.1.0
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha9
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha8
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha7
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha6
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha5
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha4
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode -->
+                                </div><!-- end ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child expand" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">core</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded --><div style="margin-left:28px" ng-if="artifact.expanded" class="ng-scope">
+
+                                    <!-- Versions list -->
+                                    <!-- ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem selected" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding selected" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha3
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha2
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha1
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode -->
+                                </div><!-- end ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">core-testing</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">runtime</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode -->
+                        </div><!-- end ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">android.arch.lifecycle</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child expand" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">android.arch.navigation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded --><div style="margin-left:20px" ng-if="group.expanded" class="ng-scope">
+                            <!-- Artifact list -->
+                            <!-- ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">navigation-common</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child expand" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">navigation-common-ktx</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded --><div style="margin-left:28px" ng-if="artifact.expanded" class="ng-scope">
+
+                                    <!-- Versions list -->
+                                    <!-- ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-rc02
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-rc01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-beta02
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-beta01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha11
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha10
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha09
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha08
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha07
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha06
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha05
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha04
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha03
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha02
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode -->
+                                </div><!-- end ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">navigation-fragment</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">navigation-fragment-ktx</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">navigation-runtime</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">navigation-runtime-ktx</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">navigation-safe-args-generator</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">navigation-safe-args-gradle-plugin</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">navigation-testing</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">navigation-testing-ktx</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">navigation-ui</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">navigation-ui-ktx</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode -->
+                        </div><!-- end ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">android.arch.paging</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">android.arch.persistence</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">android.arch.persistence.room</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">android.arch.work</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.activity</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.ads</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.annotation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.appcompat</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.appsearch</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.arch.core</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.asynclayoutinflater</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.autofill</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.baselineprofile</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.baselineprofile.apptarget</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.baselineprofile.consumer</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.baselineprofile.producer</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.benchmark</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.biometric</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.bluetooth</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.browser</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.camera</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.camera.media3</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.camera.viewfinder</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.car</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.car.app</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.cardview</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.collection</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.compose</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.compose.animation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.compose.compiler</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.compose.foundation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.compose.material</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.compose.material3</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.compose.material3.adaptive</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.compose.runtime</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.compose.ui</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.concurrent</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.constraintlayout</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.contentpager</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.coordinatorlayout</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.core</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.core.uwb</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.credentials</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.credentials.registry</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.cursoradapter</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.customview</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.databinding</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.datastore</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.documentfile</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.draganddrop</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.drawerlayout</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.dynamicanimation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.emoji</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.emoji2</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.enterprise</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.exifinterface</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.fragment</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.games</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.gaming</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.glance</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.gradle</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.graphics</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.gridlayout</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.health</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.health.connect</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.heifwriter</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.hilt</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.ink</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.input</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.interpolator</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.javascriptengine</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.leanback</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.legacy</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.lifecycle</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.lint</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.loader</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.localbroadcastmanager</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.media</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.media2</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.media3</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.mediarouter</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.metrics</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.multidex</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.navigation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.navigation.safeargs</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.navigation.safeargs.kotlin</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.paging</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.palette</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.pdf</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.percentlayout</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.performance</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.preference</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.print</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.privacysandbox.activity</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.privacysandbox.ads</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.privacysandbox.library</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.privacysandbox.plugins</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.privacysandbox.sdkruntime</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.privacysandbox.tools</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.privacysandbox.ui</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.profileinstaller</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.recommendation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.recyclerview</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.remotecallback</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.resourceinspection</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.room</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.savedstate</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.security</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.sharetarget</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.slice</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.slidingpanelayout</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.sqlite</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.startup</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.swiperefreshlayout</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.test</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.test.espresso</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.test.espresso.idling</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.test.ext</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.test.janktesthelper</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.test.services</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.test.uiautomator</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.textclassifier</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.tracing</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.transition</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.tv</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.tvprovider</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.ui</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.vectordrawable</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.versionedparcelable</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.viewpager</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.viewpager2</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.wear</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.wear.compose</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.wear.protolayout</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.wear.tiles</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.wear.watchface</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.webkit</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.window</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.window.extensions.core</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.work</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.xr.arcore</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.xr.compose</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.xr.compose.material3</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.xr.runtime</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.xr.scenecore</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.ai-pack</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.application</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.art</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.asset-pack</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.asset-pack-bundle</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.billingclient</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.car.setupwizardlib</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.car.ui</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.compose.screenshot</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.databinding</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.designcompose</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.dynamic-feature</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.experimental.built-in-kotlin</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.fused-library</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.identity</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.installreferrer</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.internal.settings</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.java.tools.build</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.kotlin.multiplatform.library</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.legacy-kapt</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.library</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.lint</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.ndk.thirdparty</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.privacy-sandbox-sdk</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.reporting</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.security.autorepro</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.security.autorepro.apptest</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.security.autorepro.javahosttest</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.security.autorepro.ndktest</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.security.autorepro.submission</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.security.lint</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.settings</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.support</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.support.constraint</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.support.test</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.support.test.espresso</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.support.test.espresso.idling</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.support.test.janktesthelper</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.support.test.services</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.support.test.uiautomator</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.test</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.adblib</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.analytics-library</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.apkdeployer</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.apkparser</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.build</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.build.jetifier</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.chunkio</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.compose</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.ddms</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.emulator</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.external.com-intellij</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.external.org-jetbrains</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.fakeadbserver</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.internal.build.test</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.layoutlib</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.lint</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.metalava</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.pixelprobe</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.screenshot</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.smali</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.utp</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.volley</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.crashlytics.sdk.android</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ads.afsn</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ads.interactivemedia.v3</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ads.mediation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ai.client.generativeai</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ai.edge.aicore</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ai.edge.litert</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ai.edge.localagents</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ambient.crossdevice</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.ads</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.ads.consent</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.apps.common.testing.accessibility.framework</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.car.connectionservice</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.datatransport</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.engage</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.enterprise.connectedapps</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.exoplayer</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.fhir</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.flexbox</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.games</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.gms</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.gms.strict-version-matcher-plugin</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.instantapps</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.instantapps.thirdpartycompat</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.ads.mobile.sdk</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.car</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.cloud.telco.subgraph</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.enterprise.amapi</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.healthdata</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.identity.googleid</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.maps</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.mapsplatform.secrets-gradle-plugin</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.mapsplatform.transportation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.navigation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.places</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.play.games</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.sdkcoroutines</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.searchinapps</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.livesharing</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.material</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.mdoc</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.mediahome</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.meet</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.odml</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.play</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.recaptcha</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.support</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.things</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.tv</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.tv.tvpanelframework</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.ump</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.wearable</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.androidbrowserhelper</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ar</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ar.sceneform</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ar.sceneform.ux</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.assistant.appactions</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.assistant.suggestion</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.camerax.effects</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.chromeos</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.cose</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.d2c</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.devtools.ksp</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.fhir</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.firebase</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.firebase.appdistribution</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.firebase.crashlytics</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.firebase.firebase-perf</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.firebase.testlab</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.gms</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.gms.google-services</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.jacquard</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.mediapipe</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.mlkit</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.net.cronet</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.oboe</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.prefab</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.relay</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.test.platform</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.testing.platform</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">io.fabric.sdk.android</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">org.chromium.net</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">org.jetbrains.kotlin</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">org.multipaz</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">tools.base.build-system.debug</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">zipflinger</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree -->
+                </div>
+            </aside>
+        </div>
+        <!-- Bottom bar -->
+        <footer class="footer">
+            <div>
+                <span>Copyright <span class="material-icons" style="font-size: 8pt; vertical-align: baseline;">copyright</span> 2020 Google</span>
+            </div>
+        </footer>
+    </div>
+
+
+
+</body>
+</html>

--- a/src/oss-tests/TestData/Maven/maven_core_all.html
+++ b/src/oss-tests/TestData/Maven/maven_core_all.html
@@ -1,0 +1,2845 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <style>
+        @charset "UTF-8";
+
+        [ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak, .ng-hide:not(.ng-hide-animate) {
+            display: none !important;
+        }
+
+        ng\:form {
+            display: block;
+        }
+
+        .ng-animate-shim {
+            visibility: hidden;
+        }
+
+        .ng-anchor {
+            position: absolute;
+        }
+    </style>
+    <script nonce="">
+        if (window.location.search.substring(1) !== "full=true") { // do not redirect if querystring is ?full=true
+            if (navigator.userAgent.match(/i(Phone|Pad)|Android|Blackberry|WebOs/i)) { // detect mobile browser
+                window.location.replace("m_index.html"); // redirect if mobile browser detected
+            }
+        }
+    </script>
+
+    <title>Google's Maven Repository</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" type="image/x-icon" href="favicon.ico">
+    <!-- Stylesheets -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Material+Icons|Material+Icons+Outlined|Material+Icons+Two+Tone|Material+Icons+Round|Material+Icons+Sharp" nonce="">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:400,500|Roboto+Mono|Roboto:300,400,500,700" nonce="">
+    <link rel="stylesheet" href="css/common_styles.css" nonce="">
+    <link rel="stylesheet" href="css/styles.css" nonce="">
+    <!-- Scripts -->
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.8.0/angular.min.js" nonce=""></script>
+    <script src="js/gmaven-index.js" nonce=""></script>
+</head>
+
+<body ng-app="MavenIndex" ng-controller="MavenIndexController as index" class="ng-scope">
+    <div class="flex-container flex-column full-height">
+        <!-- Material Design App Bar -->
+        <header>
+            <div class="app-bar">
+                <div class="app-bar-title">Google's Maven Repository</div>
+                <!-- Search box for filtering the artifact tree -->
+                <div class="search-box-container">
+                    <div class="search-box flex-container">
+                        <label class="flex-item">
+                            <input class="search-box-input ng-pristine ng-valid ng-empty ng-touched" ng-model="searchTerm" ng-change="setFilter(searchTerm)" placeholder="Search for an artifact...">
+                        </label>
+                        <i class="search-box-icon material-icons ng-binding" ng-click="clearFilter()" ng-keypress="$event.which === 13 &amp;&amp; clearFilter()" ng-class="{'clickable-icon': searchTerm.length}" tabindex="0">
+                            search
+                        </i>
+                    </div>
+                </div>
+                <div class="app-bar-icon-container">
+                    <!-- ngIf: false -->
+                </div>
+            </div>
+            <div class="nav-bar">
+                <div class="nav-bar-bread-crumb" ng-click="clearFilter()">Home</div>
+                <!-- ngIf: selectedGroupNode --><i class="nav-bar-bread-crumb-divider material-icons ng-scope" ng-if="selectedGroupNode">arrow_forward_ios</i><!-- end ngIf: selectedGroupNode -->
+                <!-- ngIf: selectedGroupNode --><div class="nav-bar-bread-crumb-path-element ng-binding ng-scope" ng-if="selectedGroupNode" ng-click="selectedGroupNode.select()">
+                    android.arch.core
+                </div><!-- end ngIf: selectedGroupNode -->
+                <!-- ngIf: selectedArtifactNode --><i class="nav-bar-bread-crumb-divider material-icons ng-scope" ng-if="selectedArtifactNode">keyboard_arrow_right</i><!-- end ngIf: selectedArtifactNode -->
+                <!-- ngIf: selectedArtifactNode --><div class="nav-bar-bread-crumb-path-element ng-binding ng-scope" ng-if="selectedArtifactNode" ng-click="selectedArtifactNode.select()">
+                    core
+                </div><!-- end ngIf: selectedArtifactNode -->
+                <!-- ngIf: selectedVersionNode -->
+                <!-- ngIf: selectedVersionNode -->
+            </div>
+        </header>
+        <!-- Container for the overview/details content panels -->
+        <div class="flex-container flex-item min-height">
+            <!-- Details - Right hand content panel -->
+            <main class="flex-container flex-item main">
+                <div class="flex-item">
+                    <!-- Welcome message - only show when no selection in overview tree exists -->
+                    <!-- ngIf: !selectedNode -->
+                    <!-- Artifact details - show all the different artifact versions (children) when an artifact is selected -->
+                    <!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div class="content-header ng-binding ng-scope" ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length">
+                        android.arch.core:core
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length -->
+                    <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                    <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><div class="content-description ng-binding ng-scope" ng-if="selectedNode.constructor.name === 'ArtifactNode'">
+                        Versions (3)
+                    </div><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                    <!-- ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.0.0-alpha3</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.0.0-alpha2</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode --><!-- ngIf: selectedNode.subnode && selectedNode.subnode.length --><div ng-if="selectedNode.subnode &amp;&amp; selectedNode.subnode.length" ng-repeat="child in selectedNode.subnode" class="ng-scope">
+                        <div ng-click="selectedNode.setExpand(true); child.select();" class="artifact-child-item">
+                            <!-- ngIf: selectedNode.constructor.name === 'GroupNode' -->
+                            <!-- ngIf: selectedNode.constructor.name === 'ArtifactNode' --><img ng-if="selectedNode.constructor.name === 'ArtifactNode'" class="version-icon ng-scope" src="maven_light.png" alt=""><!-- end ngIf: selectedNode.constructor.name === 'ArtifactNode' -->
+                            <span class="ng-binding">1.0.0-alpha1</span>
+                        </div>
+                    </div><!-- end ngIf: selectedNode.subnode && selectedNode.subnode.length --><!-- end ngRepeat: child in selectedNode.subnode -->
+                    <!-- Version details - show the POM file information for the selected group-artifact-version coordinate -->
+                    <!-- ngIf: selectedNode && selectedNode.model -->
+                </div>
+            </main>
+            <!-- Overview - Left hand navigation panel -->
+            <aside class="flex-column sidebar sidebar-left">
+                <!-- Group-Artifact-Version tree container -->
+                <div class="tree-container">
+                    <!-- ngIf: allHidden || displayTree.length==0 -->
+                    <!-- Group list -->
+                    <!-- ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child expand" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">android.arch.core</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded --><div style="margin-left:20px" ng-if="group.expanded" class="ng-scope">
+                            <!-- Artifact list -->
+                            <!-- ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child expand" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">common</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded --><div style="margin-left:28px" ng-if="artifact.expanded" class="ng-scope">
+
+                                    <!-- Versions list -->
+                                    <!-- ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.1.1
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.1.0
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha9
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha8
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha7
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha6
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha5
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha4
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode -->
+                                </div><!-- end ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem selected" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child expand" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope selected" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">core</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded --><div style="margin-left:28px" ng-if="artifact.expanded" class="ng-scope">
+
+                                    <!-- Versions list -->
+                                    <!-- ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha3
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha2
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha1
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode -->
+                                </div><!-- end ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">core-testing</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">runtime</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode -->
+                        </div><!-- end ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">android.arch.lifecycle</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child expand" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">android.arch.navigation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded --><div style="margin-left:20px" ng-if="group.expanded" class="ng-scope">
+                            <!-- Artifact list -->
+                            <!-- ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">navigation-common</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child expand" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">navigation-common-ktx</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded --><div style="margin-left:28px" ng-if="artifact.expanded" class="ng-scope">
+
+                                    <!-- Versions list -->
+                                    <!-- ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-rc02
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-rc01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-beta02
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-beta01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha11
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha10
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha09
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha08
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha07
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha06
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha05
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha04
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha03
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha02
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode --><div ng-repeat="version in artifact.subnode" class="ng-scope">
+                                        <div class="indexItem" ng-disabled="true" ng-click="version.select()" ng-class="{'selected': version.selected}" disabled="disabled">
+                                            <span class="selectable-node ng-binding" ng-class="{'selected': version.selected}">
+                                                1.0.0-alpha01
+                                            </span>
+                                        </div>
+                                    </div><!-- end ngRepeat: version in artifact.subnode -->
+                                </div><!-- end ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">navigation-fragment</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">navigation-fragment-ktx</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">navigation-runtime</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">navigation-runtime-ktx</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">navigation-safe-args-generator</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">navigation-safe-args-gradle-plugin</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">navigation-testing</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">navigation-testing-ktx</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">navigation-ui</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode --><!-- ngIf: artifact.visible --><div ng-repeat="artifact in group.subnode" ng-if="artifact.visible" class="ng-scope">
+                                <div class="indexItem" ng-click="artifact.select()" ng-class="{'selected': artifact.selected}">
+                                    <span class="material-icons caret has_child" ng-class="{'expand': artifact.expanded}" ng-click="artifact.toggle()"></span>
+                                    <!-- ngIf: artifact.highlight -->
+                                    <!-- ngIf: !artifact.highlight --><span class="selectable-node ng-binding ng-scope" ng-if="!artifact.highlight" ng-class="{'selected': artifact.selected}" ng-click="artifact.select()">navigation-ui-ktx</span><!-- end ngIf: !artifact.highlight -->
+                                </div>
+                                <!-- Versions subtree - visible when expanded -->
+                                <!-- ngIf: artifact.expanded -->
+                            </div><!-- end ngIf: artifact.visible --><!-- end ngRepeat: artifact in group.subnode -->
+                        </div><!-- end ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">android.arch.paging</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">android.arch.persistence</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">android.arch.persistence.room</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">android.arch.work</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.activity</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.ads</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.annotation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.appcompat</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.appsearch</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.arch.core</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.asynclayoutinflater</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.autofill</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.baselineprofile</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.baselineprofile.apptarget</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.baselineprofile.consumer</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.baselineprofile.producer</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.benchmark</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.biometric</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.bluetooth</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.browser</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.camera</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.camera.media3</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.camera.viewfinder</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.car</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.car.app</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.cardview</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.collection</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.compose</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.compose.animation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.compose.compiler</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.compose.foundation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.compose.material</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.compose.material3</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.compose.material3.adaptive</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.compose.runtime</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.compose.ui</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.concurrent</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.constraintlayout</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.contentpager</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.coordinatorlayout</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.core</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.core.uwb</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.credentials</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.credentials.registry</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.cursoradapter</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.customview</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.databinding</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.datastore</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.documentfile</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.draganddrop</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.drawerlayout</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.dynamicanimation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.emoji</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.emoji2</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.enterprise</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.exifinterface</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.fragment</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.games</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.gaming</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.glance</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.gradle</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.graphics</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.gridlayout</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.health</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.health.connect</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.heifwriter</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.hilt</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.ink</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.input</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.interpolator</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.javascriptengine</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.leanback</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.legacy</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.lifecycle</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.lint</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.loader</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.localbroadcastmanager</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.media</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.media2</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.media3</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.mediarouter</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.metrics</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.multidex</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.navigation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.navigation.safeargs</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.navigation.safeargs.kotlin</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.paging</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.palette</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.pdf</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.percentlayout</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.performance</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.preference</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.print</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.privacysandbox.activity</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.privacysandbox.ads</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.privacysandbox.library</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.privacysandbox.plugins</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.privacysandbox.sdkruntime</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.privacysandbox.tools</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.privacysandbox.ui</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.profileinstaller</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.recommendation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.recyclerview</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.remotecallback</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.resourceinspection</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.room</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.savedstate</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.security</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.sharetarget</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.slice</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.slidingpanelayout</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.sqlite</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.startup</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.swiperefreshlayout</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.test</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.test.espresso</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.test.espresso.idling</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.test.ext</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.test.janktesthelper</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.test.services</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.test.uiautomator</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.textclassifier</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.tracing</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.transition</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.tv</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.tvprovider</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.ui</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.vectordrawable</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.versionedparcelable</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.viewpager</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.viewpager2</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.wear</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.wear.compose</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.wear.protolayout</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.wear.tiles</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.wear.watchface</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.webkit</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.window</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.window.extensions.core</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.work</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.xr.arcore</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.xr.compose</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.xr.compose.material3</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.xr.runtime</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">androidx.xr.scenecore</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.ai-pack</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.application</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.art</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.asset-pack</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.asset-pack-bundle</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.billingclient</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.car.setupwizardlib</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.car.ui</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.compose.screenshot</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.databinding</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.designcompose</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.dynamic-feature</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.experimental.built-in-kotlin</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.fused-library</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.identity</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.installreferrer</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.internal.settings</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.java.tools.build</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.kotlin.multiplatform.library</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.legacy-kapt</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.library</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.lint</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.ndk.thirdparty</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.privacy-sandbox-sdk</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.reporting</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.security.autorepro</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.security.autorepro.apptest</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.security.autorepro.javahosttest</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.security.autorepro.ndktest</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.security.autorepro.submission</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.security.lint</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.settings</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.support</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.support.constraint</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.support.test</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.support.test.espresso</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.support.test.espresso.idling</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.support.test.janktesthelper</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.support.test.services</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.support.test.uiautomator</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.test</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.adblib</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.analytics-library</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.apkdeployer</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.apkparser</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.build</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.build.jetifier</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.chunkio</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.compose</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.ddms</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.emulator</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.external.com-intellij</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.external.org-jetbrains</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.fakeadbserver</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.internal.build.test</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.layoutlib</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.lint</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.metalava</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.pixelprobe</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.screenshot</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.smali</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.tools.utp</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.android.volley</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.crashlytics.sdk.android</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ads.afsn</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ads.interactivemedia.v3</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ads.mediation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ai.client.generativeai</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ai.edge.aicore</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ai.edge.litert</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ai.edge.localagents</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ambient.crossdevice</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.ads</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.ads.consent</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.apps.common.testing.accessibility.framework</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.car.connectionservice</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.datatransport</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.engage</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.enterprise.connectedapps</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.exoplayer</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.fhir</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.flexbox</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.games</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.gms</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.gms.strict-version-matcher-plugin</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.instantapps</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.instantapps.thirdpartycompat</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.ads.mobile.sdk</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.car</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.cloud.telco.subgraph</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.enterprise.amapi</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.healthdata</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.identity.googleid</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.maps</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.mapsplatform.secrets-gradle-plugin</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.mapsplatform.transportation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.navigation</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.places</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.play.games</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.sdkcoroutines</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.libraries.searchinapps</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.livesharing</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.material</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.mdoc</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.mediahome</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.meet</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.odml</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.play</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.recaptcha</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.support</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.things</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.tv</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.tv.tvpanelframework</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.ump</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.android.wearable</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.androidbrowserhelper</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ar</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ar.sceneform</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.ar.sceneform.ux</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.assistant.appactions</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.assistant.suggestion</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.camerax.effects</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.chromeos</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.cose</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.d2c</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.devtools.ksp</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.fhir</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.firebase</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.firebase.appdistribution</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.firebase.crashlytics</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.firebase.firebase-perf</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.firebase.testlab</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.gms</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.gms.google-services</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.jacquard</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.mediapipe</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.mlkit</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.net.cronet</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.oboe</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.prefab</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.relay</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.test.platform</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">com.google.testing.platform</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">io.fabric.sdk.android</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">org.chromium.net</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">org.jetbrains.kotlin</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">org.multipaz</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">tools.base.build-system.debug</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree --><!-- ngIf: group.visible --><div ng-repeat="group in displayTree" ng-if="group.visible" class="ng-scope">
+                        <div class="indexItem" ng-click="group.select()" ng-class="{'selected': group.selected}">
+                            <span class="material-icons caret has_child" ng-class="{'expand': group.expanded, 'has_child': group.subnode.length}" ng-click="group.toggle()"></span>
+                            <!-- ngIf: group.highlight -->
+                            <!-- ngIf: !group.highlight --><span ng-if="!group.highlight" class="ng-binding ng-scope">zipflinger</span><!-- end ngIf: !group.highlight -->
+                        </div>
+                        <!-- Artifacts subtree - visible when expanded -->
+                        <!-- ngIf: group.expanded -->
+                    </div><!-- end ngIf: group.visible --><!-- end ngRepeat: group in displayTree -->
+                </div>
+            </aside>
+        </div>
+        <!-- Bottom bar -->
+        <footer class="footer">
+            <div>
+                <span>Copyright <span class="material-icons" style="font-size: 8pt; vertical-align: baseline;">copyright</span> 2020 Google</span>
+            </div>
+        </footer>
+    </div>
+
+
+
+</body>
+</html>


### PR DESCRIPTION
This PR adds the necessary changes to support Maven upstream to [Google Maven Repository](https://maven.google.com/web/index.html#). Some notes:

- Google Maven Repo has dynamic content in its website, so we use Puppeteer Sharp to stream and parse package metadata. 
- Caching is currently not enabled for requests through Puppeteer Sharp.
- Metadata requests to Maven Central Repository return contents of the .pom file, which are displayed in html on its website. We're unable to do that with Google Maven Repository, as it only contains a link to download the .pom file. To obtain metadata, we scrape whatever's available in html on the Google Maven Repository website. 
- If a requested package URL has an unrecognized/unsupported repository URL, the Maven Project Manager will default to no-op and returning null/empty values (whereas before it defaulted to the Maven Central Repository). But I'm considering changing this to default to Maven Central. Looking for feedback. 