### PR TITLE
deps: fix 4 Dependabot advisories and apply safe NuGet updates

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning">
-      <Version>3.9.50</Version>
+      <Version>3.10.91</Version>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/Shared.CLI/Shared.CLI.csproj
+++ b/src/Shared.CLI/Shared.CLI.csproj
@@ -71,25 +71,25 @@
   <ItemGroup>
     <PackageReference Include="ELFSharp" Version="2.17.3" />
     <PackageReference Include="ICSharpCode.Decompiler" Version="9.1.0.7988" />
-    <PackageReference Include="JmesPath.Net" Version="1.0.330" />
-    <PackageReference Include="Microsoft.CST.ApplicationInspector.Commands" Version="1.9.53" />
-    <PackageReference Include="Microsoft.CST.DevSkim" Version="1.0.67" />
+    <PackageReference Include="JmesPath.Net" Version="1.1.0" />
+    <PackageReference Include="Microsoft.CST.ApplicationInspector.Commands" Version="1.9.55" />
+    <PackageReference Include="Microsoft.CST.DevSkim" Version="1.0.90" />
     <PackageReference Include="PeNet" Version="5.1.0" />
     <PackageReference Include="SharpDisasm" Version="1.1.11" />
     <PackageReference Include="WebAssembly" Version="1.3.0" />
-    <PackageReference Include="AngleSharp" Version="1.4.0" />
+    <PackageReference Include="AngleSharp" Version="1.6.0" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Crayon" Version="2.0.69" />
     <PackageReference Include="DiffPlex" Version="1.9.0" />
-    <PackageReference Include="F23.StringSimilarity" Version="7.0.0" />
+    <PackageReference Include="F23.StringSimilarity" Version="7.0.1" />
     <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageReference Include="MediaTypeMap.Core" Version="2.3.3" />
-    <PackageReference Include="Microsoft.CST.ApplicationInspector.Common" Version="1.9.53" />
-    <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.2.45" />
+    <PackageReference Include="Microsoft.CST.ApplicationInspector.Common" Version="1.9.55" />
+    <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.2.61" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.4" />
-    <PackageReference Include="NLog" Version="6.0.6" />
-    <PackageReference Include="NLog.Schema" Version="6.0.6" />
-    <PackageReference Include="NuGet.Versioning" Version="7.0.1" />
+    <PackageReference Include="NLog" Version="6.1.4" />
+    <PackageReference Include="NLog.Schema" Version="6.1.4" />
+    <PackageReference Include="NuGet.Versioning" Version="7.6.0" />
     <PackageReference Include="Octokit" Version="14.0.0" />
     <PackageReference Include="Pastel" Version="7.0.1" />
     <PackageReference Include="Sarif.Sdk" Version="4.6.0" />
@@ -97,7 +97,7 @@
     <PackageReference Include="System.Console" Version="4.3.1" />
     <PackageReference Include="Whois" Version="3.0.1" />
     <!-- SFI-ES5.2: pin vulnerable transitive -->
-    <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.4" />
+    <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.10" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>

--- a/src/Shared.CLI/Tools/ReproducibleTool/Strategies/BaseStrategy.cs
+++ b/src/Shared.CLI/Tools/ReproducibleTool/Strategies/BaseStrategy.cs
@@ -238,7 +238,7 @@ namespace Microsoft.CST.OpenSource.Reproducibility
             // Note that we're not using something like .CreateFromDirectory, or .AddDirectory,
             // since both of these had problems with permissions. Instead, we'll try to add each
             // file separately, and continue on any failures.
