### PR TITLE
Upgrade Microsoft.Extensions.* packages to 10.0.3

### DIFF
--- a/src/Shared.CLI/Shared.CLI.csproj
+++ b/src/Shared.CLI/Shared.CLI.csproj
@@ -86,7 +86,7 @@
     <PackageReference Include="MediaTypeMap.Core" Version="2.3.3" />
     <PackageReference Include="Microsoft.CST.ApplicationInspector.Common" Version="1.9.53" />
     <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.2.45" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.3" />
     <PackageReference Include="NLog" Version="6.0.6" />
     <PackageReference Include="NLog.Schema" Version="6.0.6" />
     <PackageReference Include="NuGet.Versioning" Version="7.0.1" />

--- a/src/Shared/Shared.Lib.csproj
+++ b/src/Shared/Shared.Lib.csproj
@@ -35,11 +35,11 @@
         <PackageReference Include="F23.StringSimilarity" Version="7.0.0" />
         <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
         <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.2.45" />
-        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.4" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.4" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.4" />
-        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.4" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.3" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.3" />
+        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.3" />
         <PackageReference Include="NLog" Version="6.0.6" />
         <PackageReference Include="NLog.Schema" Version="6.0.6" />
         <PackageReference Include="NuGet.Packaging" Version="7.0.1" />


### PR DESCRIPTION
Upgrade Microsoft.Extensions.Caching.Memory, DependencyInjection, DependencyInjection.Abstractions, Http, and Http.Polly from 9.0.4 to 10.0.3.

Required for compatibility with Azure.Core 1.55.0 transitive dependencies in a downstream repo.