### PR TITLE
Pin vulnerable transitive NuGet packages (SFI-ES5.2)

### DIFF
--- a/src/Shared.CLI/Shared.CLI.csproj
+++ b/src/Shared.CLI/Shared.CLI.csproj
@@ -96,6 +96,10 @@
     <PackageReference Include="SemanticVersioning" Version="3.0.0" />
     <PackageReference Include="System.Console" Version="4.3.1" />
     <PackageReference Include="Whois" Version="3.0.1" />
+    <!-- SFI-ES5.2: pin vulnerable transitive -->
+    <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.4" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Shared.Lib.Tests/Shared.Lib.Tests.csproj
+++ b/src/Shared.Lib.Tests/Shared.Lib.Tests.csproj
@@ -28,6 +28,9 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		  <PrivateAssets>all</PrivateAssets>
 	  </PackageReference>
+	  <!-- SFI-ES5.2: pin vulnerable transitive -->
+	  <PackageReference Include="System.Net.Http" Version="4.3.4" />
+	  <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Shared/Shared.Lib.csproj
+++ b/src/Shared/Shared.Lib.csproj
@@ -51,6 +51,8 @@
         <PackageReference Include="SemanticVersioning" Version="3.0.0" />
         <PackageReference Include="System.Console" Version="4.3.1" />
         <PackageReference Include="System.Linq.Async" Version="7.0.0" />
+        <!-- SFI-ES5.2: pin vulnerable transitive -->
+        <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/oss-find-squats-lib/oss-find-squats-lib.csproj
+++ b/src/oss-find-squats-lib/oss-find-squats-lib.csproj
@@ -33,6 +33,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- SFI-ES5.2: pin vulnerable transitive -->
+    <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.4" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="" />
     <None Include="..\..\icon-128.png" Pack="true" PackagePath="" />
   </ItemGroup>

--- a/src/oss-gadget-cli/oss-gadget-cli.csproj
+++ b/src/oss-gadget-cli/oss-gadget-cli.csproj
@@ -32,6 +32,12 @@
     </ItemGroup>
 
     <ItemGroup>
+      <!-- SFI-ES5.2: pin vulnerable transitive -->
+      <PackageReference Include="System.Net.Http" Version="4.3.4" />
+      <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+    </ItemGroup>
+
+    <ItemGroup>
       <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="" />
       <None Include="..\..\icon-128.png" Pack="true" PackagePath="" />
     </ItemGroup>

--- a/src/oss-tests/oss-tests.csproj
+++ b/src/oss-tests/oss-tests.csproj
@@ -25,6 +25,10 @@
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		<PrivateAssets>all</PrivateAssets>
 	</PackageReference>
+    <!-- SFI-ES5.2: pin vulnerable transitive -->
+    <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.4" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Microsoft.Bcl.Memory -> 10.0.4
- System.Net.Http      -> 4.3.4
- System.Text.RegularExpressions -> 4.3.1

Added as direct <PackageReference> overrides in the consuming csprojs. CPM not introduced. Verified via dotnet restore/build/test against nuget.org (ADO feed unreachable from build env).

S360-Run-Id: 189d082f-67ad-401e-b203-788bd7c886cf
S360-KPI: SFI-ES5.2
S360-Skill: dependabot:dependency-update-orchestrator
S360-Arm: dedicated_skill