### PR TITLE
Repopulate NPM cache after stale-entry eviction in GetPublishedAtUtcAsync

### DIFF
--- a/src/Shared/PackageManagers/NPMProjectManager.cs
+++ b/src/Shared/PackageManagers/NPMProjectManager.cs
@@ -608,11 +608,12 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             // If we got null from cache, it could mean:
             // 1. Version doesn't exist
             // 2. Cache is stale (version was published after cache was populated)
-            // Re-fetch and evict cache so next request gets fresh data.
+            // Evict the stale entry and re-fetch; passing useCache: true repopulates
+            // the cache with the fresh value so subsequent callers benefit.
             if (publishTime == null && useCache)
             {
                 DataCache.Remove($"{cacheUrl}/json");
-                jsonDoc = await GetJsonCache(client, cacheUrl, useCache: false);
+                jsonDoc = await GetJsonCache(client, cacheUrl, useCache: true);
                 publishTime = ParseUploadTime(jsonDoc, purl.Version);
             }
             

--- a/src/Shared/PackageManagers/NPMProjectManager.cs
+++ b/src/Shared/PackageManagers/NPMProjectManager.cs
@@ -613,7 +613,7 @@ namespace Microsoft.CST.OpenSource.PackageManagers
             if (publishTime == null && useCache)
             {
                 DataCache.Remove($"{cacheUrl}/json");
-                jsonDoc = await GetJsonCache(client, cacheUrl, useCache: true);
+                jsonDoc = await GetJsonCache(client, cacheUrl, useCache);
                 publishTime = ParseUploadTime(jsonDoc, purl.Version);
             }
             


### PR DESCRIPTION
In NPMProjectManager.GetPublishedAtUtcAsync, when the initial cache lookup returned a null publish time we evicted the stale entry via DataCache.Remove(...) and then immediately re-fetched with useCache: false. Looking at BaseProjectManager.GetJsonCache:

useCache: true reads cache (miss after Remove), fetches fresh, and writes the result back.
useCache: false fetches fresh but never repopulates the cache.
So the prior useCache: false was redundant with the eviction and meant the freshly-fetched value was thrown away. Switched to useCache: true so subsequent callers benefit from the fresh valu