-            using (ZipArchive? archive = ZipArchive.Create())
+            using (ZipArchive? archive = (ZipArchive)ZipArchive.CreateArchive())
             {
                 using (archive.PauseEntryRebuilding())
                 {

--- a/src/Shared.Lib.Tests/Shared.Lib.Tests.csproj
+++ b/src/Shared.Lib.Tests/Shared.Lib.Tests.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
 	  <PackageReference Include="AutoFixture" Version="4.18.1" />
-	  <PackageReference Include="AwesomeAssertions" Version="9.3.0" />
+	  <PackageReference Include="AwesomeAssertions" Version="9.5.0" />
 	  <PackageReference Include="FluentAssertions" Version="7.0.2" />
 	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 	  <PackageReference Include="NSubstitute" Version="5.3.0" />

--- a/src/Shared/Shared.Lib.csproj
+++ b/src/Shared/Shared.Lib.csproj
@@ -29,30 +29,30 @@
 	</PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AngleSharp" Version="1.4.0" />
+        <PackageReference Include="AngleSharp" Version="1.6.0" />
         <PackageReference Include="CommandLineParser" Version="2.9.1" />
         <PackageReference Include="Crayon" Version="2.0.69" />
-        <PackageReference Include="F23.StringSimilarity" Version="7.0.0" />
+        <PackageReference Include="F23.StringSimilarity" Version="7.0.1" />
         <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
-        <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.2.45" />
+        <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.2.61" />
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.4" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.4" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.4" />
         <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.4" />
-        <PackageReference Include="NLog" Version="6.0.6" />
-        <PackageReference Include="NLog.Schema" Version="6.0.6" />
-        <PackageReference Include="NuGet.Packaging" Version="7.0.1" />
-        <PackageReference Include="NuGet.Protocol" Version="7.0.1" />
+        <PackageReference Include="NLog" Version="6.1.4" />
+        <PackageReference Include="NLog.Schema" Version="6.1.4" />
+        <PackageReference Include="NuGet.Packaging" Version="7.6.0" />
+        <PackageReference Include="NuGet.Protocol" Version="7.6.0" />
         <PackageReference Include="Octokit" Version="14.0.0" />
         <PackageReference Include="packageurl-dotnet" Version="1.3.0" />
         <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
         <PackageReference Include="Sarif.Sdk" Version="4.6.0" />
         <PackageReference Include="SemanticVersioning" Version="3.0.0" />
         <PackageReference Include="System.Console" Version="4.3.1" />
-        <PackageReference Include="System.Linq.Async" Version="7.0.0" />
+        <PackageReference Include="System.Linq.Async" Version="7.0.1" />
         <!-- SFI-ES5.2: pin vulnerable transitive -->
-        <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.4" />
+        <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.10" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/oss-find-squats-lib/oss-find-squats-lib.csproj
+++ b/src/oss-find-squats-lib/oss-find-squats-lib.csproj
@@ -34,7 +34,7 @@
 
   <ItemGroup>
     <!-- SFI-ES5.2: pin vulnerable transitive -->
-    <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.4" />
+    <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/oss-tests/oss-tests.csproj
+++ b/src/oss-tests/oss-tests.csproj
@@ -13,9 +13,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AwesomeAssertions" Version="9.3.0" />
+    <PackageReference Include="AwesomeAssertions" Version="9.5.0" />
     <PackageReference Include="FluentAssertions" Version="7.0.2" />
-    <PackageReference Include="JmesPath.Net" Version="1.0.330" />
+    <PackageReference Include="JmesPath.Net" Version="1.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Moq" Version="[4.18.2]" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
@@ -26,7 +26,7 @@
 		<PrivateAssets>all</PrivateAssets>
 	</PackageReference>
     <!-- SFI-ES5.2: pin vulnerable transitive -->
-    <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.4" />
+    <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.10" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>


### PR DESCRIPTION
## Why

Dependabot currently reports 4 open vulnerability alerts on `main` (2 moderate, 2 low). This clears all of them, and picks up the low-risk minor/patch updates that were available at the same time so the next scheduled Dependabot run has less to churn through.

## Security fixes

| Package | Change | Advisory |
| --- | --- | --- |
| AngleSharp | 1.4.0 -> 1.6.0 | [GHSA-pgww-w46g-26qg](https://github.com/advisories/GHSA-pgww-w46g-26qg) - mXSS via `annotation-xml` integration point, Moderate |
| SharpCompress (transitive) | 0.40.0 -> 0.49.1 | [GHSA-6c8g-7p36-r338](https://github.com/advisories/GHSA-6c8g-7p36-r338) - zip-slip directory traversal, Moderate |
| NuGet.Packaging / .Protocol / .Versioning | 7.0.1 -> 7.6.0 | [GHSA-g4vj-cjjj-v7hg](https://github.com/advisories/GHSA-g4vj-cjjj-v7hg) - Low |

SharpCompress is not referenced directly; it comes in through `Microsoft.CST.RecursiveExtractor`, so the fix is to bump that from 1.2.45 to 1.2.61, which pulls SharpCompress 0.49.1.

## The one non-obvious bit

SharpCompress 0.49 renamed `ZipArchive.Create()` to `ZipArchive.CreateArchive()`, and the new method returns `IWritableArchive<ZipWriterOptions>` rather than a concrete `ZipArchive`. `BaseStrategy.CreateZipFromDirectory` needs the concrete type because it calls `PauseEntryRebuilding()`, which is not on the interface, so the call site casts the result back. This is the only source change in the PR and worth a look during review.

## Other bumps (minor/patch only)

Nerdbank.GitVersioning 3.10.91, AwesomeAssertions 9.5.0, Microsoft.Bcl.Memory 10.0.10, NLog + NLog.Schema 6.1.4, F23.StringSimilarity 7.0.1, System.Linq.Async 7.0.1, JmesPath.Net 1.1.0, Microsoft.CST.ApplicationInspector.{Commands,Common} 1.9.55, Microsoft.CST.DevSkim 1.0.90.

## Deliberately not updated

Several majors were available but are blocked or need their own review, so they are left alone here:

- **PeNet 6.1.2** and **WebAssembly 2.1.0** ship assemblies for newer TFMs only and cannot be consumed while the projects still multi-target `net6.0`.
- **FluentAssertions 8.x** switched to a commercial license. `AwesomeAssertions` (the OSS fork) is already referenced alongside it, so the right move is finishing that migration and dropping FluentAssertions rather than bumping it.
- **Microsoft.Extensions.\* 10.x**, **Sarif.Sdk 5.5.0**, **packageurl-dotnet 2.0.1**, **ICSharpCode.Decompiler 10.x**, **Pastel 8.0.0**, **Microsoft.NET.Test.Sdk 18.x**, **NSubstitute 6.0.0** are majors with real API or TFM implications.
- **Moq** stays pinned at `[4.18.2]`; the exact-version pin looks intentional.

Worth noting for planning: `net6.0` is EOL and is what blocks several of the above. Dropping it would unblock PeNet, WebAssembly, Pastel, and the NuGet.\* NU1701 fallback warnings in one go.

`xunit` is also flagged as deprecated in favor of `xunit.v3`. That is a test-infrastructure migration, not a dependency bump, so it is out of scope here.

## Validation

- `dotnet build OSSGadget.sln -c Release` succeeds for both `net6.0` and `net8.0`, 0 errors, no new warning categories.
- `dotnet list package --vulnerable --include-transitive` now reports no vulnerable packages across all 6 projects.
- `Shared.Lib.Tests`: 2/2 pass.
- `oss-tests` (net8.0): 414 passed / 19 failed, which is byte-for-byte the same failure set as the pre-change baseline I captured by stashing the diff. 17 of those are network dependent (the npm registry is not reachable from my environment) and 2 (`DefoggerTests.DetectZip` / `DetectNestedZip`) are a pre-existing file-lock race against `ArchiveHelperTests` that reproduces 3/3 times on unmodified `main`. No regressions from this change.

## Note for CI

`nuget.config` pins restore to the private `microsoft-sdl/PublicRegistriesFeed` ADO feed, which I could not authenticate against locally, so I validated against nuget.org using an out-of-repo config override. `nuget.config` itself is unchanged. CI will need these new package versions mirrored into `PublicRegistriesFeed` before the build passes there.